### PR TITLE
feat(courier): add temporary alert for new orders

### DIFF
--- a/seed/data/deliveries.mjs
+++ b/seed/data/deliveries.mjs
@@ -146,6 +146,30 @@ export const Deliveries = {
     createdAt: '2026-04-25T13:42:00.000Z',
     updatedAt: '2026-04-25T13:45:00.000Z',
   },
+  DELIVERY_012: {
+    code: 'delivery-012',
+    orderCode: 'order-012',
+    courier: Users.NADIA,
+    status: 'assigned',
+    attemptNumber: 1,
+    amountCollected: 34,
+    customerConfirmed: false,
+    assignedAt: '2026-04-25T13:45:00.000Z',
+    createdAt: '2026-04-25T13:42:00.000Z',
+    updatedAt: '2026-04-25T13:45:00.000Z',
+  },
+  DELIVERY_013: {
+    code: 'delivery-013',
+    orderCode: 'order-013',
+    courier: Users.NADIA,
+    status: 'assigned',
+    attemptNumber: 1,
+    amountCollected: 34,
+    customerConfirmed: false,
+    assignedAt: '2026-04-25T13:45:00.000Z',
+    createdAt: '2026-04-25T13:42:00.000Z',
+    updatedAt: '2026-04-25T13:45:00.000Z',
+  },
 };
 
 export const deliveryList = Object.values(Deliveries);

--- a/seed/data/orders.mjs
+++ b/seed/data/orders.mjs
@@ -186,6 +186,38 @@ export const Orders = {
     createdAt: '2026-04-25T13:25:00.000Z',
     updatedAt: '2026-04-25T13:45:00.000Z',
   },
+  ORDER_012: {
+    code: 'order-012',
+    buyer: Users.CARLOS,
+    seller: Users.PEDRO,
+    location: Locations.LOC_CARLOS,
+    status: 'CONFIRMADO',
+    deliveryStatus: 'assigned',
+    customerName: 'Carlos Flores',
+    customerPhone: '76459821',
+    items: [
+      { product: Products.DETERGENTE_OLA, quantity: 2 },
+    ],
+    confirmedAt: '2026-04-25T13:40:00.000Z',
+    createdAt: '2026-04-25T13:25:00.000Z',
+    updatedAt: '2026-04-25T13:45:00.000Z',
+  },
+  ORDER_013: {
+    code: 'order-013',
+    buyer: Users.CARLOS,
+    seller: Users.PEDRO,
+    location: Locations.LOC_CARLOS,
+    status: 'CONFIRMADO',
+    deliveryStatus: 'assigned',
+    customerName: 'Carlos Flores',
+    customerPhone: '76459821',
+    items: [
+      { product: Products.DETERGENTE_OLA, quantity: 2 },
+    ],
+    confirmedAt: '2026-04-25T13:40:00.000Z',
+    createdAt: '2026-04-25T13:25:00.000Z',
+    updatedAt: '2026-04-25T13:45:00.000Z',
+  },
 };
 
 export const orderList = Object.values(Orders);

--- a/src/features/mensajero/components/MessengerDashboard.css
+++ b/src/features/mensajero/components/MessengerDashboard.css
@@ -233,3 +233,89 @@ html[data-theme='dark'] .messenger-toast--error {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   }
 }
+
+/* New order temporary notification */
+.messenger-new-order-toast {
+  position: fixed;
+  top: 5.75rem;
+  right: clamp(1rem, 3vw, 3rem);
+  z-index: 900;
+  width: min(420px, calc(100vw - 2rem));
+  padding: 1.25rem;
+  border: 1.5px solid color-mix(in srgb, #88b04b 60%, var(--theme-border));
+  border-radius: 1.5rem;
+  background: color-mix(in srgb, #88b04b 8%, var(--theme-card-bg));
+  color: var(--theme-text);
+  box-shadow: 0 22px 45px rgba(38, 33, 22, 0.16);
+  animation: new-order-toast-in 0.28s ease-out;
+}
+
+.messenger-new-order-icon {
+  background: color-mix(in srgb, #88b04b 18%, var(--theme-card-bg));
+  color: #5f8330;
+}
+
+.messenger-new-order-close {
+  color: color-mix(in srgb, var(--theme-text) 58%, transparent);
+}
+
+.messenger-new-order-close:hover {
+  background: color-mix(in srgb, #88b04b 14%, transparent);
+  color: #5f8330;
+}
+
+.messenger-new-order-progress {
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, #88b04b 20%, var(--theme-border));
+}
+
+.messenger-new-order-progress span {
+  display: block;
+  height: 100%;
+  width: 100%;
+  border-radius: inherit;
+  background: #88b04b;
+  transform-origin: left;
+  animation: new-order-progress 5s linear forwards;
+}
+
+@keyframes new-order-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes new-order-progress {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
+  }
+}
+
+html[data-theme='dark'] .messenger-new-order-toast {
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.38);
+}
+
+html[data-theme='dark'] .messenger-new-order-icon {
+  color: #b7dc78;
+}
+
+@media (max-width: 640px) {
+  .messenger-new-order-toast {
+    top: 4.5rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+  }
+}

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import {
@@ -16,10 +16,10 @@ import {
 } from 'lucide-react';
 import { auth } from '../../../lib/firebase';
 import {
-  getMessengerOrders,
   markMessengerOrderAsNotDelivered,
   registerMessengerCashPayment,
   setMessengerOrderStatus,
+  subscribeToMessengerOrders,
 } from '../services/messengerOrdersService';
 import type { MessengerOrder } from '../types';
 import UndeliveredModal from '../modals/UndeliveredModal';
@@ -69,6 +69,59 @@ function MessageToast({ message, onDismiss }: { message: string; onDismiss: () =
         <X size={15} />
       </button>
     </div>
+  );
+}
+
+function NewOrderToast({
+  count,
+  onDismiss,
+}: {
+  count: number;
+  onDismiss: () => void;
+}) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 5000);
+    return () => clearTimeout(timer);
+  }, [count, onDismiss]);
+
+  const pedidoLabel = count === 1 ? 'pedido' : 'pedidos';
+
+  return (
+    <aside
+      aria-live="polite"
+      className="messenger-new-order-toast"
+      role="status"
+    >
+      <div className="flex items-start gap-4">
+        <span className="messenger-new-order-icon inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full">
+          <Package size={24} />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base font-black">Nuevo pedido disponible</h3>
+          <p className="messenger-copy mt-1 text-sm font-semibold">
+            Tienes {count} {pedidoLabel} por revisar.
+          </p>
+        </div>
+
+        <button
+          aria-label="Cerrar alerta de nuevo pedido"
+          className="messenger-new-order-close inline-flex h-8 w-8 items-center justify-center rounded-full transition"
+          onClick={onDismiss}
+          type="button"
+        >
+          <X size={17} />
+        </button>
+      </div>
+
+      <div className="messenger-new-order-progress mt-4" aria-hidden="true">
+        <span />
+      </div>
+
+      <p className="messenger-copy mt-2 text-xs font-semibold">
+        Se cerrará automáticamente en unos segundos.
+      </p>
+    </aside>
   );
 }
 
@@ -494,58 +547,133 @@ export default function MessengerDashboard({
     useState<MessengerOrder | null>(null);
   const [savingUndelivered, setSavingUndelivered] = useState(false);
   const [currentCourierId, setCurrentCourierId] = useState<string | null>(null);
+  const [newOrderCount, setNewOrderCount] = useState(0);
+  const notifiedOrderIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    const loadOrders = async (courierId: string, allowDevFallback = false) => {
+    let unsubscribeOrders: (() => void) | undefined;
+
+    const startOrdersSubscription = (
+      courierId: string,
+      allowDevFallback = false
+    ) => {
       setLoading(true);
       setMessage('');
 
-      try {
-        let data = await getMessengerOrders(courierId);
+      unsubscribeOrders?.();
 
-        if (
-          data.length === 0 &&
-          allowDevFallback &&
-          import.meta.env.PUBLIC_APP_ENV !== 'production' &&
-          courierId !== DEV_COURIER_ID
-        ) {
-          data = await getMessengerOrders(DEV_COURIER_ID);
+      unsubscribeOrders = subscribeToMessengerOrders(
+        courierId,
+        (data) => {
+          if (
+            data.length === 0 &&
+            allowDevFallback &&
+            import.meta.env.PUBLIC_APP_ENV !== 'production' &&
+            courierId !== DEV_COURIER_ID
+          ) {
+            startOrdersSubscription(DEV_COURIER_ID, false);
+            return;
+          }
+
+          setOrders(data);
+          setLoading(false);
+        },
+        (error) => {
+          console.error(error);
+          setOrders([]);
+          setLoading(false);
+          setMessage('No se pudieron cargar las entregas del emulador.');
         }
-
-        setOrders(data);
-      } catch (error) {
-        console.error(error);
-        setOrders([]);
-        setMessage('No se pudieron cargar las entregas del emulador.');
-      } finally {
-        setLoading(false);
-      }
+      );
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
+    const unsubscribeAuth = onAuthStateChanged(auth, (user) => {
       const devCourierId =
         import.meta.env.PUBLIC_APP_ENV !== 'production' ? DEV_COURIER_ID : null;
       const courierId = user?.uid || devCourierId;
       const allowDevFallback = !user;
+
       setCurrentCourierId(courierId);
 
       if (!courierId) {
+        unsubscribeOrders?.();
         setOrders([]);
         setLoading(false);
         setMessage('Inicia sesion para ver tus entregas asignadas.');
         return;
       }
 
-      void loadOrders(courierId, allowDevFallback);
+      startOrdersSubscription(courierId, allowDevFallback);
     });
 
-    return unsubscribe;
+    return () => {
+      unsubscribeOrders?.();
+      unsubscribeAuth();
+    };
   }, []);
 
   const assignedOrders = useMemo(
     () => orders.filter((order) => order.deliveryStatus === 'assigned'),
     [orders]
   );
+
+  const assignedOrderIdsKey = useMemo(
+    () =>
+      assignedOrders
+        .map((order) => order.deliveryId || order.id)
+        .sort()
+        .join('|'),
+    [assignedOrders]
+  );
+
+  useEffect(() => {
+    if (loading || clientSection !== 'assigned') return;
+
+    const currentOrderIds = assignedOrderIdsKey
+      ? assignedOrderIdsKey.split('|')
+      : [];
+
+    if (currentOrderIds.length === 0) {
+      setNewOrderCount(0);
+      return;
+    }
+
+    const storageKey = 'sansistore:messenger:notified-order-ids';
+
+    let storedIds: string[] = [];
+
+    try {
+      storedIds = JSON.parse(
+        sessionStorage.getItem(storageKey) || '[]'
+      ) as string[];
+    } catch {
+      storedIds = [];
+    }
+
+    const alreadyNotifiedIds = new Set([
+      ...storedIds,
+      ...Array.from(notifiedOrderIdsRef.current),
+    ]);
+
+    const newIds = currentOrderIds.filter(
+      (orderId) => !alreadyNotifiedIds.has(orderId)
+    );
+
+    if (newIds.length === 0) return;
+
+    const updatedIds = Array.from(
+      new Set([...storedIds, ...currentOrderIds])
+    );
+
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify(updatedIds));
+    } catch {
+      
+    }
+    notifiedOrderIdsRef.current = new Set(updatedIds);
+    setNewOrderCount(newIds.length);
+  }, [assignedOrderIdsKey, clientSection, loading]);
+
   const acceptedOrders = useMemo(
     () =>
       orders.filter(
@@ -716,6 +844,12 @@ export default function MessengerDashboard({
     <main
       className={`messenger-dashboard ${embedded ? 'messenger-dashboard--embedded' : 'min-h-screen'}`}
     >      
+      {newOrderCount > 0 && clientSection === 'assigned' && (
+        <NewOrderToast
+          count={newOrderCount}
+          onDismiss={() => setNewOrderCount(0)}
+        />
+      )}
       {!embedded && (
         <header className="messenger-header border-b">
           <div className="messenger-header-inner flex items-center justify-between">

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -3,12 +3,14 @@ import {
   doc,
   getDoc,
   getDocs,
+  onSnapshot,
   query,
   serverTimestamp,
   updateDoc,
   setDoc,
   where,
   writeBatch,
+  type Unsubscribe,
 } from 'firebase/firestore';
 import { db } from '../../../lib/firebase';
 import type { MessengerOrder, MessengerOrderItem } from '../types';
@@ -107,6 +109,79 @@ export async function getMessengerOrders(
   return orders.sort((a, b) => a.id.localeCompare(b.id));
 }
 
+export function subscribeToMessengerOrders(
+  courierId: string,
+  onChange: (orders: MessengerOrder[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe {
+  const deliveriesQuery = query(
+    collection(db, 'deliveries'),
+    where('courierId', '==', courierId)
+  );
+
+  return onSnapshot(
+    deliveriesQuery,
+    async (deliveriesSnapshot) => {
+      try {
+        const orders = await Promise.all(
+          deliveriesSnapshot.docs.map(async (deliveryDoc) => {
+            const delivery = deliveryDoc.data();
+            const orderId = String(delivery.orderId || '');
+            const orderSnap = orderId
+              ? await getDoc(doc(db, 'orders', orderId))
+              : null;
+            const order = orderSnap?.exists() ? orderSnap.data() : {};
+            const items = orderId ? await readOrderItems(orderId) : [];
+            const paymentStatus = String(order.paymentStatus || 'PENDIENTE');
+
+            return {
+              id: orderId || deliveryDoc.id,
+              deliveryId: deliveryDoc.id,
+              paymentId:
+                typeof order.paymentId === 'string' ? order.paymentId : null,
+              orderCode: String(order.orderCode || order.code || orderId || ''),
+              customerName: String(
+                order.customerName || 'Cliente no registrado'
+              ),
+              buyerName: String(order.customerName || 'Comprador invitado'),
+              phone: String(order.customerPhone || 'Sin telefono'),
+              address: String(order.address || 'Direccion no registrada'),
+              city: String(order.deliveryZone || 'Cochabamba'),
+              items,
+              cashToCollect: Number(delivery.amountCollected || order.total || 0),
+              paymentMethod: 'cash_on_delivery' as const,
+              paymentStatus,
+              paymentStatusLabel:
+                paymentStatus.toLowerCase() === 'cobrado' ||
+                paymentStatus.toLowerCase() === 'pagado'
+                  ? 'Cobrado'
+                  : 'Pendiente de cobro',
+              paymentCollectedAt:
+                order.paymentCollectedAt?.toDate?.() ?? null,
+              collectedBy:
+                typeof order.collectedBy === 'string'
+                  ? order.collectedBy
+                  : null,
+              deliveryMethod: String(order.deliveryMethod || 'Delivery'),
+              deliveryStatus: normalizeDeliveryStatus(delivery.status),
+            };
+          })
+        );
+
+        onChange(orders.sort((a, b) => a.id.localeCompare(b.id)));
+      } catch (error) {
+        onError?.(
+          error instanceof Error
+            ? error
+            : new Error('No se pudieron escuchar las entregas.')
+        );
+      }
+    },
+    (error) => {
+      onError?.(error);
+    }
+  );
+}
 const getStatusForORder = (status: DeliveryStatus) => {
   switch (status) {
     case 'accepted': return 'ACEPTADO';


### PR DESCRIPTION
## Description
This PR adds a temporary alert for new available orders in the courier dashboard.

The alert is shown when the courier has new assigned orders to review before accepting or rejecting them.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

## Related Issues
Closes #123

## Changes
- Added a temporary notification for new courier orders.
- The alert appears in the upper-right area of the courier dashboard.
- The alert closes automatically after a few seconds.
- Added a manual close button for the alert.
- Added seed data to test the alert with assigned courier orders.

## Testing
- Loaded seed data in the Firebase emulator.
- Verified that the alert appears when entering the courier dashboard.
- Verified that the alert closes automatically.
- Verified that the alert can be closed manually.
- Verified that assigned orders are still displayed correctly.
- Verified that accepting and rejecting orders are not affected.