### PR TITLE
fix: tailwind v4 in location

### DIFF
--- a/src/features/location/components/LocationCard.tsx
+++ b/src/features/location/components/LocationCard.tsx
@@ -31,7 +31,7 @@ export default function LocationCard({
                     ? 'border-[#88B04B] bg-[#88B04B]/10 shadow-[0_0_0_2px_rgba(136,176,75,0.15)]'
                     : isDefault
                         ? 'border-[#88B04B]/50 bg-[#88B04B]/5 dark:bg-[#88B04B]/10'
-                        : 'border-[--theme-border] bg-[--theme-card-bg] hover:border-[#88B04B]/40'
+                        : 'border-(--theme-border) bg-(--theme-card-bg) hover:border-[#88B04B]/40'
                 }
             `}
         >
@@ -41,7 +41,7 @@ export default function LocationCard({
 
             <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                    <span className="font-outfit text-sm font-extrabold leading-none text-[--theme-text] transition-colors duration-300">
+                    <span className="font-outfit text-sm font-extrabold leading-none text-(--theme-text) transition-colors duration-300">
                         {type}
                     </span>
                     {isDefault && (
@@ -55,7 +55,7 @@ export default function LocationCard({
                     {label}
                 </p>
 
-                <p className="mt-0.5 font-mono text-[11px] tabular-nums text-[--theme-text]/60 transition-colors duration-300">
+                <p className="mt-0.5 font-mono text-[11px] tabular-nums text-(--theme-text)/60 transition-colors duration-300">
                     {lat.toFixed(4)}, {lng.toFixed(4)}
                 </p>
             </div>

--- a/src/features/location/components/LocationSection.tsx
+++ b/src/features/location/components/LocationSection.tsx
@@ -36,23 +36,23 @@ export default function LocationSection() {
     };
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-[--theme-bg] transition-colors duration-300">
+        <div className="flex min-h-screen items-center justify-center bg-(--theme-bg) transition-colors duration-300">
             <div className="flex items-center gap-3">
 
                 {selectedLocation ? (
                     <div className="flex items-center gap-2.5 rounded-full border border-[#88B04B]/30 bg-[#88B04B]/5 px-4 py-2.5 transition-colors duration-300">
                         <MapPin size={14} className="shrink-0 text-[#88B04B]" />
-                        <span className="font-outfit text-sm font-bold text-[--theme-text] transition-colors duration-300">
+                        <span className="font-outfit text-sm font-bold text-(--theme-text) transition-colors duration-300">
                             {selectedLocation.label}
                         </span>
-                        <span className="font-mono text-[11px] text-[--theme-text]/50 transition-colors duration-300">
+                        <span className="font-mono text-[11px] text-(--theme-text)/50 transition-colors duration-300">
                             {selectedLocation.lat.toFixed(4)}, {selectedLocation.lng.toFixed(4)}
                         </span>
                     </div>
                 ) : (
                     <div className="flex items-center gap-2 rounded-full border border-dashed border-[#88B04B]/25 px-4 py-2.5 transition-colors duration-300">
                         <MapPin size={14} className="shrink-0 text-[#88B04B]/40" />
-                        <span className="font-outfit text-sm font-bold text-[--theme-text]/30 transition-colors duration-300">
+                        <span className="font-outfit text-sm font-bold text-(--theme-text)/30 transition-colors duration-300">
                             Sin destino
                         </span>
                     </div>
@@ -88,15 +88,15 @@ export default function LocationSection() {
 
             {modalView === 'map' && (
                 <div
-                    className="fixed inset-0 z-[100] flex items-center justify-center bg-[--theme-bg]/60 px-4 backdrop-blur-md"
+                    className="fixed inset-0 z-[100] flex items-center justify-center bg-(--theme-bg)/60 px-4 backdrop-blur-md"
                     onClick={() => setModalView('list')}
                 >
                     <div
-                        className="w-full max-w-lg overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-[--theme-card-bg] shadow-2xl transition-colors duration-300"
+                        className="w-full max-w-lg overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <div className="flex items-center justify-between border-b border-[#88B04B]/10 px-7 py-5">
-                            <h2 className="font-outfit text-lg font-black tracking-tight text-[--theme-text] transition-colors duration-300">
+                            <h2 className="font-outfit text-lg font-black tracking-tight text-(--theme-text) transition-colors duration-300">
                                 Nueva Ubicación
                             </h2>
                             <button
@@ -104,7 +104,7 @@ export default function LocationSection() {
                                 aria-label="Volver a la lista"
                                 className="
                                     flex h-9 w-9 items-center justify-center rounded-full
-                                    bg-[--theme-secondary-bg] text-[--theme-text]
+                                    bg-(--theme-secondary-bg) text-(--theme-text)
                                     hover:bg-[#88B04B] hover:text-white transition-all duration-200
                                 "
                             >

--- a/src/features/location/components/LocationsModal.tsx
+++ b/src/features/location/components/LocationsModal.tsx
@@ -41,11 +41,11 @@ export default function LocationsModal({
             onClick={onClose}
         >
             <div
-                className="w-full max-w-sm overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-[--theme-card-bg] shadow-2xl transition-colors duration-300"
+                className="w-full max-w-sm overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex items-center justify-between border-b border-[#88B04B]/10 px-7 py-5">
-                    <h2 className="font-outfit text-lg font-black tracking-tight text-[--theme-text] transition-colors duration-300">
+                    <h2 className="font-outfit text-lg font-black tracking-tight text-(--theme-text) transition-colors duration-300">
                         Mis Ubicaciones
                     </h2>
                     <button
@@ -53,7 +53,7 @@ export default function LocationsModal({
                         aria-label="Cerrar modal"
                         className="
                             flex h-9 w-9 items-center justify-center rounded-full
-                            bg-[--theme-secondary-bg] text-[--theme-text]
+                            bg-(--theme-secondary-bg) text-(--theme-text)
                             hover:bg-[#88B04B] hover:text-white transition-all duration-200
                         "
                     >
@@ -63,12 +63,12 @@ export default function LocationsModal({
 
                 <div className="flex max-h-[22rem] flex-col gap-3 overflow-y-auto p-5 custom-scrollbar">
                     {loading ? (
-                        <div className="flex flex-col items-center gap-3 py-12 text-[--theme-text]/40">
+                        <div className="flex flex-col items-center gap-3 py-12 text-(--theme-text)/40">
                             <Loader2 size={28} className="animate-spin text-[#88B04B]/60" />
                             <p className="font-outfit text-sm font-bold">Cargando ubicaciones...</p>
                         </div>
                     ) : locations.length === 0 ? (
-                        <div className="flex flex-col items-center gap-3 py-12 text-[--theme-text]/40">
+                        <div className="flex flex-col items-center gap-3 py-12 text-(--theme-text)/40">
                             <MapPin size={32} className="text-[#88B04B]/40" />
                             <p className="font-outfit text-sm font-bold">No hay destinos guardados</p>
                         </div>


### PR DESCRIPTION
## Description

Migrated all CSS variable class syntax from the Tailwind v3 format `[--var]` to the Tailwind v4 canonical format `(--var)` across LocationsModal, LocationSection, and LocationCard components.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code works as expected
- [x] No new warnings or errors
- [x] Self-reviewed
