### PR TITLE
fix: allow all umss.edu subdomains in UserEditModal email validation

### DIFF
--- a/src/features/admin/users/components/UserEditModal.tsx
+++ b/src/features/admin/users/components/UserEditModal.tsx
@@ -73,8 +73,8 @@ export default function UserEditModal({
       setError("Ingrese un correo electrónico válido.");
       return;
     }
-    if (email.trim().split('@')[1] !== 'est.umss.edu') {
-      setError("Solo se permite el dominio @est.umss.edu.");
+    if (!email.trim().split('@')[1]?.endsWith('umss.edu')) {
+      setError("Solo se permite el dominio @umss.edu.");
       return;
     }
     if (phone && (phone.length !== 8 || !/^[67]/.test(phone))) {


### PR DESCRIPTION
## Resumen

<!-- Explica en 1 o 2 frases qué cambia este PR y por qué. -->
se corrigio el bug del dominio

## URL de los cambios

<!-- Agrega la URL donde se puede revisar el cambio. -->

- URL: /admin → Usuarios → Editar usuario
- Ruta o pantalla afectada: src/features/admin/users/components/UserEditModal.tsx

## Cómo probar

<!-- Pasos concretos para validar el cambio. Debe ser fácil de seguir por quien revisa. -->

1. Ir al panel admin → sección Usuarios
2. Seleccionar un usuario cuyo email tenga dominio @docentes.umss.edu o @umss.edu
3. Intentar editar sus datos y guardar
4. Verificar que no aparece el error de dominio inválido

## Resultado esperado

<!-- ¿Qué debería ver o comprobar quien revisa al seguir los pasos? -->
El sistema acepta emails con cualquier subdominio de umss.edu y guarda los cambios correctamente.

## Evidencia visual

<!-- Adjunta capturas, video o GIF de la vista trabajada. Si no aplica, escribe "No aplica". -->

| Antes | Después |
| --- | --- |
| <!-- imagen --> | <!-- imagen --> |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

<!-- Ejemplo: Closes #123, Related #456. Si no aplica, escribe "No aplica". -->
Closes #460

## Checklist del autor

- [x] Probé el cambio localmente
- [ ] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [ ] Revisé mi propio código antes de pedir review

## Notas para quien revisa

<!-- Riesgos, decisiones técnicas, casos límite o algo específico que quieras que se revise. -->
El cambio es mínimo — una sola línea en la validación del email. Se reemplazó la comparación exacta por .endsWith('umss.edu') para cubrir todos los subdominios institucionales.