### PR TITLE
feat: notify buyer when order is delivered

### DIFF
--- a/src/features/orders/components/MyOrdersDashboard.tsx
+++ b/src/features/orders/components/MyOrdersDashboard.tsx
@@ -1,9 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { CheckCircle, X } from 'lucide-react';
 import { useAuthUser } from '../../../hooks/useAuthUser';
-import { getMyOrders, getMyReturns } from '../services/ordersService';
+import { getMyReturns, subscribeToMyOrders } from '../services/ordersService';
 import ReturnCard from './ReturnCard';
 import type { Order, ReturnRequest } from '../types';
 import OrderList from './OrderList';
+import { parseOrderId } from '../../cart/services/orderService';
+
+const isDeliveredOrder = (order: Order) =>
+  order.status === 'ENTREGADO' ||
+  order.deliveryStatus === 'DELIVERED' ||
+  order.deliveryStatus === 'delivered';
 
 export default function MyOrdersDashboard() {
   const { user, authReady } = useAuthUser();
@@ -11,25 +18,67 @@ export default function MyOrdersDashboard() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [returns, setReturns] = useState<ReturnRequest[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deliveredNotification, setDeliveredNotification] = useState<Order | null>(null);
+  const previousDeliveryState = useRef<Map<string, boolean>>(new Map());
+  const initializedOrders = useRef(false);
 
   useEffect(() => {
-    if (authReady) {
-      if (user) {
-        Promise.all([
-          getMyOrders(user.uid),
-          getMyReturns(user.uid)
-        ]).then(([ordersData, returnsData]) => {
-          setOrders(ordersData);
-          setReturns(returnsData);
-          setLoading(false);
-        }).catch(err => {
-          console.error("Error cargando datos:", err);
-          setLoading(false);
-        });
-      } else {
+    if (!authReady) return;
+
+    if (!user) {
+      setOrders([]);
+      setReturns([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    initializedOrders.current = false;
+    previousDeliveryState.current = new Map();
+    setDeliveredNotification(null);
+
+    getMyReturns(user.uid)
+      .then(setReturns)
+      .catch((err) => {
+        console.error("Error cargando devoluciones:", err);
+        setReturns([]);
+      });
+
+    const unsubscribe = subscribeToMyOrders(
+      user.uid,
+      (ordersData) => {
+        if (!initializedOrders.current) {
+          previousDeliveryState.current = new Map(
+            ordersData.map((order) => [order.id, isDeliveredOrder(order)])
+          );
+          initializedOrders.current = true;
+        } else {
+          const newlyDelivered = ordersData.find(
+            (order) =>
+              isDeliveredOrder(order) &&
+              previousDeliveryState.current.get(order.id) === false
+          );
+
+          if (newlyDelivered) {
+            setDeliveredNotification(newlyDelivered);
+            setActiveTab('orders');
+          }
+
+          previousDeliveryState.current = new Map(
+            ordersData.map((order) => [order.id, isDeliveredOrder(order)])
+          );
+        }
+
+        setOrders(ordersData);
+        setLoading(false);
+      },
+      (err) => {
+        console.error("Error cargando pedidos:", err);
         setLoading(false);
       }
-    }
+    );
+
+    return unsubscribe;
   }, [user, authReady]);
 
   if (!authReady || loading) {
@@ -42,6 +91,34 @@ export default function MyOrdersDashboard() {
 
   return (
     <div className="max-w-4xl mx-auto p-4 md:p-8 font-sans text-(--theme-text)">
+      {deliveredNotification && (
+        <div className="fixed right-4 top-24 z-50 w-[min(calc(100vw-2rem),24rem)] rounded-xl border border-[#88B04B]/30 bg-(--theme-card-bg) p-4 text-sm shadow-lg">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 rounded-full bg-[#88B04B]/15 p-1.5 text-[#5f8134]">
+                <CheckCircle size={18} />
+              </span>
+              <div>
+                <p className="font-bold text-[#5f8134]">
+                  Tu pedido fue entregado
+                </p>
+                <p className="mt-1 opacity-75">
+                  Pedido {parseOrderId(deliveredNotification.id).friendlyName}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setDeliveredNotification(null)}
+              className="rounded-full p-1 opacity-60 transition hover:bg-(--theme-card-bg) hover:opacity-100"
+              aria-label="Cerrar notificación"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
       <h1 className="text-3xl font-display font-extrabold mb-6 tracking-tight">
         Mis Pedidos y Devoluciones
       </h1>

--- a/src/features/orders/components/OrderCard.tsx
+++ b/src/features/orders/components/OrderCard.tsx
@@ -8,12 +8,19 @@ interface OrderCardProps {
 
 const getStatusStyles = (status: string) => {
   switch (status) {
+    case 'ENTREGADO':
     case 'delivered':
       return 'bg-[#88B04B]/10 text-[#88B04B]';
+    case 'EN CAMINO':
     case 'in_transit':
       return 'bg-blue-500/10 text-blue-500';
+    case 'PENDIENTE':
+    case 'EMPAQUETADO':
+    case 'LISTO':
     case 'preparing':
       return 'bg-amber-500/10 text-amber-500';
+    case 'CANCELADO':
+    case 'NO ENTREGADO':
     case 'cancelled':
       return 'bg-red-500/10 text-red-500';
     default:
@@ -27,7 +34,10 @@ const getStatusLabel = (status: string) => {
     preparing: "Preparando",
     in_transit: "En camino",
     delivered: "Entregado",
-    cancelled: "Cancelado"
+    cancelled: "Cancelado",
+    ENTREGADO: "Entregado",
+    'EN CAMINO': "En camino",
+    CANCELADO: "Cancelado"
   };
   return labels[status] || status;
 };

--- a/src/features/orders/components/OrderDetailsPanel.tsx
+++ b/src/features/orders/components/OrderDetailsPanel.tsx
@@ -13,9 +13,16 @@ interface OrderDetailsPanelProps {
 
 const getStatusStyles = (status: string) => {
   switch (status) {
+    case 'ENTREGADO':
     case 'delivered': return 'bg-[#88B04B]/10 text-[#88B04B] border-[#88B04B]/20';
+    case 'EN CAMINO':
     case 'in_transit': return 'bg-blue-500/10 text-blue-500 border-blue-500/20';
+    case 'PENDIENTE':
+    case 'EMPAQUETADO':
+    case 'LISTO':
     case 'preparing': return 'bg-amber-500/10 text-amber-500 border-amber-500/20';
+    case 'CANCELADO':
+    case 'NO ENTREGADO':
     case 'cancelled': return 'bg-red-500/10 text-red-500 border-red-500/20';
     default: return 'bg-gray-500/10 text-gray-500 border-gray-500/20';
   }
@@ -24,10 +31,16 @@ const getStatusStyles = (status: string) => {
 const getStatusLabel = (status: string) => {
   const labels: Record<string, string> = {
     pending: "Pendiente", preparing: "Preparando",
-    in_transit: "En camino", delivered: "Entregado", cancelled: "Cancelado"
+    in_transit: "En camino", delivered: "Entregado", cancelled: "Cancelado",
+    ENTREGADO: "Entregado", 'EN CAMINO': "En camino", CANCELADO: "Cancelado"
   };
   return labels[status] || status;
 };
+
+const isDeliveredOrder = (order: Order) =>
+  order.status === 'ENTREGADO' ||
+  order.deliveryStatus === 'DELIVERED' ||
+  order.deliveryStatus === 'delivered';
 
 function formatDateTime(value: Order['buyerReceptionConfirmedAt']) {
   if (!value) return null;
@@ -59,9 +72,10 @@ export default function OrderDetailsPanel({ order, onBack, onOrderConfirmed }: O
   const now = new Date();
   const hoursSinceOrder = (now.getTime() - orderDate.getTime()) / (1000 * 60 * 60);
   const isWithinTimeLimit = hoursSinceOrder <= 72;
-  const canRequestReturn = order.status === 'delivered' && isWithinTimeLimit;
+  const isDelivered = isDeliveredOrder(order);
+  const canRequestReturn = isDelivered && isWithinTimeLimit;
   const receptionConfirmedAt = formatDateTime(order.buyerReceptionConfirmedAt);
-  const canConfirmReception = order.status === 'delivered' && !order.buyerReceptionConfirmed;
+  const canConfirmReception = isDelivered && !order.buyerReceptionConfirmed;
 
   const handleConfirmReception = async () => {
     if (!order.buyerId || order.buyerReceptionConfirmed) return;
@@ -73,7 +87,7 @@ export default function OrderDetailsPanel({ order, onBack, onOrderConfirmed }: O
       await confirmOrderReception(order.id, order.buyerId);
       const updatedOrder = {
         ...order,
-        status: 'delivered' as const,
+        status: 'ENTREGADO' as const,
         buyerReceptionConfirmed: true,
         buyerReceptionConfirmedAt: Timestamp.fromDate(new Date()),
       };
@@ -186,7 +200,7 @@ export default function OrderDetailsPanel({ order, onBack, onOrderConfirmed }: O
               <p className="mt-1 text-xs opacity-70">
                 {order.buyerReceptionConfirmed
                   ? `Confirmada${receptionConfirmedAt ? ` el ${receptionConfirmedAt}` : ''}.`
-                  : order.status === 'delivered'
+                  : isDelivered
                     ? 'Valida que recibiste el pedido correctamente.'
                     : 'Disponible cuando el mensajero marque el pedido como entregado.'}
               </p>
@@ -304,7 +318,7 @@ export default function OrderDetailsPanel({ order, onBack, onOrderConfirmed }: O
               </button>
             ) : (
               <p className="text-xs opacity-50 italic">
-                {order.status !== 'delivered'
+                {!isDelivered
                   ? 'Las devoluciones solo están disponibles para pedidos entregados.'
                   : 'El plazo de 72 horas para devolver este pedido ha expirado.'}
               </p>

--- a/src/features/orders/services/ordersService.ts
+++ b/src/features/orders/services/ordersService.ts
@@ -395,6 +395,31 @@ export async function getMyOrders(userId: string): Promise<Order[]> {
   return processQuerySnapshot(querySnapshot);
 }
 
+export function subscribeToMyOrders(
+  userId: string,
+  onUpdate: (orders: Order[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe {
+  const q = query(
+    collection(db, "orders"),
+    where("buyerId", "==", userId),
+    orderBy("createdAt", "desc")
+  );
+
+  return onSnapshot(q, async (querySnapshot) => {
+    try {
+      const orders = await processQuerySnapshot(querySnapshot);
+      onUpdate(orders);
+    } catch (error) {
+      onError?.(
+        error instanceof Error
+          ? error
+          : new Error("No se pudieron escuchar tus pedidos.")
+      );
+    }
+  }, onError);
+}
+
 export async function confirmOrderReception(orderId: string, buyerId: string) {
   const orderRef = doc(db, "orders", orderId);
 


### PR DESCRIPTION
## Summary

This PR adds an in-app delivery notification for buyers when one of their orders is marked as delivered.

## Changes

- Added real-time subscription support for buyer orders.
- Displayed a delivery notification when an order changes to `ENTREGADO` / `DELIVERED`.
- Limited the notification to the authenticated buyer who owns the order.
- Updated buyer order cards to correctly display delivered order states.
- Updated order detail logic to recognize the existing delivered states used by the system.
- Kept the implementation scoped to the buyer orders flow.

## How to test

1. Run the project locally.
2. Start Firebase emulators and load the seed data.
3. Log in as a buyer, for example Juan Paredes.
4. Go to `/mis-pedidos` and keep the page open.
5. In another session, log in as courier Luis Torrez.
6. Go to `/courier`.
7. Start delivery and register payment for an order that belongs to the same buyer.
8. Return to the buyer session and verify that the notification appears.

## Expected result

The buyer should see an in-app notification like:

`Tu pedido fue entregado`

The notification should include the delivered order identifier and should only appear for the buyer who owns that order.

## Note

This user story implements an in-app notification, not a browser push notification.

The buyer must have `/mis-pedidos` open when the order changes to delivered in order to receive the real-time notification.
