### PR TITLE
docs: update delivery data model (add tracking fields)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ classDiagram
     +string courierId
     +string status
     +string incidentReason
+    +string evidenceUrl
     +number amountCollected
     +timestamp assignedAt
+    +timestamp pickedUpAt
+    +timestamp deliveredAt
   }
 
   class payments {
@@ -166,6 +169,8 @@ The model is a good base for an ecommerce app with delivery, with three implemen
 - In Firestore, you do not always need to store `productId`, `orderId`, etc. inside the document if the document ID already represents that value. Store it only when exports or search flows need it.
 - `inventoryMovements` should belong under `products` or live as a root collection indexed by `productId`. Nesting it under `inventory` can make global audit queries harder.
 - Define closed values for `role`, `status`, `type`, and `method` from the start to avoid inconsistent states.
+- Delivery lifecycle timestamps must be stored in `deliveries`: `assignedAt`, `pickedUpAt`, and `deliveredAt`, to support tracking and performance metrics.
+- `evidenceUrl` is optional and stores delivery or incident evidence when required.
 
 ## Branching and releases
 


### PR DESCRIPTION
## Description

This PR updates the delivery data model to include tracking fiels required for Sprint 1 user stories (from Programming API's Team) and to enable future analytics

The following fields are added to the `deliveries` entity:

- `pickedUpAt`: Records when the courier marks an order as "EN CAMINO". Without this, we can only track assignment time, not actual delivery start.
- `deliveredAt`: Records the real completion time of the delivery. This is essential to measure delivery duration and evaluate performance.
- `evidenceUrl` (optional): Stores a link to delivery proof or inciden evidence, providing visual confirmation and traceability.

This aligns the data model with the defined user stories and prepares the system for courier session analysis.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [X] Documentation

## Related Issues

None

## Checklist

- [X] Code works as expected
- [X] No new warnings or errors
- [X] Self-reviewed
