### PR TITLE
Ver ofertas de productos

### DIFF
--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -48,7 +48,9 @@ function saveSearchTerm(term: string) {
   if (!term.trim()) return;
   try {
     const current = getSearchHistory();
-    const filtered = current.filter((t) => t.toLowerCase() !== term.toLowerCase());
+    const filtered = current.filter(
+      (t) => t.toLowerCase() !== term.toLowerCase()
+    );
     const updated = [term, ...filtered].slice(0, MAX_HISTORY_ITEMS);
     localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(updated));
   } catch {
@@ -59,7 +61,9 @@ function saveSearchTerm(term: string) {
 function deleteSearchTerm(term: string) {
   try {
     const current = getSearchHistory();
-    const updated = current.filter((t) => t.toLowerCase() !== term.toLowerCase());
+    const updated = current.filter(
+      (t) => t.toLowerCase() !== term.toLowerCase()
+    );
     localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(updated));
   } catch {
     // Ignore storage errors
@@ -92,21 +96,29 @@ interface FeaturedProductsProps {
   initialSearch?: string;
 }
 
-export default function FeaturedProducts({ initialSearch = '' }: FeaturedProductsProps) {
+export default function FeaturedProducts({
+  initialSearch = '',
+}: FeaturedProductsProps) {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState(initialSearch);
   const [appliedSearch, setAppliedSearch] = useState(initialSearch);
   const [showSuggestions, setShowSuggestions] = useState(false);
-  const [searchHistory, setSearchHistory] = useState<string[]>([]);
+  const [searchHistory, setSearchHistory] = useState<string[]>(() =>
+    getSearchHistory()
+  );
   const [inputFocused, setInputFocused] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [showOffersOnly, setShowOffersOnly] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
+      if (
+        searchRef.current &&
+        !searchRef.current.contains(event.target as Node)
+      ) {
         setShowSuggestions(false);
       }
     };
@@ -131,7 +143,10 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
 
         const inventoryByProductId = new Map(
           inventorySnap.docs.map((inventoryDoc) => {
-            const inventory = { id: inventoryDoc.id, ...inventoryDoc.data() } as Inventory;
+            const inventory = {
+              id: inventoryDoc.id,
+              ...inventoryDoc.data(),
+            } as Inventory;
             return [inventory.productId ?? inventoryDoc.id, inventory];
           })
         );
@@ -139,7 +154,10 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
         setProducts(
           productsSnap.docs
             .map((productDoc) => {
-              const product = { id: productDoc.id, ...productDoc.data() } as Product;
+              const product = {
+                id: productDoc.id,
+                ...productDoc.data(),
+              } as Product;
               const inventory = inventoryByProductId.get(productDoc.id);
 
               return {
@@ -162,47 +180,66 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
     fetchProducts();
   }, []);
 
-  useEffect(() => {
-    setSearchHistory(getSearchHistory());
-  }, []);
-
   const removeAccents = (text: string) => {
     return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   };
 
   const filteredProducts = useMemo(() => {
     let result = products;
+
+    if (showOffersOnly) {
+      result = result.filter((product) => hasValidOffer(product));
+    }
+
     if (selectedCategory) {
       result = result.filter((p) => p.categoryId === selectedCategory);
     }
+
     if (!appliedSearch) return result;
+
     const term = removeAccents(appliedSearch.toLowerCase());
-    const byName = result.filter((p) => removeAccents(p.name.toLowerCase()).includes(term));
+    const byName = result.filter((p) =>
+      removeAccents(p.name.toLowerCase()).includes(term)
+    );
     const byDescription = result.filter(
-      (p) => !removeAccents(p.name.toLowerCase()).includes(term) && p.description && removeAccents(p.description.toLowerCase()).includes(term)
+      (p) =>
+        !removeAccents(p.name.toLowerCase()).includes(term) &&
+        p.description &&
+        removeAccents(p.description.toLowerCase()).includes(term)
     );
     return [...byName, ...byDescription];
-  }, [products, appliedSearch, selectedCategory]);
+  }, [products, appliedSearch, selectedCategory, showOffersOnly]);
 
   const searchSuggestions = useMemo(() => {
     if (!searchTerm || searchTerm.length < 1) {
       if (inputFocused && searchHistory.length > 0) {
-        return searchHistory.map((term) => ({ type: 'history' as const, term }));
+        return searchHistory.map((term) => ({
+          type: 'history' as const,
+          term,
+        }));
       }
       return [];
     }
     const normalizedTerm = removeAccents(searchTerm.toLowerCase());
     const historySuggestions = searchHistory
-      .filter((term) => removeAccents(term.toLowerCase()).includes(normalizedTerm))
+      .filter((term) =>
+        removeAccents(term.toLowerCase()).includes(normalizedTerm)
+      )
       .map((term) => ({ type: 'history' as const, term }));
     const productSuggestions = products
-      .filter((p) => removeAccents(p.name.toLowerCase()).includes(normalizedTerm))
+      .filter((p) =>
+        removeAccents(p.name.toLowerCase()).includes(normalizedTerm)
+      )
       .slice(0, 5)
       .map((p) => ({ type: 'product' as const, product: p }));
     return [...historySuggestions, ...productSuggestions];
   }, [products, searchTerm, searchHistory, inputFocused]);
 
-  const highlightText = (text: string, term: string, enabled: boolean = true) => {
+  const highlightText = (
+    text: string,
+    term: string,
+    enabled: boolean = true
+  ) => {
     if (!enabled || !term || !text) return text;
     const normalizedText = removeAccents(text);
     const normalizedTerm = removeAccents(term);
@@ -216,7 +253,10 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
         result.push(text.slice(lastIndex, match.index));
       }
       result.push(
-        <mark key={match.index} className="bg-primary/30 text-primary font-semibold rounded px-0.5">
+        <mark
+          key={match.index}
+          className="bg-primary/30 text-primary font-semibold rounded px-0.5"
+        >
           {text.slice(match.index, match.index + match[0].length)}
         </mark>
       );
@@ -232,7 +272,11 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
     if (!term) return null;
     const t = removeAccents(term.toLowerCase());
     if (removeAccents(product.name.toLowerCase()).includes(t)) return 'name';
-    if (product.description && removeAccents(product.description.toLowerCase()).includes(t)) return 'description';
+    if (
+      product.description &&
+      removeAccents(product.description.toLowerCase()).includes(t)
+    )
+      return 'description';
     return null;
   };
 
@@ -283,17 +327,33 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
         <div className="mb-10">
           <h2
             className="text-text-light"
-            style={{ fontSize: 'clamp(1.6rem, 3vw, 2.2rem)', letterSpacing: '-0.03em', fontWeight: 900 }}
+            style={{
+              fontSize: 'clamp(1.6rem, 3vw, 2.2rem)',
+              letterSpacing: '-0.03em',
+              fontWeight: 900,
+            }}
           >
             Productos disponibles
           </h2>
         </div>
 
-       <div className="mb-6 flex items-center gap-3 max-w-6xl">
+        <div className="mb-6 flex max-w-6xl flex-wrap items-center gap-3">
           <CategoryFilter
             selectedCategory={selectedCategory}
             onCategoryChange={setSelectedCategory}
           />
+          <button
+            type="button"
+            onClick={() => setShowOffersOnly((current) => !current)}
+            aria-pressed={showOffersOnly}
+            className={`inline-flex items-center rounded-full border px-4 py-2 text-sm font-semibold transition-all duration-200 ${
+              showOffersOnly
+                ? 'border-primary bg-primary text-bg-light hover:brightness-110'
+                : 'border-border-light text-text-light hover:border-primary hover:text-primary'
+            }`}
+          >
+            Solo ofertas
+          </button>
           <div ref={searchRef} className="relative flex-1">
             <Search
               size={18}
@@ -325,16 +385,25 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
               </button>
             )}
 
-          {showSuggestions && searchSuggestions.length > 0 && (
-            <ul className="absolute top-full left-0 right-0 z-20 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border-light bg-card-bg-light py-1 shadow-lg">
-              {searchSuggestions.map((suggestion, index) => (
-                <li key={suggestion.type === 'history' ? `history-${suggestion.term}` : suggestion.product.id}>
-                  <div className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-text-light">
-                    <button
-                      type="button"
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        const term = suggestion.type === 'history' ? suggestion.term : suggestion.product.name;
+            {showSuggestions && searchSuggestions.length > 0 && (
+              <ul className="absolute top-full left-0 right-0 z-20 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border-light bg-card-bg-light py-1 shadow-lg">
+                {searchSuggestions.map((suggestion) => (
+                  <li
+                    key={
+                      suggestion.type === 'history'
+                        ? `history-${suggestion.term}`
+                        : suggestion.product.id
+                    }
+                  >
+                    <div className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-text-light">
+                      <button
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          const term =
+                            suggestion.type === 'history'
+                              ? suggestion.term
+                              : suggestion.product.name;
                           if (suggestion.type === 'history') {
                             saveSearchTerm(term);
                             setSearchHistory(getSearchHistory());
@@ -345,58 +414,67 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
                           setSearchTerm(term);
                           setAppliedSearch(term);
                           updateUrl(term);
+                          setShowSuggestions(false);
+                        }}
+                        className="flex flex-1 items-center gap-2 hover:bg-secondary-bg-light rounded py-1 -my-1 cursor-pointer"
+                      >
+                        {suggestion.type === 'history' && (
+                          <History
+                            size={14}
+                            className="text-primary shrink-0"
+                          />
+                        )}
+                        <span className="line-clamp-1">
+                          {suggestion.type === 'history'
+                            ? highlightText(suggestion.term, searchTerm, true)
+                            : highlightText(
+                                suggestion.product.name,
+                                searchTerm,
+                                true
+                              )}
+                        </span>
+                      </button>
+                      {suggestion.type === 'history' && (
+                        <button
+                          type="button"
+                          onMouseDown={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            deleteSearchTerm(suggestion.term);
+                            setSearchHistory(getSearchHistory());
+                          }}
+                          className="shrink-0 p-1 text-text-light opacity-40 hover:text-red-500 hover:opacity-100 cursor-pointer rounded"
+                          aria-label="Eliminar de historial"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {showSuggestions &&
+              searchSuggestions.length === 0 &&
+              searchTerm && (
+                <ul className="absolute top-full left-0 right-0 z-20 mt-1 rounded-lg border border-border-light bg-card-bg-light py-1 shadow-lg">
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        saveSearchTerm(searchTerm);
+                        setSearchHistory(getSearchHistory());
+                        setAppliedSearch(searchTerm);
                         setShowSuggestions(false);
                       }}
-                      className="flex flex-1 items-center gap-2 hover:bg-secondary-bg-light rounded py-1 -my-1 cursor-pointer"
+                      className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-text-light hover:bg-secondary-bg-light"
                     >
-                      {suggestion.type === 'history' && (
-                        <History size={14} className="text-primary shrink-0" />
-                      )}
-                      <span className="line-clamp-1">
-                        {suggestion.type === 'history'
-                          ? highlightText(suggestion.term, searchTerm, true)
-                          : highlightText(suggestion.product.name, searchTerm, true)}
-                      </span>
+                      Buscar &quot;{searchTerm}&quot;
                     </button>
-                    {suggestion.type === 'history' && (
-                      <button
-                        type="button"
-                        onMouseDown={(e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          deleteSearchTerm(suggestion.term);
-                          setSearchHistory(getSearchHistory());
-                        }}
-                        className="shrink-0 p-1 text-text-light opacity-40 hover:text-red-500 hover:opacity-100 cursor-pointer rounded"
-                        aria-label="Eliminar de historial"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    )}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-          {showSuggestions && searchSuggestions.length === 0 && searchTerm && (
-            <ul className="absolute top-full left-0 right-0 z-20 mt-1 rounded-lg border border-border-light bg-card-bg-light py-1 shadow-lg">
-              <li>
-                <button
-                  type="button"
-                  onClick={() => {
-                    saveSearchTerm(searchTerm);
-                    setSearchHistory(getSearchHistory());
-                    setAppliedSearch(searchTerm);
-                    setShowSuggestions(false);
-                  }}
-                  className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-text-light hover:bg-secondary-bg-light"
-                >
-                  Buscar "{searchTerm}"
-                </button>
-              </li>
-            </ul>
-          )}
-          </div> 
+                  </li>
+                </ul>
+              )}
+          </div>
         </div>
 
         {loading && (
@@ -416,30 +494,50 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
           </div>
         )}
 
-        {!loading && !error && filteredProducts.length === 0 && (appliedSearch || selectedCategory) && (
-          <div className="py-20 text-center">
-            <Package size={40} className="mx-auto mb-3 text-text-light opacity-40" />
-            <p className="text-sm text-text-light opacity-50">
-              {selectedCategory && !appliedSearch
-                ? 'No hay productos disponibles en esta categoría'
-                : 'No se encontraron productos'}
+        {!loading && error && (
+          <div className="mb-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {!loading &&
+          filteredProducts.length === 0 &&
+          (appliedSearch || selectedCategory || showOffersOnly) && (
+            <div className="py-20 text-center">
+              <Package
+                size={40}
+                className="mx-auto mb-3 text-text-light opacity-40"
+              />
+              <p className="text-sm text-text-light opacity-50">
+                {showOffersOnly
+                  ? 'No hay ofertas disponibles en este momento'
+                  : selectedCategory && !appliedSearch
+                    ? 'No hay productos disponibles en esta categoría'
+                    : 'No se encontraron productos'}
+              </p>
+            </div>
+          )}
+
+        {!loading && error && products.length === 0 && (
+          <div className="rounded-3xl border border-border-light bg-card-bg-light px-6 py-12 text-center">
+            <Package size={40} className="mx-auto mb-3 text-primary" />
+            <p className="text-sm font-semibold text-text-light">
+              No se pudo cargar el catálogo.
+            </p>
+            <p className="mt-2 text-sm text-text-light opacity-70">
+              Intenta nuevamente más tarde.
             </p>
           </div>
         )}
 
-        {!loading && error && (
-          <div className="rounded-3xl border border-border-light bg-card-bg-light px-6 py-12 text-center">
-            <Package size={40} className="mx-auto mb-3 text-primary" />
-            <p className="text-sm font-semibold text-text-light">{error}</p>
-          </div>
-        )}
-
-        {!loading && !error && products.length > 0 && (
-            <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        {!loading && filteredProducts.length > 0 && (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
             {filteredProducts.map((product) => {
               const showOffer = hasValidOffer(product);
               const badgeData = getBadgeData(product);
-              const currentPrice = showOffer ? product.offerPrice! : product.price;
+              const currentPrice = showOffer
+                ? product.offerPrice!
+                : product.price;
               const isAvailable = (product.stockAvailable ?? 0) > 0;
 
               return (
@@ -477,27 +575,43 @@ export default function FeaturedProducts({ initialSearch = '' }: FeaturedProduct
                     <div className="flex items-center justify-between gap-3">
                       <span
                         className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
-                          isAvailable ? 'bg-primary/15 text-primary' : 'bg-primary-action text-white'
+                          isAvailable
+                            ? 'bg-primary/15 text-primary'
+                            : 'bg-primary-action text-white'
                         }`}
                       >
                         {isAvailable ? 'Disponible' : 'Producto agotado'}
                       </span>
-                      <ShoppingBag size={15} className="text-text-light opacity-35" />
+                      <ShoppingBag
+                        size={15}
+                        className="text-text-light opacity-35"
+                      />
                     </div>
 
                     <div className="mt-3 space-y-2">
                       <span className="block line-clamp-2 text-sm font-semibold leading-5 text-text-light transition-colors group-hover:text-primary">
-                        {highlightText(product.name, appliedSearch, getMatchField(product, appliedSearch) === 'name')}
+                        {highlightText(
+                          product.name,
+                          appliedSearch,
+                          getMatchField(product, appliedSearch) === 'name'
+                        )}
                       </span>
 
                       {product.description && (
                         <p className="mt-1 line-clamp-2 text-xs text-text-light opacity-65">
-                          {highlightText(product.description, appliedSearch, getMatchField(product, appliedSearch) === 'description')}
+                          {highlightText(
+                            product.description,
+                            appliedSearch,
+                            getMatchField(product, appliedSearch) ===
+                              'description'
+                          )}
                         </p>
                       )}
 
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-sm font-bold text-text-light">{formatPrice(currentPrice)}</span>
+                        <span className="text-sm font-bold text-text-light">
+                          {formatPrice(currentPrice)}
+                        </span>
                         {showOffer && (
                           <span className="text-xs text-text-light opacity-40 line-through">
                             {formatPrice(product.price)}

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -1,13 +1,5 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
-import {
-  ShoppingBag,
-  Package,
-  Search,
-  X,
-  History,
-  Trash2,
-  Percent,
-} from 'lucide-react';
+import { ShoppingBag, Package, Search, X, History, Trash2 } from 'lucide-react';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
@@ -354,22 +346,13 @@ export default function FeaturedProducts({
             type="button"
             onClick={() => setShowOffersOnly((current) => !current)}
             aria-pressed={showOffersOnly}
-            aria-label={
-              showOffersOnly
-                ? 'Quitar filtro Solo ofertas'
-                : 'Activar filtro Solo ofertas'
-            }
             className={`inline-flex items-center rounded-full border px-4 py-2 text-sm font-semibold transition-all duration-200 ${
               showOffersOnly
                 ? 'border-primary bg-primary text-bg-light hover:brightness-110'
                 : 'border-border-light text-text-light hover:border-primary hover:text-primary'
             }`}
           >
-            <Percent size={14} className="mr-2" aria-hidden="true" />
             Solo ofertas
-            {showOffersOnly && (
-              <X size={14} className="ml-2" aria-hidden="true" />
-            )}
           </button>
           <div ref={searchRef} className="relative flex-1">
             <Search

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
-import { ShoppingBag, Package, Search, X, History, Trash2 } from 'lucide-react';
+import {
+  ShoppingBag,
+  Package,
+  Search,
+  X,
+  History,
+  Trash2,
+  Percent,
+} from 'lucide-react';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
@@ -346,13 +354,22 @@ export default function FeaturedProducts({
             type="button"
             onClick={() => setShowOffersOnly((current) => !current)}
             aria-pressed={showOffersOnly}
+            aria-label={
+              showOffersOnly
+                ? 'Quitar filtro Solo ofertas'
+                : 'Activar filtro Solo ofertas'
+            }
             className={`inline-flex items-center rounded-full border px-4 py-2 text-sm font-semibold transition-all duration-200 ${
               showOffersOnly
                 ? 'border-primary bg-primary text-bg-light hover:brightness-110'
                 : 'border-border-light text-text-light hover:border-primary hover:text-primary'
             }`}
           >
+            <Percent size={14} className="mr-2" aria-hidden="true" />
             Solo ofertas
+            {showOffersOnly && (
+              <X size={14} className="ml-2" aria-hidden="true" />
+            )}
           </button>
           <div ref={searchRef} className="relative flex-1">
             <Search

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo, useRef } from 'react';
 import { ShoppingBag, Package, Search, X, History, Trash2 } from 'lucide-react';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import { db } from '../lib/firebase';
+import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
 import CategoryFilter from './CategoryFilter';
 
 interface Product {
@@ -69,38 +70,20 @@ function formatPrice(amount: number) {
   return `Bs ${amount.toFixed(2)}`;
 }
 
-function hasValidOffer(product: Product) {
-  return Boolean(
-    product.hasOffer &&
-      typeof product.offerPrice === 'number' &&
-      product.offerPrice < product.price
-  );
-}
-
-function getDiscountPercentage(product: Product) {
-  if (!hasValidOffer(product)) return null;
-
-  return Math.round(((product.price - product.offerPrice!) / product.price) * 100);
-}
-
-function isOfferBadge(badge?: string) {
-  return badge?.trim().toLowerCase() === 'oferta';
-}
-
 function getBadgeData(product: Product) {
-  const discountPercentage = getDiscountPercentage(product);
+  const badgeData = getOfferBadgeData(product);
 
-  if (discountPercentage) {
+  if (badgeData?.isDiscount) {
     return {
-      label: `-${discountPercentage}%`,
+      label: badgeData.label,
       className: 'bg-red-600 text-white',
     };
   }
 
-  if (!product.badge || isOfferBadge(product.badge)) return null;
+  if (!badgeData) return null;
 
   return {
-    label: product.badge,
+    label: badgeData.label,
     className: 'bg-primary-action text-white',
   };
 }

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -1,13 +1,5 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
-import {
-  ShoppingBag,
-  Package,
-  Search,
-  X,
-  History,
-  Trash2,
-  Percent,
-} from 'lucide-react';
+import { ShoppingBag, Package, Search, X, History, Trash2 } from 'lucide-react';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
@@ -365,7 +357,6 @@ export default function FeaturedProducts({
                 : 'border-border-light text-text-light hover:border-primary hover:text-primary'
             }`}
           >
-            <Percent size={14} className="mr-2" aria-hidden="true" />
             Solo ofertas
             {showOffersOnly && (
               <X size={14} className="ml-2" aria-hidden="true" />

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react';
 import { ArrowLeft, ChevronRight, MessageSquare, Star } from 'lucide-react';
-import { Timestamp, collection, getDocs, limit, query, where } from 'firebase/firestore';
+import {
+  Timestamp,
+  collection,
+  getDocs,
+  limit,
+  query,
+  where,
+} from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
 
@@ -72,7 +79,11 @@ function renderStars(rating: number) {
     <Star
       key={`${rating}-${index}`}
       size={14}
-      className={index < rating ? 'fill-primary text-primary' : 'text-text-light opacity-20'}
+      className={
+        index < rating
+          ? 'fill-primary text-primary'
+          : 'text-text-light opacity-20'
+      }
     />
   ));
 }
@@ -98,9 +109,15 @@ function sortReviews(reviews: Review[], sortKey: ReviewSortKey) {
       case 'oldest':
         return getReviewTimestamp(left) - getReviewTimestamp(right);
       case 'highest':
-        return right.rating - left.rating || getReviewTimestamp(right) - getReviewTimestamp(left);
+        return (
+          right.rating - left.rating ||
+          getReviewTimestamp(right) - getReviewTimestamp(left)
+        );
       case 'lowest':
-        return left.rating - right.rating || getReviewTimestamp(right) - getReviewTimestamp(left);
+        return (
+          left.rating - right.rating ||
+          getReviewTimestamp(right) - getReviewTimestamp(left)
+        );
       case 'recent':
       default:
         return getReviewTimestamp(right) - getReviewTimestamp(left);
@@ -129,7 +146,8 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
   const [error, setError] = useState<string | null>(null);
   const [imageFailed, setImageFailed] = useState(false);
   const [reviewSort, setReviewSort] = useState<ReviewSortKey>('recent');
-  const [visibleReviewsCount, setVisibleReviewsCount] = useState(REVIEW_PAGE_SIZE);
+  const [visibleReviewsCount, setVisibleReviewsCount] =
+    useState(REVIEW_PAGE_SIZE);
 
   useEffect(() => {
     let ignore = false;
@@ -182,7 +200,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
           ? null
           : (inventorySnap.docs[0].data() as InventoryRecord);
         const productReviews = reviewsSnap.docs
-          .map((reviewDoc) => ({ id: reviewDoc.id, ...reviewDoc.data() }) as Review)
+          .map(
+            (reviewDoc) => ({ id: reviewDoc.id, ...reviewDoc.data() }) as Review
+          )
           .filter((review) => review.active !== false);
 
         if (!ignore) {
@@ -190,7 +210,8 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
             ...productData,
             enabled: inventoryData?.enabled ?? true,
             stockAvailable: inventoryData?.stockAvailable ?? 0,
-            stockTotal: inventoryData?.stockTotal ?? inventoryData?.stockAvailable ?? 0,
+            stockTotal:
+              inventoryData?.stockTotal ?? inventoryData?.stockAvailable ?? 0,
           });
           setReviews(productReviews);
         }
@@ -215,11 +236,15 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
   }, [productSlug]);
 
   const showOffer = hasValidOffer(product);
-  const currentPrice = showOffer ? product?.offerPrice ?? 0 : product?.price ?? 0;
+  const currentPrice = showOffer
+    ? (product?.offerPrice ?? 0)
+    : (product?.price ?? 0);
   const stockAvailable = product?.stockAvailable ?? 0;
   const isAvailable = stockAvailable > 0 && product?.enabled !== false;
   const normalizedDescription = product?.description?.trim();
-  const descriptionText = normalizedDescription ? normalizedDescription : 'Sin descripción';
+  const descriptionText = normalizedDescription
+    ? normalizedDescription
+    : 'Sin descripción';
   const badgeData = getBadgeData(product);
   const sortedReviews = sortReviews(reviews, reviewSort);
   const visibleReviews = sortedReviews.slice(0, visibleReviewsCount);
@@ -229,7 +254,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
     ? reviews.reduce((sum, review) => sum + review.rating, 0) / reviewsCount
     : 0;
   const roundedAverage = reviewsCount ? Math.round(averageRating) : 0;
-  const averageLabel = reviewsCount ? `${averageRating.toFixed(1)}/5` : 'Sin calificaciones';
+  const averageLabel = reviewsCount
+    ? `${averageRating.toFixed(1)}/5`
+    : 'Sin calificaciones';
   const reviewSortOptions: Array<{ value: ReviewSortKey; label: string }> = [
     { value: 'recent', label: 'Más recientes' },
     { value: 'oldest', label: 'Más antiguos' },
@@ -241,12 +268,21 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
     <section className="min-h-screen bg-bg-light pb-10 pt-20 sm:pt-24">
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         <div className="mb-6 flex flex-col gap-3 sm:mb-8 sm:flex-row sm:items-center sm:justify-between">
-          <nav aria-label="Ruta de navegación" className="flex items-center gap-2 text-sm text-text-light">
-            <a href="/" className="font-semibold opacity-70 transition-opacity hover:opacity-100">
+          <nav
+            aria-label="Ruta de navegación"
+            className="flex items-center gap-2 text-sm text-text-light"
+          >
+            <a
+              href="/"
+              className="font-semibold opacity-70 transition-opacity hover:opacity-100"
+            >
               Inicio
             </a>
             <ChevronRight size={14} className="opacity-35" aria-hidden="true" />
-            <a href="/productos" className="font-semibold opacity-70 transition-opacity hover:opacity-100">
+            <a
+              href="/productos"
+              className="font-semibold opacity-70 transition-opacity hover:opacity-100"
+            >
               Productos
             </a>
             <ChevronRight size={14} className="opacity-35" aria-hidden="true" />
@@ -330,7 +366,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
         {!loading && error && (
           <div className="rounded-3xl border border-border-light bg-card-bg-light px-6 py-10 text-center">
             <MessageSquare size={36} className="mx-auto mb-4 text-primary" />
-            <h1 className="text-xl font-black text-text-light">Error al cargar el detalle</h1>
+            <h1 className="text-xl font-black text-text-light">
+              Error al cargar el detalle
+            </h1>
             <p className="mt-2 text-sm text-text-light opacity-70">{error}</p>
           </div>
         )}
@@ -359,7 +397,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
                   )}
 
                   {badgeData && (
-                    <span className={`absolute left-5 top-5 rounded-full px-3 py-1 text-xs font-semibold ${badgeData.className}`}>
+                    <span
+                      className={`absolute left-5 top-5 rounded-full px-3 py-1 text-xs font-semibold ${badgeData.className}`}
+                    >
                       {badgeData.label}
                     </span>
                   )}
@@ -375,7 +415,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
                 </h1>
 
                 <div className="mt-5 flex items-center gap-3">
-                  <span className="text-2xl font-black text-text-light">{formatPrice(currentPrice)}</span>
+                  <span className="text-2xl font-black text-text-light">
+                    {formatPrice(currentPrice)}
+                  </span>
                   {showOffer && (
                     <span className="text-sm text-text-light opacity-45 line-through">
                       {formatPrice(product.price)}
@@ -407,7 +449,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
               <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div className="flex items-center gap-3">
                   <MessageSquare size={18} className="text-primary" />
-                  <h2 className="text-xl font-black text-text-light">Comentarios del producto</h2>
+                  <h2 className="text-xl font-black text-text-light">
+                    Comentarios del producto
+                  </h2>
                 </div>
 
                 <label className="flex items-center gap-2 text-sm font-medium text-text-light">
@@ -431,16 +475,20 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
 
               <div className="mt-6 grid gap-4 rounded-3xl border border-border-light bg-secondary-bg-light/45 p-5 sm:grid-cols-[auto_1fr] sm:items-center">
                 <div className="flex items-center gap-2">
-                  {reviewsCount ? (
-                    renderStars(roundedAverage)
-                  ) : (
-                    Array.from({ length: 5 }).map((_, index) => (
-                      <Star key={index} size={14} className="text-text-light opacity-20" />
-                    ))
-                  )}
+                  {reviewsCount
+                    ? renderStars(roundedAverage)
+                    : Array.from({ length: 5 }).map((_, index) => (
+                        <Star
+                          key={index}
+                          size={14}
+                          className="text-text-light opacity-20"
+                        />
+                      ))}
                 </div>
                 <div className="space-y-1">
-                  <p className="text-base font-bold text-text-light">{averageLabel}</p>
+                  <p className="text-base font-bold text-text-light">
+                    {averageLabel}
+                  </p>
                   <p className="text-sm text-text-light opacity-65">
                     {reviewsCount
                       ? `${reviewsCount} calificación${reviewsCount === 1 ? '' : 'es'} registradas`
@@ -451,7 +499,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
 
               {reviewsCount === 0 ? (
                 <div className="mt-6 rounded-3xl border border-dashed border-border-light px-5 py-8 text-center">
-                  <p className="text-base font-semibold text-text-light">Sin calificaciones</p>
+                  <p className="text-base font-semibold text-text-light">
+                    Sin calificaciones
+                  </p>
                   <p className="mt-2 text-sm text-text-light opacity-60">
                     Este producto aún no tiene comentarios registrados.
                   </p>
@@ -475,7 +525,9 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
                           ) : null}
                         </div>
                         <div className="flex items-center gap-2">
-                          <div className="flex items-center gap-1">{renderStars(review.rating)}</div>
+                          <div className="flex items-center gap-1">
+                            {renderStars(review.rating)}
+                          </div>
                           <span className="text-sm font-semibold text-text-light opacity-70">
                             {review.rating.toFixed(1)}
                           </span>
@@ -490,7 +542,11 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
                   {hasMoreReviews && (
                     <button
                       type="button"
-                      onClick={() => setVisibleReviewsCount((count) => count + REVIEW_PAGE_SIZE)}
+                      onClick={() =>
+                        setVisibleReviewsCount(
+                          (count) => count + REVIEW_PAGE_SIZE
+                        )
+                      }
                       className="mt-2 inline-flex justify-center rounded-full border border-border-light bg-card-bg-light px-5 py-3 text-sm font-semibold text-text-light transition-colors hover:border-primary hover:text-primary"
                     >
                       Cargar más comentarios

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ArrowLeft, ChevronRight, MessageSquare, Star } from 'lucide-react';
 import { Timestamp, collection, getDocs, limit, query, where } from 'firebase/firestore';
 import { db } from '../lib/firebase';
+import { getOfferBadgeData, hasValidOffer } from '../lib/productOffers';
 
 interface Product {
   id: string;
@@ -48,42 +49,20 @@ function formatPrice(amount: number) {
   return `Bs ${amount.toFixed(2)}`;
 }
 
-function hasValidOffer(product: Product | null) {
-  return Boolean(
-    product &&
-      product.hasOffer &&
-      typeof product.offerPrice === 'number' &&
-      product.offerPrice < product.price
-  );
-}
-
-function getDiscountPercentage(product: Product | null) {
-  if (!hasValidOffer(product)) return null;
-
-  const basePrice = product?.price ?? 0;
-  const offerPrice = product?.offerPrice ?? 0;
-
-  return Math.round(((basePrice - offerPrice) / basePrice) * 100);
-}
-
-function isOfferBadge(badge?: string | null) {
-  return badge?.trim().toLowerCase() === 'oferta';
-}
-
 function getBadgeData(product: Product | null) {
-  const discountPercentage = getDiscountPercentage(product);
+  const badgeData = getOfferBadgeData(product);
 
-  if (discountPercentage) {
+  if (badgeData?.isDiscount) {
     return {
-      label: `-${discountPercentage}%`,
+      label: badgeData.label,
       className: 'product-detail-badge product-detail-badge--discount',
     };
   }
 
-  if (!product?.badge || isOfferBadge(product.badge)) return null;
+  if (!badgeData) return null;
 
   return {
-    label: product.badge,
+    label: badgeData.label,
     className: 'product-detail-badge product-detail-badge--label',
   };
 }

--- a/src/lib/productOffers.ts
+++ b/src/lib/productOffers.ts
@@ -1,0 +1,53 @@
+export interface OfferableProduct {
+  price: number;
+  hasOffer?: boolean;
+  offerPrice?: number | null;
+  badge?: string | null;
+}
+
+export function hasValidOffer(product: OfferableProduct | null | undefined) {
+  if (!product) return false;
+
+  return Boolean(
+    product.hasOffer &&
+      typeof product.offerPrice === 'number' &&
+      product.offerPrice > 0 &&
+      product.offerPrice < product.price
+  );
+}
+
+export function calculateDiscountPercentage(price: number, offerPrice: number) {
+  if (price <= 0 || offerPrice <= 0 || offerPrice >= price) return null;
+
+  return Math.round(((price - offerPrice) / price) * 100);
+}
+
+export function getDiscountPercentage(product: OfferableProduct | null | undefined) {
+  if (!product || !hasValidOffer(product) || typeof product.offerPrice !== 'number') {
+    return null;
+  }
+
+  return calculateDiscountPercentage(product.price, product.offerPrice);
+}
+
+export function isOfferBadge(badge?: string | null) {
+  return badge?.trim().toLowerCase() === 'oferta';
+}
+
+export function getOfferBadgeData(product: OfferableProduct | null | undefined) {
+  const discountPercentage = getDiscountPercentage(product);
+
+  if (discountPercentage) {
+    return {
+      label: `-${discountPercentage}%`,
+      isDiscount: true,
+    };
+  }
+
+  if (!product?.badge || isOfferBadge(product.badge)) return null;
+
+  return {
+    label: product.badge,
+    isDiscount: false,
+  };
+}

--- a/src/lib/productOffers.ts
+++ b/src/lib/productOffers.ts
@@ -10,9 +10,9 @@ export function hasValidOffer(product: OfferableProduct | null | undefined) {
 
   return Boolean(
     product.hasOffer &&
-      typeof product.offerPrice === 'number' &&
-      product.offerPrice > 0 &&
-      product.offerPrice < product.price
+    typeof product.offerPrice === 'number' &&
+    product.offerPrice > 0 &&
+    product.offerPrice < product.price
   );
 }
 
@@ -22,8 +22,14 @@ export function calculateDiscountPercentage(price: number, offerPrice: number) {
   return Math.round(((price - offerPrice) / price) * 100);
 }
 
-export function getDiscountPercentage(product: OfferableProduct | null | undefined) {
-  if (!product || !hasValidOffer(product) || typeof product.offerPrice !== 'number') {
+export function getDiscountPercentage(
+  product: OfferableProduct | null | undefined
+) {
+  if (
+    !product ||
+    !hasValidOffer(product) ||
+    typeof product.offerPrice !== 'number'
+  ) {
     return null;
   }
 
@@ -34,7 +40,9 @@ export function isOfferBadge(badge?: string | null) {
   return badge?.trim().toLowerCase() === 'oferta';
 }
 
-export function getOfferBadgeData(product: OfferableProduct | null | undefined) {
+export function getOfferBadgeData(
+  product: OfferableProduct | null | undefined
+) {
   const discountPercentage = getDiscountPercentage(product);
 
   if (discountPercentage) {


### PR DESCRIPTION
## Description

This PR implements the user story #205 - Ver ofertas de productos as part of #30 - Ver productos disponibles.

What this PR does
- Adds a “Solo ofertas” chip filter in the products catalog, combinable with existing filters.
- Applies offer filtering using strict valid-offer rules:
  - hasOffer: true
  - offerPrice > 0
  - offerPrice < price
- Displays the empty state message:
  - "No hay ofertas disponibles en este momento" when the offers filter is active and no products match.
- Keeps offer pricing UI consistent:
  - discounted price + original strikethrough price in product cards.
- Centralizes offer logic in a shared utility:
  - src/lib/productOffers.ts
  - includes calculateDiscountPercentage(price, offerPrice) and reusable validations.
- Reuses shared offer rules in both:
  - src/components/FeaturedProducts.tsx
  - src/components/ProductDetail.tsx
- Improves accessibility and affordance of the offers chip:
  - aria-pressed
  - clear active state with removable ×.
- Updates issue #205 acceptance/testing text so criteria are fully testable and aligned with delivered behavior.
Why this is needed
- Ensures users can quickly find discounted products within the existing catalog flow.
- Prevents invalid offers from being shown as real discounts.
- Reduces duplicated business logic across components.
- Aligns implementation and testability with the user story scope.
Validation
- npm run build passes.
- Targeted lint checks for modified offer-related files pass.
Related issues
- Implements: #205
- Contributes to parent issue: #30

## Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation

## Related Issues

<!-- Closes #123 -->

## Checklist

- [x] Code works as expected
- [x] No new warnings or errors
- [x] Self-reviewed
