### PR TITLE
feat: agregar historial de entregas para mensajero con fecha y ordena…

### DIFF
--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -37,6 +37,14 @@ const DEV_COURIER_ID = 'user-nadia';
 
 const formatBolivianos = (amount: number) => `Bs ${amount}`;
 
+const formatDate = (date: Date | null | undefined) => {
+    if (!date) return 'Fecha no disponible';
+    return new Intl.DateTimeFormat('es-BO', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(date);
+};
+
 const formatOrderAgeDate = (order: MessengerOrder) => {
     const date = order.assignedAt ?? order.createdAt ?? order.updatedAt;
 
@@ -403,7 +411,9 @@ function PendingOrderCard({
     );
 }
 
+// ✅ MODIFICADO: Se agregó la fecha de entrega
 function DeliveredOrderRow({ order }: { order: MessengerOrder }) {
+    const deliveryDate = order.paymentCollectedAt || order.updatedAt || order.createdAt;
     return (
         <article className="messenger-delivered-row flex items-center justify-between gap-4 rounded-[26px] border p-6 shadow-[0_10px_24px_rgba(18,32,56,0.06)]">
             <div className="flex items-center gap-4">
@@ -411,8 +421,11 @@ function DeliveredOrderRow({ order }: { order: MessengerOrder }) {
                     <CheckCircle2 size={20} />
                 </span>
                 <div>
-                    <h3 className="font-black">#{order.id}</h3>
+                    <h3 className="font-black">#{order.orderCode || order.id}</h3>
                     <p className="messenger-copy text-sm">{order.customerName}</p>
+                    <p className="messenger-muted mt-1 text-xs">
+                        Entregado: {formatDate(deliveryDate)}
+                    </p>
                 </div>
             </div>
             <div className="flex shrink-0 items-center gap-4">
@@ -688,6 +701,7 @@ export default function MessengerDashboard({
                 }
             );
         };
+        
 
         const unsubscribeAuth = onAuthStateChanged(auth, (user) => {
             const devCourierId =
@@ -796,10 +810,20 @@ export default function MessengerDashboard({
         () => sortAcceptedOrdersByAge(acceptedOrders, acceptedSortOrder),
         [acceptedOrders, acceptedSortOrder]
     );
+    
+    // ✅ MODIFICADO: Se agregó ordenamiento por fecha descendente
     const deliveredOrders = useMemo(
-        () => orders.filter((order) => order.deliveryStatus === 'delivered'),
+        () => orders
+            .filter((order) => order.deliveryStatus === 'delivered')
+            .sort((a, b) => {
+                const dateA = a.paymentCollectedAt || a.updatedAt || a.createdAt;
+                const dateB = b.paymentCollectedAt || b.updatedAt || b.createdAt;
+                if (!dateA || !dateB) return 0;
+                return dateB.getTime() - dateA.getTime();
+            }),
         [orders]
     );
+    
     const notDeliveredOrders = useMemo(
         () => orders.filter((order) => order.deliveryStatus === 'not_delivered'),
         [orders]
@@ -1176,7 +1200,7 @@ export default function MessengerDashboard({
                                     ))
                                 ) : (
                                     <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
-                                        No hay entregas completadas hoy.
+                                        No hay entregas completadas.
                                     </div>
                                 )}
                             </div>


### PR DESCRIPTION
## Description

Agrega historial de entregas para el mensajero con fecha y ordenamiento descendente.

## Cambios realizados

- Agrega función `formatDate` para mostrar fechas legibles
- Modifica `DeliveredOrderRow` para mostrar `orderCode` y fecha de entrega
- Ordena `deliveredOrders` por fecha descendente (más reciente primero)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

## Related Issues

Closes #117

## Checklist

- [x] Code works as expected
- [x] No new warnings or errors
- [x] Self-reviewed