### PR TITLE
Feature/ventas diarias admi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-PUBLIC_FIREBASE_API_KEY=
-PUBLIC_FIREBASE_AUTH_DOMAIN=
-PUBLIC_FIREBASE_PROJECT_ID=
-PUBLIC_FIREBASE_STORAGE_BUCKET=
-PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
-PUBLIC_FIREBASE_APP_ID=
+PUBLIC_FIREBASE_API_KEY=dummy-api-key-for-emulator
+PUBLIC_FIREBASE_AUTH_DOMAIN=sansistore.firebaseapp.com
+PUBLIC_FIREBASE_PROJECT_ID=sansistore
+PUBLIC_FIREBASE_STORAGE_BUCKET=sansistore.appspot.com
+PUBLIC_FIREBASE_MESSAGING_SENDER_ID=000000000000
+PUBLIC_FIREBASE_APP_ID=demo-app-id
 PUBLIC_FIREBASE_MEASUREMENT_ID=
-PUBLIC_APP_ENV=production
+PUBLIC_APP_ENV=development
 
 # Server-only Firebase Admin credentials for API routes.
 # Use either FIREBASE_SERVICE_ACCOUNT_KEY as a full JSON string, or the pair below.
@@ -15,5 +15,5 @@ FIREBASE_PRIVATE_KEY=
 
 # Local-only fallback while login/role HUs are not implemented.
 # Never enable this in production.
-ENABLE_DEV_ADMIN_BYPASS=false
+ENABLE_DEV_ADMIN_BYPASS=true
 DEV_ADMIN_UID=dev-admin

--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -13,11 +13,18 @@ import {
   Menu,
   X,
   ChevronRight,
+  ArrowLeft, // <- Agregado para el botón de retroceso
 } from 'lucide-react';
 import UserManagement from '../users/components/UserManagement.tsx';
 import CategoryList from '../categories/components/CategoryList.tsx';
+import DailySales from '../ventas/components/DailySales.tsx';
 
-type Section = 'dashboard' | 'usuarios' | 'categorias' | null;
+type Section =
+  | 'dashboard'
+  | 'usuarios'
+  | 'categorias'
+  | 'ventas-diarias'
+  | null;
 
 interface NavItem {
   label: string;
@@ -35,6 +42,7 @@ interface NavSection {
 export default function AdminLayout() {
   const [activeSection, setActiveSection] = useState<Section>('dashboard');
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [ventasOpen, setVentasOpen] = useState(true);
 
   const navSections: NavSection[] = [
     {
@@ -78,7 +86,7 @@ export default function AdminLayout() {
     {
       title: 'Analítica',
       items: [
-        { label: 'Ventas', icon: <BarChart2 size={15} />, section: null, disabled: true },
+        { label: 'Ventas', icon: <BarChart2 size={15} />, section: 'ventas-diarias' },
         { label: 'Inventario', icon: <Package size={15} />, section: null, disabled: true },
         { label: 'Mensajeros', icon: <Bike size={15} />, section: null, disabled: true },
         { label: 'Reportes', icon: <FileText size={15} />, section: null, disabled: true },
@@ -90,16 +98,10 @@ export default function AdminLayout() {
     dashboard: { title: 'Dashboard', subtitle: 'Panel de administración' },
     usuarios: { title: 'Gestión de usuarios', subtitle: 'Registra y administra usuarios' },
     categorias: { title: 'Categorías', subtitle: 'Gestiona las categorías de productos' },
+    'ventas-diarias': { title: 'Ventas diarias', subtitle: 'Monitorea el rendimiento diario de ventas' },
   };
 
   const currentPage = pageTitles[activeSection ?? 'dashboard'];
-
-  const today = new Date().toLocaleDateString('es-BO', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
 
   return (
     <div className="flex h-screen overflow-hidden bg-[var(--theme-bg)]">
@@ -140,6 +142,51 @@ export default function AdminLayout() {
                 {section.title}
               </p>
               {section.items.map((item) => {
+                if (item.label === 'Ventas') {
+                  return (
+                    <div key={item.label} className="mb-1">
+                      <button
+                        onClick={() => setVentasOpen(!ventasOpen)}
+                        className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px]
+                        text-white/50 hover:text-white/80 hover:bg-white/5 transition-colors"
+                      >
+                        <span>{item.icon}</span>
+                        <span className="flex-1 text-left">Ventas</span>
+                        <ChevronRight
+                          size={12}
+                          className={`transition-transform ${ventasOpen ? 'rotate-90' : ''}`}
+                        />
+                      </button>
+
+                      {ventasOpen && (
+                        <div className="ml-7 mt-1 space-y-1">
+                          <button
+                            onClick={() => {
+                              setActiveSection('ventas-diarias');
+                              setSidebarOpen(false);
+                            }}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-[12px]
+                            transition-colors ${
+                              activeSection === 'ventas-diarias'
+                                ? 'bg-[#88b04b]/15 text-[#88b04b]'
+                                : 'text-white/40 hover:text-white/80 hover:bg-white/5'
+                            }`}
+                          >
+                            Ventas diarias
+                          </button>
+
+                          <button
+                            className="w-full text-left px-3 py-2 rounded-lg text-[12px]
+                            text-white/20 cursor-not-allowed"
+                          >
+                            Más vendidos
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
+
                 const isActive = activeSection === item.section;
                 return (
                   <button
@@ -192,36 +239,49 @@ export default function AdminLayout() {
       </aside>
 
       {/* Main */}
-      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden bg-[#fafafa]">
 
-        {/* Topbar */}
-        <header className="flex items-center justify-between px-5 py-3.5 border-b border-[var(--theme-border)] bg-[var(--theme-card-bg)]">
-          <div className="flex items-center gap-3">
+        {/* Topbar: Modificado para replicar el Mockup */}
+        <header className="flex items-center justify-between px-6 py-5 md:px-10 md:py-6 bg-[#0a0a0a]">
+          <div className="flex items-center gap-4 md:gap-8">
+            {/* Menú Hamburguesa Mobile */}
             <button
-              className="md:hidden p-1 text-[var(--theme-text)]/50 hover:text-[var(--theme-text)] transition-colors"
+              className="md:hidden p-1 text-white/50 hover:text-white transition-colors"
               onClick={() => setSidebarOpen(!sidebarOpen)}
             >
-              {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
+              {sidebarOpen ? <X size={20} /> : <Menu size={20} />}
             </button>
-            <div>
-              <h1 className="text-[15px] font-semibold text-[var(--theme-text)]">
+
+            {/* Grupo de Título y Botón Volver */}
+            <div className="flex items-center gap-4 md:gap-8">
+              {activeSection !== 'dashboard' && (
+                <button
+                  onClick={() => setActiveSection('dashboard')}
+                  className="hidden md:flex items-center gap-2 text-white/50 hover:text-white transition-colors text-sm font-medium"
+                >
+                  <ArrowLeft size={16} /> Dashboard
+                </button>
+              )}
+              
+              <h1 className="text-xl md:text-3xl font-bold text-white tracking-tight">
                 {currentPage.title}
               </h1>
-              <p className="text-[11px] text-[var(--theme-text)]/40">
-                {currentPage.subtitle}
-              </p>
             </div>
           </div>
-          <span className="text-[11px] text-[var(--theme-text)]/35 hidden sm:block capitalize">
-            {today}
-          </span>
+          
+          <div className="flex items-center gap-4">
+             {/* Badge Área 7 */}
+             <div className="px-5 py-1.5 border border-[#88b04b] text-[#88b04b] rounded-full text-xs md:text-sm font-medium tracking-wide">
+               Área 7
+             </div>
+          </div>
         </header>
 
         {/* Content */}
-        <main className="flex-1 overflow-y-auto p-5">
+        <main className="flex-1 overflow-y-auto p-6 md:p-10">
           {activeSection === 'dashboard' && (
-            <div className="flex items-center justify-center h-full text-[var(--theme-text)]/30 text-sm">
-              Dashboard — próximamente
+            <div className="flex items-center justify-center h-full text-black/30 text-sm font-medium">
+              Dashboard principal — Próximamente
             </div>
           )}
           {activeSection === 'usuarios' && (
@@ -229,6 +289,9 @@ export default function AdminLayout() {
           )}
           {activeSection === 'categorias' && (
             <CategoryList />
+          )}
+          {activeSection === 'ventas-diarias' && (
+            <DailySales />
           )}
         </main>
 

--- a/src/features/admin/ventas/components/DailySales.tsx
+++ b/src/features/admin/ventas/components/DailySales.tsx
@@ -1,0 +1,158 @@
+export default function DailySales() {
+  return (
+    /* Contenedor principal centrado y con ancho máximo para que no se estire */
+    <div className="max-w-5xl mx-auto space-y-8 pb-10">
+
+      {/* Se eliminó el Header duplicado. Tu Layout ya lo maneja. */}
+
+      {/* Filters */}
+      <div className="space-y-3">
+        <h3 className="text-xs font-bold text-[var(--theme-text)]/50 uppercase tracking-wider">
+          Filtrar por rango de fechas
+        </h3>
+
+        <div className="flex flex-col md:flex-row gap-4">
+          {/* Input Fecha Inicio con Label integrado */}
+          <div className="flex-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card-bg)] px-4 py-2 flex flex-col justify-center">
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/50 uppercase">Fecha de inicio</span>
+            <input
+              type="date"
+              className="w-full bg-transparent text-sm outline-none text-[var(--theme-text)] mt-0.5"
+            />
+          </div>
+
+          {/* Input Fecha Fin con Label integrado */}
+          <div className="flex-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card-bg)] px-4 py-2 flex flex-col justify-center">
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/50 uppercase">Fecha de fin</span>
+            <input
+              type="date"
+              className="w-full bg-transparent text-sm outline-none text-[var(--theme-text)] mt-0.5"
+            />
+          </div>
+
+          <button
+            className="px-8 py-3 rounded-xl bg-[#88b04b] hover:bg-[#7aa03f] transition-colors text-white text-sm font-medium"
+          >
+            Aplicar filtro
+          </button>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="space-y-3">
+        <h3 className="text-xs font-bold text-[var(--theme-text)]/50 uppercase tracking-wider">
+          Resumen del período
+        </h3>
+        
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {/* Tarjetas sin borde, fondo gris suave y texto centrado como en el mockup */}
+          <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
+            <p className="text-3xl font-bold text-[#88b04b] mb-1">
+              Bs. 12,840
+            </p>
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
+              Ventas totales
+            </span>
+          </div>
+
+          <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
+            <p className="text-3xl font-bold text-[var(--theme-text)] mb-1">
+              48
+            </p>
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
+              Órdenes
+            </span>
+          </div>
+
+          <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
+            <p className="text-3xl font-bold text-[#88b04b] mb-1">
+              Bs. 267
+            </p>
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
+              Promedio diario
+            </span>
+          </div>
+
+          <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
+            <p className="text-3xl font-bold text-[#88b04b] mb-1">
+              15
+            </p>
+            <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
+              Días con ventas
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Table Section */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xs font-bold text-[var(--theme-text)]/50 uppercase tracking-wider">
+            Ventas por día
+          </h3>
+          <span className="text-xs text-[#88b04b] font-medium flex items-center gap-1">
+            {/* Ícono de recargar simple en SVG */}
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Actualización en tiempo real
+          </span>
+        </div>
+
+        <div className="bg-[var(--theme-card-bg)] rounded-2xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-black/5">
+              <tr className="text-left text-[11px] font-bold text-[var(--theme-text)]/50 uppercase tracking-wider">
+                <th className="px-5 py-4">Fecha</th>
+                <th className="px-5 py-4">Órdenes</th>
+                <th className="px-5 py-4">Monto total</th>
+                <th className="px-5 py-4">Promedio</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {[
+                ['15/05/2026', 6, 'Bs. 1,980', 'Bs. 330'],
+                ['14/05/2026', 5, 'Bs. 1,450', 'Bs. 290'],
+                ['13/05/2026', 4, 'Bs. 1,120', 'Bs. 280'],
+                ['12/05/2026', 7, 'Bs. 2,310', 'Bs. 330'],
+              ].map((sale, index) => (
+                <tr
+                  key={sale[0]}
+                  className={index !== 0 ? "border-t border-[var(--theme-border)]/50" : ""}
+                >
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[0]}</td>
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[1]}</td>
+                  <td className="px-5 py-4 text-[#88b04b] font-medium">
+                    {sale[2]}
+                  </td>
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[3]}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Info Box Firestore */}
+        <div className="bg-[#f2f7eb] border border-[#dcedc8] rounded-2xl p-5 mt-4">
+          <h4 className="text-sm font-bold text-gray-800 mb-1">Datos en tiempo real</h4>
+          <p className="text-xs text-gray-600">
+            La información se actualiza automáticamente desde Firestore.<br/>
+            Solo se incluyen órdenes confirmadas o completadas.
+          </p>
+        </div>
+      </div>
+
+      {/* Empty State */}
+      <div className="border-2 border-dashed border-[var(--theme-border)] rounded-2xl p-10 flex flex-col items-center justify-center text-center">
+        <p className="text-sm font-bold text-[var(--theme-text)]">
+          No se encontraron ventas en el rango seleccionado.
+        </p>
+        <p className="text-xs text-[var(--theme-text)]/50 mt-2">
+          Intenta con un rango de fechas diferente.
+        </p>
+      </div>
+
+    </div>
+  );
+}

--- a/src/features/admin/ventas/components/DailySales.tsx
+++ b/src/features/admin/ventas/components/DailySales.tsx
@@ -1,4 +1,24 @@
+import { useState } from 'react';
+import { useDailySales } from '../hooks/useDailySales';
+
+const formatCurrency = (amount: number) =>
+  `Bs. ${amount.toLocaleString('es-BO', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+  })}`;
+
 export default function DailySales() {
+  const [startDateInput, setStartDateInput] = useState('');
+  const [endDateInput, setEndDateInput] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const { summary, dailySales, loading, error } = useDailySales(startDate, endDate);
+
+  const applyFilter = () => {
+    setStartDate(startDateInput);
+    setEndDate(endDateInput);
+  };
+
   return (
     /* Contenedor principal centrado y con ancho máximo para que no se estire */
     <div className="max-w-5xl mx-auto space-y-8 pb-10">
@@ -17,6 +37,8 @@ export default function DailySales() {
             <span className="text-[10px] font-bold text-[var(--theme-text)]/50 uppercase">Fecha de inicio</span>
             <input
               type="date"
+              value={startDateInput}
+              onChange={(event) => setStartDateInput(event.target.value)}
               className="w-full bg-transparent text-sm outline-none text-[var(--theme-text)] mt-0.5"
             />
           </div>
@@ -26,11 +48,14 @@ export default function DailySales() {
             <span className="text-[10px] font-bold text-[var(--theme-text)]/50 uppercase">Fecha de fin</span>
             <input
               type="date"
+              value={endDateInput}
+              onChange={(event) => setEndDateInput(event.target.value)}
               className="w-full bg-transparent text-sm outline-none text-[var(--theme-text)] mt-0.5"
             />
           </div>
 
           <button
+            onClick={applyFilter}
             className="px-8 py-3 rounded-xl bg-[#88b04b] hover:bg-[#7aa03f] transition-colors text-white text-sm font-medium"
           >
             Aplicar filtro
@@ -48,7 +73,7 @@ export default function DailySales() {
           {/* Tarjetas sin borde, fondo gris suave y texto centrado como en el mockup */}
           <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
             <p className="text-3xl font-bold text-[#88b04b] mb-1">
-              Bs. 12,840
+              {formatCurrency(summary.totalSales)}
             </p>
             <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
               Ventas totales
@@ -57,7 +82,7 @@ export default function DailySales() {
 
           <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
             <p className="text-3xl font-bold text-[var(--theme-text)] mb-1">
-              48
+              {summary.totalOrders}
             </p>
             <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
               Órdenes
@@ -66,7 +91,7 @@ export default function DailySales() {
 
           <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
             <p className="text-3xl font-bold text-[#88b04b] mb-1">
-              Bs. 267
+              {formatCurrency(summary.dailyAverage)}
             </p>
             <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
               Promedio diario
@@ -75,7 +100,7 @@ export default function DailySales() {
 
           <div className="bg-black/5 rounded-2xl p-6 text-center flex flex-col justify-center">
             <p className="text-3xl font-bold text-[#88b04b] mb-1">
-              15
+              {summary.daysWithSales}
             </p>
             <span className="text-[10px] font-bold text-[var(--theme-text)]/40 uppercase tracking-wider">
               Días con ventas
@@ -111,22 +136,17 @@ export default function DailySales() {
             </thead>
 
             <tbody>
-              {[
-                ['15/05/2026', 6, 'Bs. 1,980', 'Bs. 330'],
-                ['14/05/2026', 5, 'Bs. 1,450', 'Bs. 290'],
-                ['13/05/2026', 4, 'Bs. 1,120', 'Bs. 280'],
-                ['12/05/2026', 7, 'Bs. 2,310', 'Bs. 330'],
-              ].map((sale, index) => (
+              {dailySales.map((sale, index) => (
                 <tr
-                  key={sale[0]}
+                  key={sale.date}
                   className={index !== 0 ? "border-t border-[var(--theme-border)]/50" : ""}
                 >
-                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[0]}</td>
-                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[1]}</td>
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale.date}</td>
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale.orders}</td>
                   <td className="px-5 py-4 text-[#88b04b] font-medium">
-                    {sale[2]}
+                    {formatCurrency(sale.totalAmount)}
                   </td>
-                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{sale[3]}</td>
+                  <td className="px-5 py-4 text-[var(--theme-text)]/80">{formatCurrency(sale.average)}</td>
                 </tr>
               ))}
             </tbody>
@@ -144,14 +164,16 @@ export default function DailySales() {
       </div>
 
       {/* Empty State */}
-      <div className="border-2 border-dashed border-[var(--theme-border)] rounded-2xl p-10 flex flex-col items-center justify-center text-center">
-        <p className="text-sm font-bold text-[var(--theme-text)]">
-          No se encontraron ventas en el rango seleccionado.
-        </p>
-        <p className="text-xs text-[var(--theme-text)]/50 mt-2">
-          Intenta con un rango de fechas diferente.
-        </p>
-      </div>
+      {!loading && !error && dailySales.length === 0 && (
+        <div className="border-2 border-dashed border-[var(--theme-border)] rounded-2xl p-10 flex flex-col items-center justify-center text-center">
+          <p className="text-sm font-bold text-[var(--theme-text)]">
+            No se encontraron ventas en el rango seleccionado.
+          </p>
+          <p className="text-xs text-[var(--theme-text)]/50 mt-2">
+            Intenta con un rango de fechas diferente.
+          </p>
+        </div>
+      )}
 
     </div>
   );

--- a/src/features/admin/ventas/hooks/useDailySales.ts
+++ b/src/features/admin/ventas/hooks/useDailySales.ts
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+  Timestamp,
+  where,
+  type DocumentData,
+  type QueryConstraint,
+} from 'firebase/firestore';
+import { db } from '../../../../lib/firebase';
+
+export interface DailySale {
+  date: string;
+  orders: number;
+  totalAmount: number;
+  average: number;
+}
+
+export interface DailySalesSummary {
+  totalSales: number;
+  totalOrders: number;
+  dailyAverage: number;
+  daysWithSales: number;
+}
+
+export interface DailySalesState {
+  summary: DailySalesSummary;
+  dailySales: DailySale[];
+  loading: boolean;
+  error: string | null;
+}
+
+interface OrderDocument {
+  createdAt?: Timestamp | Date | string | null;
+  total?: number | string | null;
+  status?: string | null;
+  paymentStatus?: string | null;
+  deliveryStatus?: string | null;
+}
+
+const EMPTY_SUMMARY: DailySalesSummary = {
+  totalSales: 0,
+  totalOrders: 0,
+  dailyAverage: 0,
+  daysWithSales: 0,
+};
+
+const VALID_STATUS_VALUES = new Set([
+  'confirmed',
+  'completed',
+  'paid',
+  'delivered',
+  'collected',
+  'confirmado',
+  'completado',
+  'pagado',
+  'entregado',
+  'cobrado',
+]);
+
+const INVALID_STATUS_VALUES = new Set([
+  'cancelled',
+  'canceled',
+  'cancelado',
+  'pending',
+  'pendiente',
+  'rejected',
+  'rechazado',
+  'creado',
+  'registrado',
+]);
+
+function normalizeStatus(value: string | null | undefined) {
+  return value
+    ?.trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[_\s-]+/g, '_');
+}
+
+function toDate(value: OrderDocument['createdAt']): Date | null {
+  if (!value) return null;
+  if (value instanceof Timestamp) return value.toDate();
+  if (value instanceof Date) return value;
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toAmount(value: OrderDocument['total']) {
+  const amount = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(amount) ? amount : 0;
+}
+
+function inputDateToTimestamp(value: string, endOfDay = false) {
+  if (!value) return null;
+
+  const date = new Date(`${value}T${endOfDay ? '23:59:59.999' : '00:00:00.000'}`);
+  return Number.isNaN(date.getTime()) ? null : Timestamp.fromDate(date);
+}
+
+function formatDateKey(date: Date) {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${day}/${month}/${date.getFullYear()}`;
+}
+
+function isValidSale(order: OrderDocument) {
+  const statuses = [
+    normalizeStatus(order.status),
+    normalizeStatus(order.paymentStatus),
+    normalizeStatus(order.deliveryStatus),
+  ].filter((status): status is string => Boolean(status));
+
+  if (statuses.some((status) => INVALID_STATUS_VALUES.has(status))) {
+    return false;
+  }
+
+  return statuses.some((status) => VALID_STATUS_VALUES.has(status));
+}
+
+function mapDocument(data: DocumentData): OrderDocument {
+  return {
+    createdAt: data.createdAt,
+    total: data.total,
+    status: typeof data.status === 'string' ? data.status : null,
+    paymentStatus: typeof data.paymentStatus === 'string' ? data.paymentStatus : null,
+    deliveryStatus: typeof data.deliveryStatus === 'string' ? data.deliveryStatus : null,
+  };
+}
+
+function buildDailySales(orders: OrderDocument[]): Pick<DailySalesState, 'summary' | 'dailySales'> {
+  const grouped = new Map<string, { dateValue: number; orders: number; totalAmount: number }>();
+
+  for (const order of orders) {
+    if (!isValidSale(order)) continue;
+
+    const createdAt = toDate(order.createdAt);
+    if (!createdAt) continue;
+
+    const date = formatDateKey(createdAt);
+    const current = grouped.get(date) ?? {
+      dateValue: new Date(createdAt.getFullYear(), createdAt.getMonth(), createdAt.getDate()).getTime(),
+      orders: 0,
+      totalAmount: 0,
+    };
+
+    current.orders += 1;
+    current.totalAmount += toAmount(order.total);
+    grouped.set(date, current);
+  }
+
+  const dailySales = [...grouped.entries()]
+    .map(([date, sale]) => ({
+      date,
+      orders: sale.orders,
+      totalAmount: sale.totalAmount,
+      average: sale.orders > 0 ? sale.totalAmount / sale.orders : 0,
+      dateValue: sale.dateValue,
+    }))
+    .sort((a, b) => b.dateValue - a.dateValue)
+    .map((sale) => ({
+      date: sale.date,
+      orders: sale.orders,
+      totalAmount: sale.totalAmount,
+      average: sale.average,
+    }));
+
+  const totalSales = dailySales.reduce((total, sale) => total + sale.totalAmount, 0);
+  const totalOrders = dailySales.reduce((total, sale) => total + sale.orders, 0);
+  const daysWithSales = dailySales.length;
+
+  return {
+    dailySales,
+    summary: {
+      totalSales,
+      totalOrders,
+      dailyAverage: daysWithSales > 0 ? totalSales / daysWithSales : 0,
+      daysWithSales,
+    },
+  };
+}
+
+export function useDailySales(startDate: string, endDate: string): DailySalesState {
+  const [state, setState] = useState<DailySalesState>({
+    summary: EMPTY_SUMMARY,
+    dailySales: [],
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    const constraints: QueryConstraint[] = [];
+    const start = inputDateToTimestamp(startDate);
+    const end = inputDateToTimestamp(endDate, true);
+
+    if (start) constraints.push(where('createdAt', '>=', start));
+    if (end) constraints.push(where('createdAt', '<=', end));
+    constraints.push(orderBy('createdAt', 'desc'));
+
+    return onSnapshot(
+      query(collection(db, 'orders'), ...constraints),
+      (snapshot) => {
+        const orders = snapshot.docs.map((doc) => mapDocument(doc.data()));
+        const sales = buildDailySales(orders);
+
+        setState({
+          ...sales,
+          loading: false,
+          error: null,
+        });
+      },
+      (error) => {
+        setState({
+          summary: EMPTY_SUMMARY,
+          dailySales: [],
+          loading: false,
+          error: error.message,
+        });
+      },
+    );
+  }, [endDate, startDate]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- Connects daily sales view to Firestore orders.
- Adds daily sales aggregation by createdAt date.
- Calculates total sales, total orders, daily average, and days with sales.
- Keeps the existing approved UI without visual redesign.
- Updates .env.example for local emulator testing.

## Testing
- Ran ESLint on DailySales and useDailySales.
- Ran Astro build successfully.
- Tested with Firestore Emulator data.