### PR TITLE
feat: agregar historial completo de pedido HU #178

### DIFF
--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -14,6 +14,7 @@ import {
   X,
   ChevronRight,
   ArrowLeft,
+  ClipboardList,
 } from 'lucide-react';
 import UserManagement from '../users/components/UserManagement.tsx';
 import CategoryList from '../categories/components/CategoryList.tsx';
@@ -25,10 +26,13 @@ import ConfigPanel from '../settings/components/ConfigPanel.tsx';
 // ── HU #161: Reportes de ventas ──
 import SalesReport from '../analytics/components/SalesReport.tsx';
 import AccessLogPanel from '../audit/components/AccessLogPanel.tsx';
+// ── HU #178: Historial de pedido ──
+import OrderHistory from '../pedidos/components/OrderHistory.tsx';
 
 type Section =
   | 'dashboard'
   | 'pedidos'
+  | 'historial'        // ── HU #178 ──
   | 'usuarios'
   | 'categorias'
   | 'ventas-diarias'
@@ -55,6 +59,7 @@ export default function AdminLayout() {
   const [activeSection, setActiveSection] = useState<Section>('dashboard');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [ventasOpen, setVentasOpen] = useState(true);
+  const [pedidosOpen, setPedidosOpen] = useState(true); // ── HU #178 ──
 
   const navSections: NavSection[] = [
     {
@@ -169,6 +174,64 @@ export default function AdminLayout() {
                 {section.title}
               </p>
               {section.items.map((item) => {
+
+                // ── Menú Pedidos con submenú Historial ── HU #178 ──
+                if (item.label === 'Pedidos') {
+                  return (
+                    <div key={item.label} className="mb-1">
+                      <button
+                        onClick={() => setPedidosOpen(!pedidosOpen)}
+                        className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px]
+                        text-white/50 hover:text-white/80 hover:bg-white/5 transition-colors"
+                      >
+                        <span>{item.icon}</span>
+                        <span className="flex-1 text-left">Pedidos</span>
+                        <ChevronRight
+                          size={12}
+                          className={`transition-transform ${pedidosOpen ? 'rotate-90' : ''}`}
+                        />
+                      </button>
+
+                      {pedidosOpen && (
+                        <div className="ml-7 mt-1 space-y-1">
+                          <button
+                            onClick={() => {
+                              setActiveSection('pedidos');
+                              setSidebarOpen(false);
+                            }}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-[12px]
+                            transition-colors ${
+                              activeSection === 'pedidos'
+                                ? 'bg-[#88b04b]/15 text-[#88b04b]'
+                                : 'text-white/40 hover:text-white/80 hover:bg-white/5'
+                            }`}
+                          >
+                            Recepción
+                          </button>
+
+                          {/* ── HU #178 ── */}
+                          <button
+                            onClick={() => {
+                              setActiveSection('historial');
+                              setSidebarOpen(false);
+                            }}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-[12px]
+                            transition-colors flex items-center gap-1.5 ${
+                              activeSection === 'historial'
+                                ? 'bg-[#88b04b]/15 text-[#88b04b]'
+                                : 'text-white/40 hover:text-white/80 hover:bg-white/5'
+                            }`}
+                          >
+                            <ClipboardList size={11} />
+                            Historial
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
+
+                // ── Menú Ventas con submenú existente ──
                 if (item.label === 'Ventas') {
                   return (
                     <div key={item.label} className="mb-1">
@@ -295,9 +358,16 @@ export default function AdminLayout() {
                   <ArrowLeft size={16} /> Dashboard
                 </button>
               )}
-              <h1 className="text-xl md:text-3xl font-bold text-white tracking-tight">
-                {currentPage.title}
-              </h1>
+              <div>
+                <h1 className="text-xl md:text-3xl font-bold text-white tracking-tight">
+                  {currentPage?.title}
+                </h1>
+                {currentPage?.subtitle && (
+                  <p className="hidden md:block text-xs text-white/30 mt-0.5">
+                    {currentPage.subtitle}
+                  </p>
+                )}
+              </div>
             </div>
           </div>
 
@@ -335,6 +405,8 @@ export default function AdminLayout() {
           {/*Reportes de ventas*/}
           {activeSection === 'reportes' && <SalesReport />}
           {activeSection === 'bitacora' && <AccessLogPanel />}
+          {/* ── HU #178 ── */}
+          {activeSection === 'historial' && <OrderHistory />}
         </main>
 
       </div>

--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -106,9 +106,9 @@ export default function AdminLayout() {
     {
       title: 'Analítica',
       items: [
-        { label: 'Ventas', icon: <BarChart2 size={15} />, section: 'ventas-diarias' },
-        { label: 'Inventario', icon: <Package size={15} />, section: null, disabled: true },
-        { label: 'Mensajeros', icon: <Bike size={15} />, section: null, disabled: true },
+        { label: 'Ventas',     icon: <BarChart2 size={15} />, section: 'ventas-diarias' },
+        { label: 'Inventario', icon: <Package size={15} />,   section: null, disabled: true },
+        { label: 'Mensajeros', icon: <Bike size={15} />,      section: null, disabled: true },
         {
           // ── HU #161: habilitado ──
           label: 'Reportes',
@@ -120,17 +120,16 @@ export default function AdminLayout() {
   ];
 
   const pageTitles: Record<string, { title: string; subtitle: string }> = {
-    dashboard: { title: 'Dashboard', subtitle: 'Panel de administración' },
-    pedidos: { title: 'Pedidos', subtitle: 'Validación de recepción por comprador' },
-    usuarios: { title: 'Gestión de usuarios', subtitle: 'Registra y administra usuarios' },
-    categorias: { title: 'Categorías', subtitle: 'Gestiona las categorías de productos' },
-    'ventas-diarias': { title: 'Ventas diarias', subtitle: 'Monitorea el rendimiento diario de ventas' },
-    'mas-vendidos': { title: 'Más vendidos', subtitle: 'Productos con más unidades vendidas' },
-    // ── HU #152 ──
-    parametros: { title: 'Parámetros del sistema', subtitle: 'Configura los parámetros globales del sistema' },
-    // ── HU #161 ──
-    reportes: { title: 'Reportes de ventas', subtitle: 'Genera reportes de ventas por rango de fechas' },
-    bitacora: { title: 'Bitacora', subtitle: 'registra actividad de inicio y cierre de sesion' },
+    dashboard:       { title: 'Dashboard',              subtitle: 'Panel de administración' },
+    pedidos:         { title: 'Pedidos',                subtitle: 'Validación de recepción por comprador' },
+    historial:       { title: 'Historial de pedido',    subtitle: 'Auditoría completa del pedido' },
+    usuarios:        { title: 'Gestión de usuarios',    subtitle: 'Registra y administra usuarios' },
+    categorias:      { title: 'Categorías',             subtitle: 'Gestiona las categorías de productos' },
+    'ventas-diarias':{ title: 'Ventas diarias',         subtitle: 'Monitorea el rendimiento diario de ventas' },
+    'mas-vendidos':  { title: 'Más vendidos',           subtitle: 'Productos con más unidades vendidas' },
+    parametros:      { title: 'Parámetros del sistema', subtitle: 'Configura los parámetros globales del sistema' },
+    reportes:        { title: 'Reportes de ventas',     subtitle: 'Genera reportes de ventas por rango de fechas' },
+    bitacora:        { title: 'Bitácora',               subtitle: 'Registra actividad de inicio y cierre de sesión' },
   };
 
   const currentPage = pageTitles[activeSection ?? 'dashboard'];
@@ -385,22 +384,11 @@ export default function AdminLayout() {
               Dashboard principal — Próximamente
             </div>
           )}
-          {activeSection === 'usuarios' && (
-            <UserManagement />
-          )}
-          {activeSection === 'pedidos' && (
-            <OrderReceptionPanel />
-          )}
-          {activeSection === 'categorias' && (
-            <CategoryList />
-          )}
-          {activeSection === 'ventas-diarias' && (
-            <DailySales />
-          )}
-          {activeSection === 'mas-vendidos' && (
-            <TopSellingProducts />
-          )}
-          {/*Parámetros del sistema*/}
+          {activeSection === 'usuarios' && <UserManagement />}
+          {activeSection === 'pedidos' && <OrderReceptionPanel />}
+          {activeSection === 'categorias' && <CategoryList />}
+          {activeSection === 'ventas-diarias' && <DailySales />}
+          {activeSection === 'mas-vendidos' && <TopSellingProducts />}
           {activeSection === 'parametros' && <ConfigPanel />}
           {/*Reportes de ventas*/}
           {activeSection === 'reportes' && <SalesReport />}

--- a/src/features/admin/pedidos/components/OrderHistory.tsx
+++ b/src/features/admin/pedidos/components/OrderHistory.tsx
@@ -5,10 +5,10 @@ import {
   Search, Loader2, AlertCircle, CheckCircle2,
   XCircle, AlertTriangle, Info, ChevronDown,
 } from 'lucide-react';
-import { useOrderHistory } from '../hooks/useAdminOrderHistory';
-import { useOrdersList } from '../hooks/useOrdersList';
-import type { OrderHistory as OrderHistoryType, OrderSummary, TimelineEvent } from '../types';
-
+import { useOrderHistory } from '@features/admin/pedidos/hooks/useAdminOrderHistory';
+import { useOrdersList } from '@features/admin/pedidos/hooks/useOrdersList';
+import type { OrderHistory as OrderHistoryType, TimelineEvent } from '@features/admin/pedidos/types';
+import { paymentMethodLabel } from '@/features/admin/pedidos/utils';
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function fmt(iso?: string | null): string {
@@ -47,18 +47,6 @@ function fmtFull(iso?: string | null): string {
 // Siempre 2 decimales: Bs. 19.40
 function formatMoney(n: number): string {
   return `Bs. ${n.toFixed(2)}`;
-}
-
-// Traduce métodos de pago internos a texto legible
-function paymentMethodLabel(method: string): string {
-  const map: Record<string, string> = {
-    cash_on_delivery: 'Contra entrega',
-    cash:             'Efectivo',
-    transfer:         'Transferencia',
-    qr:               'QR',
-    card:             'Tarjeta',
-  };
-  return map[method] ?? method;
 }
 
 // Divide el orderId en uuid + friendlyId

--- a/src/features/admin/pedidos/components/OrderHistory.tsx
+++ b/src/features/admin/pedidos/components/OrderHistory.tsx
@@ -1,9 +1,13 @@
 // src/features/admin/pedidos/components/OrderHistory.tsx
 
 import { useState } from 'react';
-import { Search, Loader2, AlertCircle, CheckCircle2, XCircle, AlertTriangle, Info } from 'lucide-react';
+import {
+  Search, Loader2, AlertCircle, CheckCircle2,
+  XCircle, AlertTriangle, Info, ChevronDown,
+} from 'lucide-react';
 import { useOrderHistory } from '../hooks/useAdminOrderHistory';
-import type { OrderHistory as OrderHistoryType, TimelineEvent } from '../types';
+import { useOrdersList } from '../hooks/useOrdersList';
+import type { OrderHistory as OrderHistoryType, OrderSummary, TimelineEvent } from '../types';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -15,32 +19,88 @@ function fmt(iso?: string | null): string {
   }) + ' ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
 }
 
-function fmtTime(iso?: string | null): string {
+function fmtDate(iso?: string | null): string {
   if (!iso) return '—';
-  return new Date(iso).toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+  return new Date(iso).toLocaleDateString('es-BO', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+  });
 }
 
+// Fecha + hora completa para la línea de tiempo
+function fmtDateTime(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-BO', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  }) + ' · ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+}
+
+// Fecha completa para campos como "Asignado"
+function fmtFull(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-BO', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+  }) + ' ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+}
+
+// Siempre 2 decimales: Bs. 19.40
 function formatMoney(n: number): string {
-  return `Bs. ${n.toFixed(0)}`;
+  return `Bs. ${n.toFixed(2)}`;
+}
+
+// Traduce métodos de pago internos a texto legible
+function paymentMethodLabel(method: string): string {
+  const map: Record<string, string> = {
+    cash_on_delivery: 'Contra entrega',
+    cash:             'Efectivo',
+    transfer:         'Transferencia',
+    qr:               'QR',
+    card:             'Tarjeta',
+  };
+  return map[method] ?? method;
+}
+
+// Divide el orderId en uuid + friendlyId
+function parseOrderId(orderId: string): { uuid: string; friendly: string } {
+  const idx = orderId.indexOf('_');
+  if (idx === -1) return { uuid: orderId, friendly: '' };
+  return { uuid: orderId.slice(0, idx), friendly: orderId.slice(idx + 1) };
 }
 
 function statusLabel(s: string): { text: string; color: string } {
   const map: Record<string, { text: string; color: string }> = {
-    pending:    { text: 'Pendiente',   color: 'text-yellow-600 bg-yellow-50' },
-    reserved:   { text: 'Reservado',   color: 'text-blue-600 bg-blue-50' },
-    confirmed:  { text: 'Confirmado',  color: 'text-blue-600 bg-blue-50' },
-    in_transit: { text: 'En camino',   color: 'text-orange-600 bg-orange-50' },
-    delivered:  { text: 'Entregado',   color: 'text-[#88b04b] bg-[#88b04b]/10' },
-    cancelled:  { text: 'Cancelado',   color: 'text-red-500 bg-red-50' },
-    verified:   { text: 'Verificado',  color: 'text-[#88b04b] bg-[#88b04b]/10' },
-    completed:  { text: 'Completado',  color: 'text-[#88b04b] bg-[#88b04b]/10' },
-    paid:       { text: 'Pagado',      color: 'text-[#88b04b] bg-[#88b04b]/10' },
-    unpaid:     { text: 'Sin pagar',   color: 'text-yellow-600 bg-yellow-50' },
-    assigned:   { text: 'Asignada',    color: 'text-blue-600 bg-blue-50' },
-    failed:     { text: 'Fallida',     color: 'text-red-500 bg-red-50' },
+    CREADO:      { text: 'Creado',       color: 'text-blue-600 bg-blue-50' },
+    RESERVADO:   { text: 'Reservado',    color: 'text-blue-600 bg-blue-50' },
+    CONFIRMADO:  { text: 'Confirmado',   color: 'text-blue-600 bg-blue-50' },
+    ACEPTADO:    { text: 'Aceptado',     color: 'text-blue-600 bg-blue-50' },
+    EN_CAMINO:   { text: 'En camino',    color: 'text-orange-600 bg-orange-50' },
+    ENTREGADO:   { text: 'Entregado',    color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    CANCELADO:   { text: 'Cancelado',    color: 'text-red-500 bg-red-50' },
+    VERIFICADO:  { text: 'Verificado',   color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    COMPLETADO:  { text: 'Completado',   color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    PENDIENTE:   { text: 'Pendiente',    color: 'text-yellow-600 bg-yellow-50' },
+    PAGADO:      { text: 'Pagado',       color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    pending:     { text: 'Pendiente',    color: 'text-yellow-600 bg-yellow-50' },
+    delivered:   { text: 'Entregado',    color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    cancelled:   { text: 'Cancelado',    color: 'text-red-500 bg-red-50' },
+    assigned:    { text: 'Asignada',     color: 'text-blue-600 bg-blue-50' },
+    accepted:    { text: 'Aceptada',     color: 'text-blue-600 bg-blue-50' },
+    in_transit:  { text: 'En camino',    color: 'text-orange-600 bg-orange-50' },
+    failed:      { text: 'Fallida',      color: 'text-red-500 bg-red-50' },
+    verified:    { text: 'Verificado',   color: 'text-[#88b04b] bg-[#88b04b]/10' },
   };
   return map[s] ?? { text: s, color: 'text-gray-500 bg-gray-100' };
 }
+
+const STATUS_FILTERS = [
+  { label: 'Todos',      value: null },
+  { label: 'Creados',    value: 'CREADO' },
+  { label: 'Reservados', value: 'RESERVADO' },
+  { label: 'En camino',  value: 'EN_CAMINO' },
+  { label: 'Entregados', value: 'ENTREGADO' },
+  { label: 'Cancelados', value: 'CANCELADO' },
+];
 
 // ── Subcomponentes ────────────────────────────────────────────────────────────
 
@@ -67,7 +127,7 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between py-1.5 border-b border-gray-50 last:border-0">
       <span className="text-sm text-gray-500">{label}</span>
-      <span className="text-sm font-medium text-gray-800 text-right max-w-[60%] truncate">{value}</span>
+      <span className="text-sm font-medium text-gray-800 text-right max-w-[60%]">{value}</span>
     </div>
   );
 }
@@ -76,22 +136,10 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
 
 function TimelineDot({ type }: { type?: TimelineEvent['type'] }) {
   const configs = {
-    success: {
-      bg: 'bg-[#88b04b]/15 border-[#88b04b]/40',
-      icon: <CheckCircle2 size={10} className="text-[#88b04b]" />,
-    },
-    error: {
-      bg: 'bg-red-50 border-red-200',
-      icon: <XCircle size={10} className="text-red-400" />,
-    },
-    warning: {
-      bg: 'bg-yellow-50 border-yellow-200',
-      icon: <AlertTriangle size={10} className="text-yellow-500" />,
-    },
-    info: {
-      bg: 'bg-blue-50 border-blue-200',
-      icon: <Info size={10} className="text-blue-400" />,
-    },
+    success: { bg: 'bg-[#88b04b]/15 border-[#88b04b]/40', icon: <CheckCircle2 size={10} className="text-[#88b04b]" /> },
+    error:   { bg: 'bg-red-50 border-red-200',             icon: <XCircle size={10} className="text-red-400" /> },
+    warning: { bg: 'bg-yellow-50 border-yellow-200',       icon: <AlertTriangle size={10} className="text-yellow-500" /> },
+    info:    { bg: 'bg-blue-50 border-blue-200',           icon: <Info size={10} className="text-blue-400" /> },
   };
   const cfg = configs[type ?? 'info'];
   return (
@@ -101,18 +149,133 @@ function TimelineDot({ type }: { type?: TimelineEvent['type'] }) {
   );
 }
 
+// ── Lista de pedidos ──────────────────────────────────────────────────────────
+
+function OrdersList({
+  onSelect,
+  selectedId,
+}: {
+  onSelect: (orderId: string) => void;
+  selectedId: string | null;
+}) {
+  const { orders, loading, loadingMore, error, hasMore, loadMore, filterByStatus, activeStatus } =
+    useOrdersList();
+
+  return (
+    <div className="bg-white border border-[rgba(136,176,75,0.15)] rounded-xl overflow-hidden">
+      <div className="px-5 py-4 border-b border-gray-50">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Pedidos recientes
+        </p>
+        <div className="flex gap-1.5 flex-wrap">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={String(f.value)}
+              onClick={() => filterByStatus(f.value)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                activeStatus === f.value
+                  ? 'bg-[#88b04b] text-white'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 size={20} className="animate-spin text-[#88b04b]" />
+        </div>
+      ) : error ? (
+        <div className="flex items-center gap-2 px-5 py-4 text-sm text-red-500">
+          <AlertCircle size={15} /> {error}
+        </div>
+      ) : orders.length === 0 ? (
+        <div className="px-5 py-10 text-center text-sm text-gray-300">No hay pedidos</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-[1fr_110px_90px_100px_90px] gap-3 px-5 py-2.5
+            bg-gray-50 border-b border-gray-100 text-[10px] font-semibold uppercase
+            tracking-wider text-gray-400">
+            <span>Cliente</span>
+            <span>ID amigable</span>
+            <span className="text-right">Total</span>
+            <span>Estado</span>
+            <span>Fecha</span>
+          </div>
+
+          {orders.map((order) => {
+            const isSelected = order.orderId === selectedId;
+            const st = statusLabel(order.status);
+            const { friendly } = parseOrderId(order.orderId);
+            return (
+              <button
+                key={order.orderId}
+                onClick={() => onSelect(order.orderId)}
+                className={`w-full grid grid-cols-[1fr_110px_90px_100px_90px] gap-3 px-5 py-3
+                  border-b border-gray-50 last:border-0 text-left transition-colors
+                  ${isSelected
+                    ? 'bg-[#88b04b]/8 border-l-2 border-l-[#88b04b]'
+                    : 'hover:bg-gray-50'
+                  }`}
+              >
+                <span className="text-sm text-gray-800 font-medium truncate">
+                  {order.customerName}
+                </span>
+                <span className="text-xs text-gray-500 font-mono truncate">
+                  {friendly || order.orderId.slice(0, 8) + '…'}
+                </span>
+                <span className="text-sm font-semibold text-gray-700 text-right">
+                  {formatMoney(order.total)}
+                </span>
+                <span><Badge text={st.text} color={st.color} /></span>
+                <span className="text-xs text-gray-400">{fmtDate(order.createdAt)}</span>
+              </button>
+            );
+          })}
+
+          {hasMore && (
+            <div className="px-5 py-3 border-t border-gray-50">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="flex items-center gap-2 text-sm text-[#88b04b] font-medium
+                  hover:text-[#7aa043] disabled:opacity-50 transition-colors"
+              >
+                {loadingMore ? <Loader2 size={14} className="animate-spin" /> : <ChevronDown size={14} />}
+                Cargar más
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── Componente principal ──────────────────────────────────────────────────────
 
 export default function OrderHistory() {
-  const { data, loading, error, search } = useOrderHistory();
+  const { data, loading: loadingDetail, error, search } = useOrderHistory();
   const [inputValue, setInputValue] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   function handleSearch() {
-    search(inputValue);
+    if (!inputValue.trim()) return;
+    setSelectedId(inputValue.trim());
+    search(inputValue.trim());
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') handleSearch();
+  }
+
+  function handleSelectOrder(orderId: string) {
+    setSelectedId(orderId);
+    setInputValue(orderId);
+    search(orderId);
   }
 
   return (
@@ -133,14 +296,12 @@ export default function OrderHistory() {
         />
         <button
           onClick={handleSearch}
-          disabled={loading || !inputValue.trim()}
+          disabled={loadingDetail || !inputValue.trim()}
           className="flex items-center gap-2 px-5 py-2.5 bg-[#88b04b] text-white text-sm
             font-semibold rounded-xl hover:bg-[#7aa043] disabled:opacity-50
             disabled:cursor-not-allowed transition-colors"
         >
-          {loading
-            ? <Loader2 size={15} className="animate-spin" />
-            : <Search size={15} />}
+          {loadingDetail ? <Loader2 size={15} className="animate-spin" /> : <Search size={15} />}
           Buscar
         </button>
       </div>
@@ -149,69 +310,57 @@ export default function OrderHistory() {
       {error && (
         <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-100
           rounded-xl text-sm text-red-600">
-          <AlertCircle size={16} className="flex-shrink-0" />
-          {error}
+          <AlertCircle size={16} className="flex-shrink-0" /> {error}
         </div>
       )}
 
-      {/* Resultados */}
-      {data && <HistoryResult data={data} />}
-
-      {/* Estado vacío */}
-      {!data && !loading && !error && (
-        <div className="flex flex-col items-center justify-center py-20 text-gray-300 select-none">
-          <Search size={40} strokeWidth={1.2} />
-          <p className="mt-3 text-sm">Ingresa un ID de pedido para consultar su historial</p>
+      {loadingDetail && (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 size={22} className="animate-spin text-[#88b04b]" />
         </div>
       )}
+
+      {data && !loadingDetail && <HistoryResult data={data} />}
+
+      <OrdersList onSelect={handleSelectOrder} selectedId={selectedId} />
     </div>
   );
 }
 
-// ── Vista con datos ───────────────────────────────────────────────────────────
+// ── Vista detalle ─────────────────────────────────────────────────────────────
 
 function HistoryResult({ data }: { data: OrderHistoryType }) {
+  const { uuid, friendly } = parseOrderId(data.orderId);
+
   return (
     <div className="space-y-4">
 
       {/* Fila 1: Datos generales + Productos */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-        <Card title={`Datos generales — #${data.orderId}`}>
-          {/* Usa customerName si existe, si no buyerName */}
+        {/* Datos generales — sin paymentStatus ni deliveryStatus */}
+        <Card title="Datos generales">
+          {/* ID dividido en uuid + friendly */}
+          <div className="py-1.5 border-b border-gray-50">
+            <p className="text-xs text-gray-400 mb-1">ID de pedido</p>
+            <p className="text-xs font-mono text-gray-400 break-all leading-relaxed">{uuid}</p>
+            {friendly && (
+              <p className="text-sm font-semibold text-gray-700 mt-0.5">{friendly}</p>
+            )}
+          </div>
           <Row label="Cliente"   value={data.customerName ?? data.buyerName} />
-          {data.customerPhone && <Row label="Teléfono"  value={data.customerPhone} />}
-          {data.address        && <Row label="Dirección" value={data.address} />}
+          {data.customerPhone && <Row label="Teléfono"   value={data.customerPhone} />}
+          {data.address        && <Row label="Dirección"  value={data.address} />}
           <Row label="Vendedor"  value={data.sellerName} />
-          <Row
-            label="Total"
-            value={<span className="text-[#88b04b] font-bold">{formatMoney(data.total)}</span>}
-          />
-          <Row
-            label="Estado pedido"
-            value={<Badge {...statusLabel(data.status)} />}
-          />
-          {data.paymentStatus && (
-            <Row
-              label="Estado pago"
-              value={<Badge {...statusLabel(data.paymentStatus)} />}
-            />
-          )}
-          {data.deliveryStatus && (
-            <Row
-              label="Estado entrega"
-              value={<Badge {...statusLabel(data.deliveryStatus)} />}
-            />
-          )}
-          <Row label="Fecha" value={fmt(data.createdAt)} />
+          <Row label="Total"     value={<span className="text-[#88b04b] font-bold">{formatMoney(data.total)}</span>} />
+          <Row label="Estado"    value={<Badge {...statusLabel(data.status)} />} />
+          <Row label="Fecha"     value={fmt(data.createdAt)} />
           {data.incidentReason && (
-            <Row
-              label="Incidente"
-              value={<span className="text-red-500 text-xs">{data.incidentReason}</span>}
-            />
+            <Row label="Incidente" value={<span className="text-red-500 text-xs">{data.incidentReason}</span>} />
           )}
         </Card>
 
+        {/* Productos con decimales */}
         <Card title="Productos">
           <div className="space-y-3">
             {data.items.map((item) => (
@@ -224,7 +373,7 @@ function HistoryResult({ data }: { data: OrderHistoryType }) {
                   <div>
                     <p className="text-sm font-medium text-gray-800">{item.productName}</p>
                     <p className="text-xs text-gray-400">
-                      x{item.quantity} · Bs. {item.unitPrice} c/u
+                      x{item.quantity} · Bs. {item.unitPrice.toFixed(2)} c/u
                     </p>
                   </div>
                 </div>
@@ -244,65 +393,46 @@ function HistoryResult({ data }: { data: OrderHistoryType }) {
       {/* Fila 2: Pago + Entrega */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 
+        {/* Pago — con estado propio y método traducido */}
         <Card title="Pago">
           {data.payment ? (
             <>
-              <Row label="Método"         value={data.payment.method} />
-              <Row
-                label="Monto"
-                value={
-                  <span className="text-[#88b04b] font-bold">
-                    {formatMoney(data.payment.amount)}
-                  </span>
-                }
-              />
-              <Row label="Estado"         value={<Badge {...statusLabel(data.payment.status)} />} />
-              {data.payment.registeredAt && (
-                <Row label="Registrado"   value={fmt(data.payment.registeredAt)} />
-              )}
-              {data.payment.verifiedAt && (
-                <Row label="Verificado"   value={fmt(data.payment.verifiedAt)} />
-              )}
-              {data.payment.verifiedBy && (
-                <Row label="Verificado por" value={data.payment.verifiedBy} />
-              )}
+              <Row label="Método"  value={paymentMethodLabel(data.payment.method)} />
+              <Row label="Monto"   value={<span className="text-[#88b04b] font-bold">{formatMoney(data.payment.amount)}</span>} />
+              <Row label="Estado"  value={<Badge {...statusLabel(data.payment.status)} />} />
+              {data.payment.registeredAt && <Row label="Registrado"     value={fmtFull(data.payment.registeredAt)} />}
+              {data.payment.verifiedAt   && <Row label="Verificado"     value={fmtFull(data.payment.verifiedAt)} />}
+              {data.payment.verifiedBy   && <Row label="Verificado por" value={data.payment.verifiedBy} />}
             </>
           ) : (
             <p className="text-sm text-gray-400 py-2">Sin información de pago</p>
           )}
         </Card>
 
+        {/* Entrega — "Asignado" con fecha completa, estado propio */}
         <Card title="Entrega">
           {data.delivery ? (
             <>
-              <Row label="Mensajero"      value={data.delivery.courierName ?? data.delivery.courierId} />
-              <Row
-                label="Estado"
-                value={<Badge {...statusLabel(data.delivery.status)} />}
-              />
+              <Row label="Mensajero"    value={data.delivery.courierName ?? data.delivery.courierId} />
+              <Row label="Estado"       value={<Badge {...statusLabel(data.delivery.status)} />} />
               {data.delivery.deliveryCode && (
-                <Row label="Código"       value={
+                <Row label="Código" value={
                   <span className="font-mono text-xs bg-gray-100 px-2 py-0.5 rounded">
                     {data.delivery.deliveryCode}
                   </span>
                 } />
               )}
-              {data.delivery.assignedAt  && <Row label="Asignado"   value={fmtTime(data.delivery.assignedAt)} />}
-              {data.delivery.pickedUpAt  && <Row label="Recogido"    value={fmtTime(data.delivery.pickedUpAt)} />}
-              {data.delivery.inTransitAt && <Row label="En tránsito" value={fmtTime(data.delivery.inTransitAt)} />}
-              {data.delivery.deliveredAt && <Row label="Entregado"   value={fmtTime(data.delivery.deliveredAt)} />}
-              {data.delivery.attemptNumber != null && (
-                <Row label="Intentos"    value={data.delivery.attemptNumber} />
-              )}
+              {/* Fecha completa, no solo hora */}
+              {data.delivery.assignedAt  && <Row label="Asignado"    value={fmtFull(data.delivery.assignedAt)} />}
+              {data.delivery.pickedUpAt  && <Row label="Recogido"     value={fmtFull(data.delivery.pickedUpAt)} />}
+              {data.delivery.inTransitAt && <Row label="En tránsito"  value={fmtFull(data.delivery.inTransitAt)} />}
+              {data.delivery.deliveredAt && <Row label="Entregado"    value={fmtFull(data.delivery.deliveredAt)} />}
+              {data.delivery.attemptNumber != null && <Row label="Intentos" value={data.delivery.attemptNumber} />}
               {data.delivery.incidentReason && (
-                <Row label="Incidente"   value={
-                  <span className="text-red-500 text-xs">{data.delivery.incidentReason}</span>
-                } />
+                <Row label="Incidente" value={<span className="text-red-500 text-xs">{data.delivery.incidentReason}</span>} />
               )}
               {data.delivery.customerConfirmed && (
-                <Row label="Confirmado cliente" value={
-                  <Badge text="Sí" color="text-[#88b04b] bg-[#88b04b]/10" />
-                } />
+                <Row label="Confirmado cliente" value={<Badge text="Sí" color="text-[#88b04b] bg-[#88b04b]/10" />} />
               )}
             </>
           ) : (
@@ -311,7 +441,7 @@ function HistoryResult({ data }: { data: OrderHistoryType }) {
         </Card>
       </div>
 
-      {/* Línea de tiempo */}
+      {/* Línea de tiempo — fecha + hora completa */}
       <Card title="Línea de tiempo">
         {data.timeline.length === 0 ? (
           <p className="text-sm text-gray-400 py-2">Sin eventos registrados</p>
@@ -326,9 +456,10 @@ function HistoryResult({ data }: { data: OrderHistoryType }) {
                 <div className="pb-5">
                   <p className="text-sm font-semibold text-gray-800">{event.label}</p>
                   {event.detail && (
-                    <p className="text-xs text-gray-400 mt-0.5">{event.detail}</p>
+                    <p className="text-xs text-gray-500 mt-0.5">{event.detail}</p>
                   )}
-                  <p className="text-xs text-gray-300 mt-0.5">{fmtTime(event.timestamp)}</p>
+                  {/* Fecha + hora completa */}
+                  <p className="text-xs text-gray-500 mt-0.5">{fmtDateTime(event.timestamp)}</p>
                 </div>
               </div>
             ))}

--- a/src/features/admin/pedidos/components/OrderHistory.tsx
+++ b/src/features/admin/pedidos/components/OrderHistory.tsx
@@ -1,0 +1,341 @@
+// src/features/admin/pedidos/components/OrderHistory.tsx
+
+import { useState } from 'react';
+import { Search, Loader2, AlertCircle, CheckCircle2, XCircle, AlertTriangle, Info } from 'lucide-react';
+import { useOrderHistory } from '../hooks/useAdminOrderHistory';
+import type { OrderHistory as OrderHistoryType, TimelineEvent } from '../types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmt(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-BO', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+  }) + ' ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+}
+
+function fmtTime(iso?: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatMoney(n: number): string {
+  return `Bs. ${n.toFixed(0)}`;
+}
+
+function statusLabel(s: string): { text: string; color: string } {
+  const map: Record<string, { text: string; color: string }> = {
+    pending:    { text: 'Pendiente',   color: 'text-yellow-600 bg-yellow-50' },
+    reserved:   { text: 'Reservado',   color: 'text-blue-600 bg-blue-50' },
+    confirmed:  { text: 'Confirmado',  color: 'text-blue-600 bg-blue-50' },
+    in_transit: { text: 'En camino',   color: 'text-orange-600 bg-orange-50' },
+    delivered:  { text: 'Entregado',   color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    cancelled:  { text: 'Cancelado',   color: 'text-red-500 bg-red-50' },
+    verified:   { text: 'Verificado',  color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    completed:  { text: 'Completado',  color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    paid:       { text: 'Pagado',      color: 'text-[#88b04b] bg-[#88b04b]/10' },
+    unpaid:     { text: 'Sin pagar',   color: 'text-yellow-600 bg-yellow-50' },
+    assigned:   { text: 'Asignada',    color: 'text-blue-600 bg-blue-50' },
+    failed:     { text: 'Fallida',     color: 'text-red-500 bg-red-50' },
+  };
+  return map[s] ?? { text: s, color: 'text-gray-500 bg-gray-100' };
+}
+
+// ── Subcomponentes ────────────────────────────────────────────────────────────
+
+function Badge({ text, color }: { text: string; color: string }) {
+  return (
+    <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${color}`}>
+      {text}
+    </span>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white border border-[rgba(136,176,75,0.15)] rounded-xl p-5">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400 mb-4">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between py-1.5 border-b border-gray-50 last:border-0">
+      <span className="text-sm text-gray-500">{label}</span>
+      <span className="text-sm font-medium text-gray-800 text-right max-w-[60%] truncate">{value}</span>
+    </div>
+  );
+}
+
+// ── Timeline dot por tipo ─────────────────────────────────────────────────────
+
+function TimelineDot({ type }: { type?: TimelineEvent['type'] }) {
+  const configs = {
+    success: {
+      bg: 'bg-[#88b04b]/15 border-[#88b04b]/40',
+      icon: <CheckCircle2 size={10} className="text-[#88b04b]" />,
+    },
+    error: {
+      bg: 'bg-red-50 border-red-200',
+      icon: <XCircle size={10} className="text-red-400" />,
+    },
+    warning: {
+      bg: 'bg-yellow-50 border-yellow-200',
+      icon: <AlertTriangle size={10} className="text-yellow-500" />,
+    },
+    info: {
+      bg: 'bg-blue-50 border-blue-200',
+      icon: <Info size={10} className="text-blue-400" />,
+    },
+  };
+  const cfg = configs[type ?? 'info'];
+  return (
+    <div className={`flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center mt-0.5 ${cfg.bg}`}>
+      {cfg.icon}
+    </div>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────────────
+
+export default function OrderHistory() {
+  const { data, loading, error, search } = useOrderHistory();
+  const [inputValue, setInputValue] = useState('');
+
+  function handleSearch() {
+    search(inputValue);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') handleSearch();
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+
+      {/* Buscador */}
+      <div className="flex gap-3">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Buscar por ID de pedido..."
+          className="flex-1 px-4 py-2.5 rounded-xl border border-[rgba(136,176,75,0.25)]
+            bg-white text-sm text-gray-800 placeholder-gray-400
+            focus:outline-none focus:ring-2 focus:ring-[#88b04b]/30 focus:border-[#88b04b]
+            transition-all"
+        />
+        <button
+          onClick={handleSearch}
+          disabled={loading || !inputValue.trim()}
+          className="flex items-center gap-2 px-5 py-2.5 bg-[#88b04b] text-white text-sm
+            font-semibold rounded-xl hover:bg-[#7aa043] disabled:opacity-50
+            disabled:cursor-not-allowed transition-colors"
+        >
+          {loading
+            ? <Loader2 size={15} className="animate-spin" />
+            : <Search size={15} />}
+          Buscar
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-100
+          rounded-xl text-sm text-red-600">
+          <AlertCircle size={16} className="flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {/* Resultados */}
+      {data && <HistoryResult data={data} />}
+
+      {/* Estado vacío */}
+      {!data && !loading && !error && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-300 select-none">
+          <Search size={40} strokeWidth={1.2} />
+          <p className="mt-3 text-sm">Ingresa un ID de pedido para consultar su historial</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Vista con datos ───────────────────────────────────────────────────────────
+
+function HistoryResult({ data }: { data: OrderHistoryType }) {
+  return (
+    <div className="space-y-4">
+
+      {/* Fila 1: Datos generales + Productos */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+        <Card title={`Datos generales — #${data.orderId}`}>
+          {/* Usa customerName si existe, si no buyerName */}
+          <Row label="Cliente"   value={data.customerName ?? data.buyerName} />
+          {data.customerPhone && <Row label="Teléfono"  value={data.customerPhone} />}
+          {data.address        && <Row label="Dirección" value={data.address} />}
+          <Row label="Vendedor"  value={data.sellerName} />
+          <Row
+            label="Total"
+            value={<span className="text-[#88b04b] font-bold">{formatMoney(data.total)}</span>}
+          />
+          <Row
+            label="Estado pedido"
+            value={<Badge {...statusLabel(data.status)} />}
+          />
+          {data.paymentStatus && (
+            <Row
+              label="Estado pago"
+              value={<Badge {...statusLabel(data.paymentStatus)} />}
+            />
+          )}
+          {data.deliveryStatus && (
+            <Row
+              label="Estado entrega"
+              value={<Badge {...statusLabel(data.deliveryStatus)} />}
+            />
+          )}
+          <Row label="Fecha" value={fmt(data.createdAt)} />
+          {data.incidentReason && (
+            <Row
+              label="Incidente"
+              value={<span className="text-red-500 text-xs">{data.incidentReason}</span>}
+            />
+          )}
+        </Card>
+
+        <Card title="Productos">
+          <div className="space-y-3">
+            {data.items.map((item) => (
+              <div key={item.itemId} className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-[#88b04b]/10 flex items-center
+                    justify-center text-[#88b04b] text-xs font-bold flex-shrink-0">
+                    {item.productName.charAt(0)}
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-gray-800">{item.productName}</p>
+                    <p className="text-xs text-gray-400">
+                      x{item.quantity} · Bs. {item.unitPrice} c/u
+                    </p>
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-gray-700">
+                  {formatMoney(item.subtotal)}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 pt-3 border-t border-gray-100 flex justify-between">
+            <span className="text-sm text-gray-500">Total</span>
+            <span className="text-sm font-bold text-[#88b04b]">{formatMoney(data.total)}</span>
+          </div>
+        </Card>
+      </div>
+
+      {/* Fila 2: Pago + Entrega */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+        <Card title="Pago">
+          {data.payment ? (
+            <>
+              <Row label="Método"         value={data.payment.method} />
+              <Row
+                label="Monto"
+                value={
+                  <span className="text-[#88b04b] font-bold">
+                    {formatMoney(data.payment.amount)}
+                  </span>
+                }
+              />
+              <Row label="Estado"         value={<Badge {...statusLabel(data.payment.status)} />} />
+              {data.payment.registeredAt && (
+                <Row label="Registrado"   value={fmt(data.payment.registeredAt)} />
+              )}
+              {data.payment.verifiedAt && (
+                <Row label="Verificado"   value={fmt(data.payment.verifiedAt)} />
+              )}
+              {data.payment.verifiedBy && (
+                <Row label="Verificado por" value={data.payment.verifiedBy} />
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-400 py-2">Sin información de pago</p>
+          )}
+        </Card>
+
+        <Card title="Entrega">
+          {data.delivery ? (
+            <>
+              <Row label="Mensajero"      value={data.delivery.courierName ?? data.delivery.courierId} />
+              <Row
+                label="Estado"
+                value={<Badge {...statusLabel(data.delivery.status)} />}
+              />
+              {data.delivery.deliveryCode && (
+                <Row label="Código"       value={
+                  <span className="font-mono text-xs bg-gray-100 px-2 py-0.5 rounded">
+                    {data.delivery.deliveryCode}
+                  </span>
+                } />
+              )}
+              {data.delivery.assignedAt  && <Row label="Asignado"   value={fmtTime(data.delivery.assignedAt)} />}
+              {data.delivery.pickedUpAt  && <Row label="Recogido"    value={fmtTime(data.delivery.pickedUpAt)} />}
+              {data.delivery.inTransitAt && <Row label="En tránsito" value={fmtTime(data.delivery.inTransitAt)} />}
+              {data.delivery.deliveredAt && <Row label="Entregado"   value={fmtTime(data.delivery.deliveredAt)} />}
+              {data.delivery.attemptNumber != null && (
+                <Row label="Intentos"    value={data.delivery.attemptNumber} />
+              )}
+              {data.delivery.incidentReason && (
+                <Row label="Incidente"   value={
+                  <span className="text-red-500 text-xs">{data.delivery.incidentReason}</span>
+                } />
+              )}
+              {data.delivery.customerConfirmed && (
+                <Row label="Confirmado cliente" value={
+                  <Badge text="Sí" color="text-[#88b04b] bg-[#88b04b]/10" />
+                } />
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-400 py-2">Sin información de entrega</p>
+          )}
+        </Card>
+      </div>
+
+      {/* Línea de tiempo */}
+      <Card title="Línea de tiempo">
+        {data.timeline.length === 0 ? (
+          <p className="text-sm text-gray-400 py-2">Sin eventos registrados</p>
+        ) : (
+          <div className="space-y-0">
+            {data.timeline.map((event, i) => (
+              <div key={i} className="flex gap-4 relative">
+                {i < data.timeline.length - 1 && (
+                  <div className="absolute left-[11px] top-6 bottom-0 w-[1.5px] bg-gray-100" />
+                )}
+                <TimelineDot type={event.type} />
+                <div className="pb-5">
+                  <p className="text-sm font-semibold text-gray-800">{event.label}</p>
+                  {event.detail && (
+                    <p className="text-xs text-gray-400 mt-0.5">{event.detail}</p>
+                  )}
+                  <p className="text-xs text-gray-300 mt-0.5">{fmtTime(event.timestamp)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+    </div>
+  );
+}

--- a/src/features/admin/pedidos/components/OrderHistory.tsx
+++ b/src/features/admin/pedidos/components/OrderHistory.tsx
@@ -184,45 +184,49 @@ function OrdersList({
         <div className="px-5 py-10 text-center text-sm text-gray-300">No hay pedidos</div>
       ) : (
         <>
-          <div className="grid grid-cols-[1fr_110px_90px_100px_90px] gap-3 px-5 py-2.5
-            bg-gray-50 border-b border-gray-100 text-[10px] font-semibold uppercase
-            tracking-wider text-gray-400">
-            <span>Cliente</span>
-            <span>ID amigable</span>
-            <span className="text-right">Total</span>
-            <span>Estado</span>
-            <span>Fecha</span>
-          </div>
+          <div className="overflow-x-auto">
+            <div className="min-w-[640px]">
+              <div className="grid grid-cols-5 gap-3 px-5 py-2.5
+                bg-gray-50 border-b border-gray-100 text-[10px] font-semibold uppercase
+                tracking-wider text-gray-400">
+                <span>Cliente</span>
+                <span>ID amigable</span>
+                <span>Total</span>
+                <span>Estado</span>
+                <span>Fecha</span>
+              </div>
 
-          {orders.map((order) => {
-            const isSelected = order.orderId === selectedId;
-            const st = statusLabel(order.status);
-            const { friendly } = parseOrderId(order.orderId);
-            return (
-              <button
-                key={order.orderId}
-                onClick={() => onSelect(order.orderId)}
-                className={`w-full grid grid-cols-[1fr_110px_90px_100px_90px] gap-3 px-5 py-3
-                  border-b border-gray-50 last:border-0 text-left transition-colors
-                  ${isSelected
-                    ? 'bg-[#88b04b]/8 border-l-2 border-l-[#88b04b]'
-                    : 'hover:bg-gray-50'
-                  }`}
-              >
-                <span className="text-sm text-gray-800 font-medium truncate">
-                  {order.customerName}
-                </span>
-                <span className="text-xs text-gray-500 font-mono truncate">
-                  {friendly || order.orderId.slice(0, 8) + '…'}
-                </span>
-                <span className="text-sm font-semibold text-gray-700 text-right">
+              {orders.map((order) => {
+                const isSelected = order.orderId === selectedId;
+                const st = statusLabel(order.status);
+                const { friendly } = parseOrderId(order.orderId);
+                return (
+                  <button
+                    key={order.orderId}
+                    onClick={() => onSelect(order.orderId)}
+                    className={`w-full grid grid-cols-5 gap-3 px-5 py-3
+                      border-b border-gray-50 last:border-0 text-left transition-colors
+                      ${isSelected
+                        ? 'bg-[#88b04b]/8 border-l-2 border-l-[#88b04b]'
+                        : 'hover:bg-gray-50'
+                      }`}
+                  >
+                    <span className="text-sm text-gray-800 font-medium truncate">
+                      {order.customerName}
+                    </span>
+                    <span className="text-xs text-gray-500 font-mono truncate">
+                      {friendly || order.orderId.slice(0, 8) + '…'}
+                    </span>
+<span className="text-sm font-semibold text-gray-700">
                   {formatMoney(order.total)}
-                </span>
-                <span><Badge text={st.text} color={st.color} /></span>
-                <span className="text-xs text-gray-400">{fmtDate(order.createdAt)}</span>
-              </button>
-            );
-          })}
+                    </span>
+                    <span><Badge text={st.text} color={st.color} /></span>
+                    <span className="text-xs text-gray-400">{fmtDate(order.createdAt)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
 
           {hasMore && (
             <div className="px-5 py-3 border-t border-gray-50">

--- a/src/features/admin/pedidos/hooks/useAdminOrderHistory.ts
+++ b/src/features/admin/pedidos/hooks/useAdminOrderHistory.ts
@@ -1,0 +1,41 @@
+// src/features/admin/pedidos/hooks/useOrderHistory.ts
+
+import { useState } from 'react';
+import { getOrderHistory } from '../services/orderHistoryService';
+import type { OrderHistory } from '../types';
+
+interface UseOrderHistoryResult {
+  data: OrderHistory | null;
+  loading: boolean;
+  error: string | null;
+  search: (orderId: string) => Promise<void>;
+  reset: () => void;
+}
+
+export function useOrderHistory(): UseOrderHistoryResult {
+  const [data, setData] = useState<OrderHistory | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function search(orderId: string) {
+    if (!orderId.trim()) return;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    try {
+      const result = await getOrderHistory(orderId.trim());
+      setData(result);
+    } catch (err: any) {
+      setError(err.message ?? 'Error al consultar el pedido');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function reset() {
+    setData(null);
+    setError(null);
+  }
+
+  return { data, loading, error, search, reset };
+}

--- a/src/features/admin/pedidos/hooks/useOrdersList.ts
+++ b/src/features/admin/pedidos/hooks/useOrdersList.ts
@@ -1,0 +1,84 @@
+// src/features/admin/pedidos/hooks/useOrdersList.ts
+
+import { useState, useEffect, useCallback } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../../../../lib/firebase';
+import type { OrderSummary } from '../types';
+
+async function getAuthorizationHeader(): Promise<Record<string, string>> {
+  return new Promise((resolve) => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      unsub();
+      if (user) {
+        const token = await user.getIdToken();
+        resolve({ Authorization: `Bearer ${token}` });
+      } else {
+        resolve({});
+      }
+    });
+  });
+}
+
+interface UseOrdersListResult {
+  orders: OrderSummary[];
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  filterByStatus: (status: string | null) => void;
+  activeStatus: string | null;
+}
+
+export function useOrdersList(): UseOrdersListResult {
+  const [orders, setOrders]           = useState<OrderSummary[]>([]);
+  const [loading, setLoading]         = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError]             = useState<string | null>(null);
+  const [hasMore, setHasMore]         = useState(false);
+  const [cursor, setCursor]           = useState<string | null>(null);
+  const [activeStatus, setActiveStatus] = useState<string | null>(null);
+
+  const fetchOrders = useCallback(async (
+    status: string | null,
+    cursorId: string | null,
+    append: boolean
+  ) => {
+    try {
+      const headers = await getAuthorizationHeader();
+      const params = new URLSearchParams({ limit: '20' });
+      if (status)   params.set('status', status);
+      if (cursorId) params.set('cursor', cursorId);
+
+      const res = await fetch(`/api/admin/orders_list?${params}`, { headers });
+      if (!res.ok) throw new Error(`Error ${res.status}`);
+
+      const data = await res.json();
+      setOrders((prev) => append ? [...prev, ...data.orders] : data.orders);
+      setHasMore(data.hasMore);
+      setCursor(data.nextCursor);
+    } catch (err: any) {
+      setError(err.message ?? 'Error al cargar pedidos');
+    }
+  }, []);
+
+  // Carga inicial
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchOrders(activeStatus, null, false).finally(() => setLoading(false));
+  }, [activeStatus, fetchOrders]);
+
+  function loadMore() {
+    if (!hasMore || loadingMore || !cursor) return;
+    setLoadingMore(true);
+    fetchOrders(activeStatus, cursor, true).finally(() => setLoadingMore(false));
+  }
+
+  function filterByStatus(status: string | null) {
+    setCursor(null);
+    setActiveStatus(status);
+  }
+
+  return { orders, loading, loadingMore, error, hasMore, loadMore, filterByStatus, activeStatus };
+}

--- a/src/features/admin/pedidos/services/orderHistoryService.ts
+++ b/src/features/admin/pedidos/services/orderHistoryService.ts
@@ -1,0 +1,35 @@
+// src/features/admin/pedidos/services/orderHistoryService.ts
+
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../../../../lib/firebase';
+import type { OrderHistory } from '../types';
+
+async function getAuthorizationHeader(): Promise<Record<string, string>> {
+  return new Promise((resolve) => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      unsub();
+      if (user) {
+        const token = await user.getIdToken();
+        resolve({ Authorization: `Bearer ${token}` });
+      } else {
+        resolve({});
+      }
+    });
+  });
+}
+
+export async function getOrderHistory(orderId: string): Promise<OrderHistory> {
+  const headers = await getAuthorizationHeader();
+
+  const response = await fetch(
+    `/api/admin/order_history?orderId=${encodeURIComponent(orderId)}`,
+    { headers }
+  );
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.error ?? `Error ${response.status}`);
+  }
+
+  return response.json() as Promise<OrderHistory>;
+}

--- a/src/features/admin/pedidos/types.ts
+++ b/src/features/admin/pedidos/types.ts
@@ -1,0 +1,72 @@
+// src/features/admin/pedidos/types.ts
+
+export interface OrderItem {
+  itemId: string;
+  productId: string;
+  productName: string;
+  unitPrice: number;
+  quantity: number;
+  subtotal: number;
+}
+
+export interface OrderPayment {
+  paymentId: string;
+  orderId: string;
+  amount: number;
+  method: string;
+  status: string;
+  registeredBy: string;
+  verifiedBy?: string;
+  registeredAt?: string;
+  verifiedAt?: string;
+}
+
+export interface OrderDelivery {
+  deliveryId: string;
+  orderId: string;
+  courierId: string;
+  courierName?: string;
+  status: string;
+  deliveryCode?: string;
+  attemptNumber?: number;
+  incidentReason?: string;
+  evidenceUrl?: string;
+  failureReason?: string;
+  amountCollected: number;
+  customerConfirmed?: boolean;
+  customerConfirmedAt?: string;
+  assignedAt?: string;
+  pickedUpAt?: string;
+  inTransitAt?: string;
+  deliveredAt?: string;
+  failedAt?: string;
+  reprogrammedAt?: string;
+}
+
+export interface TimelineEvent {
+  label: string;
+  detail?: string;
+  timestamp: string;
+  type?: 'success' | 'warning' | 'error' | 'info';
+}
+
+export interface OrderHistory {
+  orderId: string;
+  buyerName: string;
+  sellerName: string;
+  customerName?: string;
+  customerPhone?: string;
+  address?: string;
+  total: number;
+  status: string;
+  paymentStatus?: string;
+  deliveryStatus?: string;
+  createdAt: string;
+  confirmedAt?: string;
+  cancelledAt?: string;
+  incidentReason?: string;
+  items: OrderItem[];
+  payment?: OrderPayment;
+  delivery?: OrderDelivery;
+  timeline: TimelineEvent[];
+}

--- a/src/features/admin/pedidos/types.ts
+++ b/src/features/admin/pedidos/types.ts
@@ -1,5 +1,3 @@
-// src/features/admin/pedidos/types.ts
-
 export interface OrderItem {
   itemId: string;
   productId: string;
@@ -16,31 +14,31 @@ export interface OrderPayment {
   method: string;
   status: string;
   registeredBy: string;
-  verifiedBy?: string;
-  registeredAt?: string;
-  verifiedAt?: string;
+  verifiedBy?: string | null;
+  registeredAt?: string | null;
+  verifiedAt?: string | null;
 }
 
 export interface OrderDelivery {
   deliveryId: string;
   orderId: string;
   courierId: string;
-  courierName?: string;
+  courierName?: string | null;
   status: string;
-  deliveryCode?: string;
-  attemptNumber?: number;
-  incidentReason?: string;
-  evidenceUrl?: string;
-  failureReason?: string;
+  deliveryCode?: string | null;
+  attemptNumber?: number | null;
+  incidentReason?: string | null;
+  evidenceUrl?: string | null;
+  failureReason?: string | null;
   amountCollected: number;
   customerConfirmed?: boolean;
-  customerConfirmedAt?: string;
-  assignedAt?: string;
-  pickedUpAt?: string;
-  inTransitAt?: string;
-  deliveredAt?: string;
-  failedAt?: string;
-  reprogrammedAt?: string;
+  customerConfirmedAt?: string | null;
+  assignedAt?: string | null;
+  pickedUpAt?: string | null;
+  inTransitAt?: string | null;
+  deliveredAt?: string | null;
+  failedAt?: string | null;
+  reprogrammedAt?: string | null;
 }
 
 export interface TimelineEvent {
@@ -54,19 +52,37 @@ export interface OrderHistory {
   orderId: string;
   buyerName: string;
   sellerName: string;
-  customerName?: string;
-  customerPhone?: string;
-  address?: string;
+  customerName?: string | null;
+  customerPhone?: string | null;
+  address?: string | null;
   total: number;
   status: string;
-  paymentStatus?: string;
-  deliveryStatus?: string;
+  paymentStatus?: string | null;
+  deliveryStatus?: string | null;
   createdAt: string;
-  confirmedAt?: string;
-  cancelledAt?: string;
-  incidentReason?: string;
+  confirmedAt?: string | null;
+  cancelledAt?: string | null;
+  incidentReason?: string | null;
   items: OrderItem[];
-  payment?: OrderPayment;
-  delivery?: OrderDelivery;
+  payment?: OrderPayment | null;
+  delivery?: OrderDelivery | null;
   timeline: TimelineEvent[];
+}
+
+export interface OrderSummary {
+  orderId: string;
+  customerName: string;
+  total: number;
+  status: string;
+  paymentStatus?: string | null;
+  deliveryStatus?: string | null;
+  createdAt: string;
+  cancelledAt?: string | null;
+  incidentReason?: string | null;
+}
+
+export interface OrdersListResponse {
+  orders: OrderSummary[];
+  hasMore: boolean;
+  nextCursor: string | null;
 }

--- a/src/features/admin/pedidos/utils.ts
+++ b/src/features/admin/pedidos/utils.ts
@@ -1,0 +1,11 @@
+// Traduce métodos de pago internos a texto legible
+export function paymentMethodLabel(method: string): string {
+  const map: Record<string, string> = {
+    cash_on_delivery: 'Contra entrega',
+    cash:             'Efectivo',
+    transfer:         'Transferencia',
+    qr:               'QR',
+    card:             'Tarjeta',
+  };
+  return map[method] ?? method;
+}

--- a/src/pages/api/admin/order_history.ts
+++ b/src/pages/api/admin/order_history.ts
@@ -139,7 +139,7 @@ export const GET: APIRoute = async ({ request }) => {
     if (!payment) {
       const payQuery = await adminDb
         .collection('payments')
-        .where('orderId', '==', orderId)
+        .where('orderId', '==', order.orderId)
         .limit(1)
         .get();
       if (!payQuery.empty) {
@@ -196,7 +196,7 @@ export const GET: APIRoute = async ({ request }) => {
     if (!delivery) {
       const delQuery = await adminDb
         .collection('deliveries')
-        .where('orderId', '==', orderId)
+        .where('orderId', '==', order.orderId)
         .limit(1)
         .get();
       if (!delQuery.empty) delivery = await resolveDelivery(delQuery.docs[0]);

--- a/src/pages/api/admin/order_history.ts
+++ b/src/pages/api/admin/order_history.ts
@@ -49,15 +49,49 @@ export const GET: APIRoute = async ({ request }) => {
       return new Response(JSON.stringify({ error: 'orderId requerido' }), { status: 400, headers });
     }
 
-    // ── Buscar por campo orderId (no por ID de documento) ─────────────────
-    const orderQuery = await adminDb
+    // Buscar primero por orderId completo
+    let orderQuery = await adminDb
       .collection('orders')
       .where('orderId', '==', orderId)
       .limit(1)
       .get();
 
+    // Si no encuentra, buscar por ID amigable (parte después del _)
+    // Firestore no soporta búsqueda por sufijo, así que se pagina y filtra en servidor
     if (orderQuery.empty) {
-      return new Response(JSON.stringify({ error: 'Pedido no encontrado' }), { status: 404, headers });
+      const lowerInput = orderId.toLowerCase();
+      let found: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+      let pageCursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+
+      outer: while (true) {
+        let pageQuery: FirebaseFirestore.Query = adminDb
+          .collection('orders')
+          .orderBy('createdAt', 'desc')
+          .limit(200);
+
+        if (pageCursor) pageQuery = pageQuery.startAfter(pageCursor);
+
+        const pageSnap = await pageQuery.get();
+        if (pageSnap.empty) break;
+
+        for (const doc of pageSnap.docs) {
+          const id: string = doc.data().orderId ?? '';
+          const idx = id.indexOf('_');
+          if (idx !== -1 && id.slice(idx + 1).toLowerCase() === lowerInput) {
+            found = doc;
+            break outer;
+          }
+        }
+
+        if (pageSnap.docs.length < 200) break; // última página
+        pageCursor = pageSnap.docs[pageSnap.docs.length - 1];
+      }
+
+      if (!found) {
+        return new Response(JSON.stringify({ error: 'Pedido no encontrado' }), { status: 404, headers });
+      }
+
+      orderQuery = { empty: false, docs: [found] } as any;
     }
 
     const orderDoc = orderQuery.docs[0];

--- a/src/pages/api/admin/order_history.ts
+++ b/src/pages/api/admin/order_history.ts
@@ -1,7 +1,6 @@
-// src/pages/api/admin/order_history.ts
-
 import type { APIRoute } from 'astro';
-import { adminDb, adminAuth } from '../../../lib/firebase-admin';
+import { adminDb, adminAuth } from '@/lib/firebase-admin';
+import { paymentMethodLabel } from '@/features/admin/pedidos/utils';
 
 const devBypassEnabled =
   import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
@@ -217,7 +216,7 @@ export const GET: APIRoute = async ({ request }) => {
 
     push('Pedido creado',        toISO(order.createdAt),   `Comprador: ${buyerName}`,            'info');
     push('Pedido confirmado',    toISO(order.confirmedAt), `Vendedor: ${sellerName}`,             'success');
-    push('Pago registrado',      payment?.registeredAt ?? null, payment ? `Método: ${payment.method}` : undefined, 'info');
+    push('Pago registrado',      payment?.registeredAt ?? null, payment ? `Método: ${paymentMethodLabel(payment.method)}` : undefined, 'info');
     push('Asignado a mensajero', delivery?.assignedAt  ?? null, delivery ? `Mensajero: ${delivery.courierName}` : undefined, 'info');
     push('Pedido recogido',      delivery?.pickedUpAt  ?? null, 'Mensajero recogió el pedido',    'info');
     push('En camino',            delivery?.inTransitAt ?? null, 'Mensajero en tránsito',          'info');

--- a/src/pages/api/admin/order_history.ts
+++ b/src/pages/api/admin/order_history.ts
@@ -1,0 +1,233 @@
+// src/pages/api/admin/order_history.ts
+
+import type { APIRoute } from 'astro';
+import { adminDb, adminAuth } from '../../../lib/firebase-admin';
+
+const devBypassEnabled =
+  import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
+  import.meta.env.PUBLIC_APP_ENV !== 'production';
+
+function toISO(ts: unknown): string | null {
+  if (!ts) return null;
+  if (typeof ts === 'object' && 'toDate' in (ts as any)) {
+    return (ts as any).toDate().toISOString();
+  }
+  if (ts instanceof Date) return ts.toISOString();
+  return String(ts);
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const headers = { 'Content-Type': 'application/json' };
+
+  try {
+    // ── Auth ──────────────────────────────────────────────────────────────
+    let uid: string | null = null;
+
+    const authHeader = request.headers.get('Authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+
+    if (token) {
+      const decoded = await adminAuth.verifyIdToken(token);
+      uid = decoded.uid;
+
+      const userDoc = await adminDb.collection('users').doc(uid).get();
+      const roles: string[] = userDoc.data()?.roles ?? [];
+      if (!roles.includes('admin')) {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers });
+      }
+    } else if (devBypassEnabled) {
+      uid = import.meta.env.DEV_ADMIN_UID ?? 'dev-admin';
+    } else {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers });
+    }
+
+    // ── Parámetros ────────────────────────────────────────────────────────
+    const url = new URL(request.url);
+    const orderId = url.searchParams.get('orderId')?.trim();
+
+    if (!orderId) {
+      return new Response(JSON.stringify({ error: 'orderId requerido' }), { status: 400, headers });
+    }
+
+    // ── Buscar por campo orderId (no por ID de documento) ─────────────────
+    const orderQuery = await adminDb
+      .collection('orders')
+      .where('orderId', '==', orderId)
+      .limit(1)
+      .get();
+
+    if (orderQuery.empty) {
+      return new Response(JSON.stringify({ error: 'Pedido no encontrado' }), { status: 404, headers });
+    }
+
+    const orderDoc = orderQuery.docs[0];
+    const order = orderDoc.data();
+    const docId = orderDoc.id; // ID real del documento para subconsultas
+
+    // ── Comprador y vendedor ──────────────────────────────────────────────
+    const [buyerSnap, sellerSnap] = await Promise.all([
+      adminDb.collection('users').doc(order.buyerId).get(),
+      order.sellerId
+        ? adminDb.collection('users').doc(order.sellerId).get()
+        : Promise.resolve(null),
+    ]);
+    const buyerName: string  = buyerSnap.data()?.displayName  ?? order.buyerId;
+    const sellerName: string = sellerSnap?.data()?.displayName ?? order.sellerId ?? '—';
+
+    // ── Items (subcolección usando ID real del documento) ─────────────────
+    const itemsSnap = await adminDb
+      .collection('orders').doc(docId)
+      .collection('orderItems')
+      .get();
+
+    const items = itemsSnap.docs.map((d) => ({ itemId: d.id, ...d.data() }));
+
+    // ── Pago ──────────────────────────────────────────────────────────────
+    let payment = null;
+    if (order.paymentId) {
+      const paySnap = await adminDb.collection('payments').doc(order.paymentId).get();
+      if (paySnap.exists) {
+        const p = paySnap.data()!;
+        payment = {
+          paymentId:    paySnap.id,
+          orderId:      order.orderId,
+          amount:       p.amount,
+          method:       p.method,
+          status:       p.status,
+          registeredBy: p.registeredBy,
+          verifiedBy:   p.verifiedBy   ?? null,
+          registeredAt: toISO(p.registeredAt),
+          verifiedAt:   toISO(p.verifiedAt),
+        };
+      }
+    }
+    // Fallback por query
+    if (!payment) {
+      const payQuery = await adminDb
+        .collection('payments')
+        .where('orderId', '==', orderId)
+        .limit(1)
+        .get();
+      if (!payQuery.empty) {
+        const p = payQuery.docs[0].data();
+        payment = {
+          paymentId:    payQuery.docs[0].id,
+          orderId:      order.orderId,
+          amount:       p.amount,
+          method:       p.method,
+          status:       p.status,
+          registeredBy: p.registeredBy,
+          verifiedBy:   p.verifiedBy   ?? null,
+          registeredAt: toISO(p.registeredAt),
+          verifiedAt:   toISO(p.verifiedAt),
+        };
+      }
+    }
+
+    // ── Entrega ───────────────────────────────────────────────────────────
+    let delivery = null;
+    const resolveDelivery = async (snap: FirebaseFirestore.DocumentSnapshot) => {
+      const d = snap.data()!;
+      let courierName = d.courierId;
+      const courierSnap = await adminDb.collection('users').doc(d.courierId).get();
+      if (courierSnap.exists) courierName = courierSnap.data()?.displayName ?? d.courierId;
+
+      return {
+        deliveryId:          snap.id,
+        orderId:             order.orderId,
+        courierId:           d.courierId,
+        courierName,
+        status:              d.status,
+        deliveryCode:        d.deliveryCode        ?? null,
+        attemptNumber:       d.attemptNumber       ?? null,
+        incidentReason:      d.incidentReason      ?? null,
+        evidenceUrl:         d.evidenceUrl         ?? null,
+        failureReason:       d.failureReason       ?? null,
+        amountCollected:     d.amountCollected      ?? 0,
+        customerConfirmed:   d.customerConfirmed   ?? false,
+        customerConfirmedAt: toISO(d.customerConfirmedAt),
+        assignedAt:          toISO(d.assignedAt),
+        pickedUpAt:          toISO(d.pickedUpAt),
+        inTransitAt:         toISO(d.inTransitAt),
+        deliveredAt:         toISO(d.deliveredAt),
+        failedAt:            toISO(d.failedAt),
+        reprogrammedAt:      toISO(d.reprogrammedAt),
+      };
+    };
+
+    if (order.deliveryId) {
+      const delSnap = await adminDb.collection('deliveries').doc(order.deliveryId).get();
+      if (delSnap.exists) delivery = await resolveDelivery(delSnap);
+    }
+    if (!delivery) {
+      const delQuery = await adminDb
+        .collection('deliveries')
+        .where('orderId', '==', orderId)
+        .limit(1)
+        .get();
+      if (!delQuery.empty) delivery = await resolveDelivery(delQuery.docs[0]);
+    }
+
+    // ── Línea de tiempo ───────────────────────────────────────────────────
+    type TLEvent = { label: string; detail?: string; timestamp: string | null; type?: string };
+    const rawTimeline: TLEvent[] = [];
+
+    const push = (
+      label: string,
+      timestamp: string | null,
+      detail?: string,
+      type?: TLEvent['type']
+    ) => {
+      if (timestamp) rawTimeline.push({ label, detail, timestamp, type });
+    };
+
+    push('Pedido creado',        toISO(order.createdAt),   `Comprador: ${buyerName}`,            'info');
+    push('Pedido confirmado',    toISO(order.confirmedAt), `Vendedor: ${sellerName}`,             'success');
+    push('Pago registrado',      payment?.registeredAt ?? null, payment ? `Método: ${payment.method}` : undefined, 'info');
+    push('Asignado a mensajero', delivery?.assignedAt  ?? null, delivery ? `Mensajero: ${delivery.courierName}` : undefined, 'info');
+    push('Pedido recogido',      delivery?.pickedUpAt  ?? null, 'Mensajero recogió el pedido',    'info');
+    push('En camino',            delivery?.inTransitAt ?? null, 'Mensajero en tránsito',          'info');
+    push('Entregado y cobrado',  delivery?.deliveredAt ?? null, delivery ? `Bs. ${delivery.amountCollected} cobrados` : undefined, 'success');
+    push('Entrega fallida',      delivery?.failedAt    ?? null, delivery?.failureReason ?? delivery?.incidentReason ?? undefined, 'error');
+    push('Entrega reprogramada', delivery?.reprogrammedAt ?? null, undefined,                     'warning');
+    push('Confirmado por cliente', delivery?.customerConfirmedAt ?? null, undefined,              'success');
+    push('Pago verificado',      payment?.verifiedAt   ?? null, payment?.verifiedBy ? `Verificado por ${payment.verifiedBy}` : undefined, 'success');
+    push('Pedido cancelado',     toISO(order.cancelledAt), order.incidentReason ?? undefined,     'error');
+
+    const timeline = rawTimeline
+      .filter((e) => e.timestamp)
+      .sort((a, b) => new Date(a.timestamp!).getTime() - new Date(b.timestamp!).getTime());
+
+    // ── Respuesta ─────────────────────────────────────────────────────────
+    return new Response(
+      JSON.stringify({
+        orderId:        order.orderId,
+        buyerName,
+        sellerName,
+        customerName:   order.customerName   ?? null,
+        customerPhone:  order.customerPhone  ?? null,
+        address:        order.address        ?? null,
+        total:          order.total,
+        status:         order.status,
+        paymentStatus:  order.paymentStatus  ?? null,
+        deliveryStatus: order.deliveryStatus ?? null,
+        createdAt:      toISO(order.createdAt),
+        confirmedAt:    toISO(order.confirmedAt),
+        cancelledAt:    toISO(order.cancelledAt),
+        incidentReason: order.incidentReason ?? null,
+        items,
+        payment,
+        delivery,
+        timeline,
+      }),
+      { status: 200, headers }
+    );
+
+  } catch (err) {
+    console.error('[order_history]', err);
+    return new Response(JSON.stringify({ error: 'Error interno del servidor' }), {
+      status: 500,
+      headers,
+    });
+  }
+};

--- a/src/pages/api/admin/orders_list.ts
+++ b/src/pages/api/admin/orders_list.ts
@@ -1,0 +1,116 @@
+// src/pages/api/admin/orders_list.ts
+
+import type { APIRoute } from 'astro';
+import { adminDb, adminAuth } from '../../../lib/firebase-admin';
+
+const devBypassEnabled =
+  import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
+  import.meta.env.PUBLIC_APP_ENV !== 'production';
+
+function toISO(ts: unknown): string | null {
+  if (!ts) return null;
+  if (typeof ts === 'object' && 'toDate' in (ts as any)) {
+    return (ts as any).toDate().toISOString();
+  }
+  if (ts instanceof Date) return ts.toISOString();
+  return String(ts);
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const headers = { 'Content-Type': 'application/json' };
+
+  try {
+    // ── Auth ──────────────────────────────────────────────────────────────
+    let uid: string | null = null;
+
+    const authHeader = request.headers.get('Authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+
+    if (token) {
+      const decoded = await adminAuth.verifyIdToken(token);
+      uid = decoded.uid;
+      const userDoc = await adminDb.collection('users').doc(uid).get();
+      const roles: string[] = userDoc.data()?.roles ?? [];
+      if (!roles.includes('admin')) {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers });
+      }
+    } else if (devBypassEnabled) {
+      uid = import.meta.env.DEV_ADMIN_UID ?? 'dev-admin';
+    } else {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers });
+    }
+
+    // ── Parámetros ────────────────────────────────────────────────────────
+    const url = new URL(request.url);
+    const status    = url.searchParams.get('status')    ?? null;
+    const limitParam = parseInt(url.searchParams.get('limit') ?? '20');
+    const limit     = isNaN(limitParam) ? 20 : Math.min(limitParam, 50);
+    const cursor    = url.searchParams.get('cursor')    ?? null; // orderId del último item
+
+    // ── Query base ────────────────────────────────────────────────────────
+    let query: FirebaseFirestore.Query = adminDb
+      .collection('orders')
+      .orderBy('createdAt', 'desc')
+      .limit(limit + 1); // +1 para saber si hay más páginas
+
+    if (status) {
+      query = query.where('status', '==', status);
+    }
+
+    // Paginación por cursor (último documento visto)
+    if (cursor) {
+      const cursorSnap = await adminDb
+        .collection('orders')
+        .where('orderId', '==', cursor)
+        .limit(1)
+        .get();
+      if (!cursorSnap.empty) {
+        query = query.startAfter(cursorSnap.docs[0]);
+      }
+    }
+
+    const snap = await query.get();
+    const hasMore = snap.docs.length > limit;
+    const docs = hasMore ? snap.docs.slice(0, limit) : snap.docs;
+
+    // ── Resolver nombres de compradores en paralelo ───────────────────────
+    const buyerIds = [...new Set(docs.map((d) => d.data().buyerId).filter(Boolean))];
+    const buyerSnaps = await Promise.all(
+      buyerIds.map((id) => adminDb.collection('users').doc(id).get())
+    );
+    const buyerMap: Record<string, string> = {};
+    buyerSnaps.forEach((s) => {
+      if (s.exists) buyerMap[s.id] = s.data()?.displayName ?? s.id;
+    });
+
+    // ── Mapear resultados ─────────────────────────────────────────────────
+    const orders = docs.map((d) => {
+      const o = d.data();
+      return {
+        orderId:       o.orderId,
+        customerName:  o.customerName ?? buyerMap[o.buyerId] ?? o.buyerId,
+        total:         o.total,
+        status:        o.status,
+        paymentStatus: o.paymentStatus ?? null,
+        deliveryStatus:o.deliveryStatus ?? null,
+        createdAt:     toISO(o.createdAt),
+        cancelledAt:   toISO(o.cancelledAt),
+        incidentReason:o.incidentReason ?? null,
+      };
+    });
+
+    const nextCursor = hasMore ? orders[orders.length - 1].orderId : null;
+
+    return new Response(
+      JSON.stringify({ orders, hasMore, nextCursor }),
+      { status: 200, headers }
+    );
+
+  } catch (err) {
+    console.error('[orders_list]', err);
+    return new Response(JSON.stringify({ error: 'Error interno del servidor' }), {
+      status: 500,
+      headers,
+    });
+  }
+};


### PR DESCRIPTION
## Resumen
Agrega la vista de historial completo de pedido en el panel de administración (HU #178). Permite consultar datos generales, productos, pago, entrega y línea de tiempo de cualquier pedido buscando por su ID, además de listar los pedidos recientes con filtros por estado.

## URL de los cambios
- URL: `http://localhost:4321/admin`
- Ruta o pantalla afectada: Panel Admin → Pedidos → Historial

## Cómo probar
1. Iniciar el proyecto con `bun run dev` y navegar a `/admin`
2. En el sidebar, expandir **Pedidos** y hacer clic en **Historial**
3. En la lista de pedidos recientes, hacer clic en cualquier fila para cargar su detalle
4. Alternativamente, ingresar un `orderId` o el friendly id (despues del '_' de un `orderId`) manualmente en el buscador y presionar **Buscar** o Enter
5. Probar los filtros de estado (Todos / Creados / Reservados / En camino / Entregados / Cancelados)
6. Verificar que el detalle muestre: datos generales, productos, sección de pago, sección de entrega y línea de tiempo

## Resultado esperado
- La lista carga automáticamente los 20 pedidos más recientes ordenados por fecha
- Al seleccionar un pedido se resalta en verde y se muestra el detalle completo debajo del buscador
- El ID del pedido se muestra dividido: UUID en gris pequeño y el ID amigable en negrita (ej. `wfz-uyc`)
- Los montos se muestran con 2 decimales (ej. `Bs. 19.40`)
- El método de pago muestra `Contra entrega` en lugar de `cash_on_delivery`
- Los timestamps de entrega muestran fecha completa + hora (ej. `04/06/2026 02:02 p. m.`)
- La línea de tiempo muestra fecha + hora completa en cada evento
- Si el pedido no tiene entrega o pago, las secciones muestran "Sin información"
- En un pedido cancelado se muestra el motivo de cancelación

## Evidencia visual
| Antes | Después |
| --- | 
<img width="1258" height="836" alt="image" src="https://github.com/user-attachments/assets/cbf5c5a6-29ff-4598-affb-5139b978a757" />
<img width="1258" height="834" alt="image" src="https://github.com/user-attachments/assets/0f09d857-48ca-4b5a-86a4-eaff1b045444" />
<img width="1256" height="826" alt="image" src="https://github.com/user-attachments/assets/82941035-24ec-4413-a51a-98e5b18850b0" />

 |

## Tipo de cambio
- [x] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
Closes #178

## Checklist del autor
- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa
- El endpoint `/api/admin/order_history` busca por el campo `orderId` dentro del documento (no por el ID del documento en Firestore), lo cual es intencional para soportar el formato `uuid_friendlyId` del proyecto.
- El endpoint `/api/admin/orders_list` pagina de 20 en 20 usando cursor. El cursor es el `orderId` del último elemento visible.
- Los campos `paymentStatus` y `deliveryStatus` se muestran únicamente en sus secciones correspondientes (Pago y Entrega), no en Datos generales, para evitar redundancia.
- Si `sellerId` es `null` (pedidos recién creados sin vendedor asignado), el campo muestra `—` sin romper la consulta a Firestore.
- Para probar con un pedido completo (con entrega y pago verificado) se necesita un pedido que haya llegado a estado `ENTREGADO` en la base de datos.