### PR TITLE
Feature/messenger daily earnings

### DIFF
--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -31,6 +31,12 @@ import {
     sortAcceptedOrdersByAge,
     type AcceptedOrderSort,
 } from '../utils/acceptedOrderSorting';
+import {
+    getCollectedOrdersForDay,
+    getCollectedTotal,
+    getCollectedTotalForDay,
+    isMessengerOrderCollected,
+} from '../utils/collectionSummary';
 import UndeliveredModal from '../modals/UndeliveredModal';
 
 import CancelNoPaymentModal from '../modals/CancelNoPaymentModal';
@@ -869,27 +875,24 @@ export default function MessengerDashboard({
     // ✅ MODIFICADO: Se agregó ordenamiento por fecha descendente
     const deliveredOrders = useMemo(
         () => orders
-            .filter((order) => order.deliveryStatus === 'delivered')
+            .filter(isMessengerOrderCollected)
             .sort((a, b) => {
-                const dateA = a.paymentCollectedAt || a.updatedAt || a.createdAt;
-                const dateB = b.paymentCollectedAt || b.updatedAt || b.createdAt;
+                const dateA = a.paymentCollectedAt;
+                const dateB = b.paymentCollectedAt;
                 if (!dateA || !dateB) return 0;
                 return dateB.getTime() - dateA.getTime();
             }),
         [orders]
     );
-    const todayCollectedTotal = useMemo(() => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    return orders
-        .filter((order) => {
-            if (order.deliveryStatus !== 'delivered') return false;
-            const date = order.paymentCollectedAt || order.updatedAt || order.createdAt;
-            return date ? date >= today : false;
-        })
-        .reduce((total, order) => total + order.cashToCollect, 0);
-}, [orders]);
+    const todayCollectedOrders = useMemo(
+        () => getCollectedOrdersForDay(orders),
+        [orders]
+    );
+    const todayCollectedTotal = useMemo(
+        () => getCollectedTotalForDay(orders),
+        [orders]
+    );
+    const collectedTotal = useMemo(() => getCollectedTotal(orders), [orders]);
     
     const notDeliveredOrders = useMemo(
         () =>
@@ -1249,8 +1252,8 @@ const confirmPayment = async (order: MessengerOrder, secret: string) => {
                         <section className="messenger-summary-grid grid gap-5">
                             <SummaryCard
                                 icon={<CheckCircle2 size={20} />}
-                                label="Cantidad completados"
-                                value={deliveredOrders.length}
+                                label="Cobrados en la jornada"
+                                value={todayCollectedOrders.length}
                             />
                           <SummaryCard
                                 icon={<CheckCircle2 size={20} />}
@@ -1261,12 +1264,7 @@ const confirmPayment = async (order: MessengerOrder, secret: string) => {
                                 featured
                                 icon={<DollarSign size={20} />}
                                 label="Total cobrado"
-                                value={formatBolivianos(
-                                    deliveredOrders.reduce(
-                                        (total, order) => total + order.cashToCollect,
-                                        0
-                                    )
-                                )}
+                                value={formatBolivianos(collectedTotal)}
                             />
 
                         </section>

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -878,6 +878,18 @@ export default function MessengerDashboard({
             }),
         [orders]
     );
+    const todayCollectedTotal = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    return orders
+        .filter((order) => {
+            if (order.deliveryStatus !== 'delivered') return false;
+            const date = order.paymentCollectedAt || order.updatedAt || order.createdAt;
+            return date ? date >= today : false;
+        })
+        .reduce((total, order) => total + order.cashToCollect, 0);
+}, [orders]);
     
     const notDeliveredOrders = useMemo(
         () =>
@@ -1240,6 +1252,11 @@ const confirmPayment = async (order: MessengerOrder, secret: string) => {
                                 label="Cantidad completados"
                                 value={deliveredOrders.length}
                             />
+                          <SummaryCard
+                                icon={<CheckCircle2 size={20} />}
+                                label="Cobrado en la jornada"
+                                value={formatBolivianos(todayCollectedTotal)}
+                            />                
                             <SummaryCard
                                 featured
                                 icon={<DollarSign size={20} />}
@@ -1251,6 +1268,7 @@ const confirmPayment = async (order: MessengerOrder, secret: string) => {
                                     )
                                 )}
                             />
+
                         </section>
 
                         <section className="mt-11">

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -18,6 +18,7 @@ import type { MessengerOrder, MessengerOrderItem } from '../types';
 
 type DeliveryStatus = MessengerOrder['deliveryStatus'];
 type OrderData = Record<string, unknown>;
+type PaymentData = Record<string, unknown>;
 
 type CustomerLocation = {
   label: string | null;
@@ -86,6 +87,17 @@ const asString = (value: unknown): string | null =>
 const asNumber = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
 
+const toAmount = (...values: unknown[]) => {
+  for (const value of values) {
+    const amount =
+      typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : null;
+
+    if (amount != null && Number.isFinite(amount)) return amount;
+  }
+
+  return 0;
+};
+
 const readBuyerName = async (buyerId: unknown): Promise<string | null> => {
   const uid = asString(buyerId);
   if (!uid) return null;
@@ -121,6 +133,23 @@ const formatCourierZoneName = (zoneName: string | null): string | undefined => {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
 };
 
+const readPayment = async (paymentId: string | null): Promise<PaymentData> => {
+  if (!paymentId) return {};
+
+  const paymentSnap = await getDoc(doc(db, 'payments', paymentId));
+  return paymentSnap.exists() ? paymentSnap.data() : {};
+};
+
+const isCollectedPaymentStatus = (status: string) => {
+  const normalized = status
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+
+  return normalized === 'cobrado' || normalized === 'pagado' || normalized === 'paid';
+};
+
 const mapMessengerOrder = async (
   deliveryId: string,
   delivery: OrderData
@@ -128,12 +157,19 @@ const mapMessengerOrder = async (
   const orderId = String(delivery.orderId || '');
   const orderSnap = orderId ? await getDoc(doc(db, 'orders', orderId)) : null;
   const order = orderSnap?.exists() ? orderSnap.data() : {};
-  const [items, buyerName, customerLocation] = await Promise.all([
+  const paymentId = asString(order.paymentId) ?? (orderId || null);
+  const [items, buyerName, customerLocation, payment] = await Promise.all([
     orderId ? readOrderItems(orderId) : [],
     readBuyerName(order.buyerId),
     readCustomerLocation(order.locationId),
+    readPayment(paymentId),
   ]);
-  const paymentStatus = String(order.paymentStatus || 'PENDIENTE');
+  const paymentStatus = String(payment.status ?? order.paymentStatus ?? 'PENDIENTE');
+  const storedPaymentStatusLabel = String(
+    payment.statusLabel ?? order.paymentStatusLabel ?? ''
+  );
+  const paymentCollectedAt =
+    toDate(payment.collectedAt) ?? toDate(order.paymentCollectedAt);
   const customerName =
     asString(order.customerName) ||
     'Cliente no registrado';
@@ -151,7 +187,7 @@ const mapMessengerOrder = async (
   return {
     id: orderId || deliveryId,
     deliveryId,
-    paymentId: typeof order.paymentId === 'string' ? order.paymentId : null,
+    paymentId,
     customerName,
     buyerName: asString(order.customerName) || buyerName || 'Comprador invitado',
     secret: typeof order.secret === 'string' ? order.secret : undefined,
@@ -166,16 +202,15 @@ const mapMessengerOrder = async (
       asString(order.locationLabel) ||
       courierZoneName,
     items,
-    cashToCollect: Number(delivery.amountCollected || order.total || 0),
+    cashToCollect: toAmount(delivery.amountCollected, payment.amount, order.total),
     paymentMethod: 'cash_on_delivery' as const,
     paymentStatus,
-    paymentStatusLabel:
-      paymentStatus.toLowerCase() === 'cobrado' ||
-      paymentStatus.toLowerCase() === 'pagado'
-        ? 'Cobrado'
-        : 'Pendiente de cobro',
-    paymentCollectedAt: order.paymentCollectedAt?.toDate?.() ?? null,
-    collectedBy: typeof order.collectedBy === 'string' ? order.collectedBy : null,
+    paymentStatusLabel: isCollectedPaymentStatus(paymentStatus)
+      ? 'Cobrado'
+      : storedPaymentStatusLabel || 'Pendiente de cobro',
+    paymentCollectedAt,
+    collectedBy:
+      asString(payment.collectedBy) ?? asString(order.collectedBy),
     deliveryMethod: String(order.deliveryMethod || 'Delivery'),
     deliveryStatus: normalizeDeliveryStatus(delivery.status),
     assignedAt: toDate(delivery.assignedAt),
@@ -194,66 +229,9 @@ export async function getMessengerOrders(
   const deliveriesSnapshot = await getDocs(deliveriesQuery);
 
   const orders = await Promise.all(
-    deliveriesSnapshot.docs.map(async (deliveryDoc) => {
-      const delivery = deliveryDoc.data();
-      const orderId = String(delivery.orderId || '');
-      const orderSnap = orderId
-        ? await getDoc(doc(db, 'orders', orderId))
-        : null;
-      const order = orderSnap?.exists() ? orderSnap.data() : {};
-      const items = orderId ? await readOrderItems(orderId) : [];
-      const paymentStatus = String(order.paymentStatus || 'PENDIENTE');
-      const customerLocation = await readCustomerLocation(order.locationId);
-      const courierZoneName =
-        customerLocation.lat != null && customerLocation.lng != null
-          ? formatCourierZoneName(
-              getCurrentZone(customerLocation.lat, customerLocation.lng)
-            )
-          : undefined;
-
-      return {
-        id: orderId || deliveryDoc.id,
-        deliveryId: deliveryDoc.id,
-        paymentId: typeof order.paymentId === 'string' ? order.paymentId : null,
-        customerName: String(order.customerName || 'Cliente no registrado'),
-        buyerName: String(order.customerName || 'Comprador invitado'),  
-         
-        secret: typeof order.secret === 'string' ? order.secret : undefined,    
-        phone: String(order.customerPhone || 'Sin telefono'),
-        address: String(
-          order.address || customerLocation.label || 'Direccion no registrada'
-        ),
-        city: String(order.deliveryZone || 'Cochabamba'),
-        locationLabel: customerLocation.label ?? undefined,
-        deliveryLat: customerLocation.lat,
-        deliveryLng: customerLocation.lng,
-        lat: customerLocation.lat,
-        lng: customerLocation.lng,
-        reference: String(
-          order.reference ||
-            order.locationLabel ||
-            courierZoneName ||
-            customerLocation.label ||
-            ''
-        ),
-        items,
-        cashToCollect: Number(delivery.amountCollected || order.total || 0),
-        paymentMethod: 'cash_on_delivery' as const,
-        paymentStatus,
-        paymentStatusLabel:
-          paymentStatus.toLowerCase() === 'cobrado' ||
-          paymentStatus.toLowerCase() === 'pagado'
-            ? 'Cobrado'
-            : 'Pendiente de cobro',
-        paymentCollectedAt: order.paymentCollectedAt?.toDate?.() ?? null,
-        collectedBy: typeof order.collectedBy === 'string' ? order.collectedBy : null,
-        deliveryMethod: String(order.deliveryMethod || 'Delivery'),         
-        deliveryStatus: normalizeDeliveryStatus(delivery.status),
-        assignedAt: toDate(delivery.assignedAt),
-        createdAt: toDate(delivery.createdAt) ?? toDate(order.createdAt),
-        updatedAt: toDate(delivery.updatedAt) ?? toDate(order.updatedAt),
-      };
-    })
+    deliveriesSnapshot.docs.map((deliveryDoc) =>
+      mapMessengerOrder(deliveryDoc.id, deliveryDoc.data())
+    )
   );
 
   return orders.sort((a, b) => a.id.localeCompare(b.id));
@@ -274,74 +252,9 @@ export function subscribeToMessengerOrders(
     async (deliveriesSnapshot) => {
       try {
         const orders = await Promise.all(
-          deliveriesSnapshot.docs.map(async (deliveryDoc) => {
-            const delivery = deliveryDoc.data();
-            const orderId = String(delivery.orderId || '');
-            const orderSnap = orderId
-              ? await getDoc(doc(db, 'orders', orderId))
-              : null;
-            const order = orderSnap?.exists() ? orderSnap.data() : {};
-            const items = orderId ? await readOrderItems(orderId) : [];
-            const paymentStatus = String(order.paymentStatus || 'PENDIENTE');
-            const customerLocation = await readCustomerLocation(order.locationId);
-            const courierZoneName =
-              customerLocation.lat != null && customerLocation.lng != null
-                ? formatCourierZoneName(
-                    getCurrentZone(customerLocation.lat, customerLocation.lng)
-                  )
-                : undefined;
-
-            return {
-              id: orderId || deliveryDoc.id,
-              deliveryId: deliveryDoc.id,
-              paymentId:
-                typeof order.paymentId === 'string' ? order.paymentId : null,
-              customerName: String(
-                order.customerName || 'Cliente no registrado'
-              ),
-              buyerName: String(order.customerName || 'Comprador invitado'),
-              secret: typeof order.secret === 'string' ? order.secret : undefined,
-              phone: String(order.customerPhone || 'Sin telefono'),
-              address: String(
-                order.address ||
-                  customerLocation.label ||
-                  'Direccion no registrada'
-              ),
-              city: String(order.deliveryZone || 'Cochabamba'),
-              locationLabel: customerLocation.label ?? undefined,
-              deliveryLat: customerLocation.lat,
-              deliveryLng: customerLocation.lng,
-              lat: customerLocation.lat,
-              lng: customerLocation.lng,
-              reference: String(
-                order.reference ||
-                  order.locationLabel ||
-                  courierZoneName ||
-                  customerLocation.label ||
-                  ''
-              ),
-              items,
-              cashToCollect: Number(delivery.amountCollected || order.total || 0),
-              paymentMethod: 'cash_on_delivery' as const,
-              paymentStatus,
-              paymentStatusLabel:
-                paymentStatus.toLowerCase() === 'cobrado' ||
-                paymentStatus.toLowerCase() === 'pagado'
-                  ? 'Cobrado'
-                  : 'Pendiente de cobro',
-              paymentCollectedAt:
-                order.paymentCollectedAt?.toDate?.() ?? null,
-              collectedBy:
-                typeof order.collectedBy === 'string'
-                  ? order.collectedBy
-                  : null,
-              deliveryMethod: String(order.deliveryMethod || 'Delivery'),
-              deliveryStatus: normalizeDeliveryStatus(delivery.status),
-              assignedAt: toDate(delivery.assignedAt),
-              createdAt: toDate(delivery.createdAt) ?? toDate(order.createdAt),
-              updatedAt: toDate(delivery.updatedAt) ?? toDate(order.updatedAt),
-            };
-          })
+          deliveriesSnapshot.docs.map((deliveryDoc) =>
+            mapMessengerOrder(deliveryDoc.id, deliveryDoc.data())
+          )
         );
 
         onChange(orders.sort((a, b) => a.id.localeCompare(b.id)));
@@ -415,10 +328,13 @@ export async function registerMessengerCashPayment(
 ) {
   const orderRef = doc(db, 'orders', order.id);
   const deliveryRef = doc(db, 'deliveries', order.deliveryId);
+  const paymentId = order.paymentId || order.id;
+  const paymentRef = doc(db, 'payments', paymentId);
   const collectedAt = serverTimestamp();
   const batch = writeBatch(db);
 
   batch.update(orderRef, {
+    paymentId,
     status: 'ENTREGADO',
     deliveryStatus: 'DELIVERED',
     paymentStatus: 'COBRADO',
@@ -432,22 +348,29 @@ export async function registerMessengerCashPayment(
   batch.update(deliveryRef, {
     status: 'delivered',
     amountCollected: order.cashToCollect,
+    collectedBy: courierId,
+    paymentCollectedAt: collectedAt,
     customerConfirmed: true,
     customerConfirmedAt: collectedAt,
     deliveredAt: collectedAt,
     updatedAt: collectedAt,
   });
 
-  if (order.paymentId) {
-    batch.update(doc(db, 'payments', order.paymentId), {
+  batch.set(
+    paymentRef,
+    {
+      paymentId,
+      orderId: order.id,
       status: 'COBRADO',
       statusLabel: 'Cobrado',
+      method: order.paymentMethod,
       amount: order.cashToCollect,
       collectedAt,
       collectedBy: courierId,
       updatedAt: collectedAt,
-    });
-  }
+    },
+    { merge: true }
+  );
 
   await batch.commit();
 }

--- a/src/features/mensajero/utils/collectionSummary.ts
+++ b/src/features/mensajero/utils/collectionSummary.ts
@@ -1,0 +1,45 @@
+import type { MessengerOrder } from '../types';
+
+const COLLECTED_PAYMENT_STATUSES = new Set(['cobrado', 'pagado', 'paid']);
+
+const normalizeStatus = (value: string | null | undefined) =>
+  value
+    ?.normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase() ?? '';
+
+export const isMessengerOrderCollected = (order: MessengerOrder) =>
+  order.deliveryStatus === 'delivered' &&
+  (COLLECTED_PAYMENT_STATUSES.has(normalizeStatus(order.paymentStatus)) ||
+    COLLECTED_PAYMENT_STATUSES.has(normalizeStatus(order.paymentStatusLabel)));
+
+export const isSameLocalDay = (date: Date, day: Date) =>
+  date.getFullYear() === day.getFullYear() &&
+  date.getMonth() === day.getMonth() &&
+  date.getDate() === day.getDate();
+
+export const getCollectedOrdersForDay = (
+  orders: MessengerOrder[],
+  day = new Date()
+) =>
+  orders.filter(
+    (order) =>
+      isMessengerOrderCollected(order) &&
+      order.paymentCollectedAt != null &&
+      isSameLocalDay(order.paymentCollectedAt, day)
+  );
+
+export const getCollectedTotal = (orders: MessengerOrder[]) =>
+  orders
+    .filter(isMessengerOrderCollected)
+    .reduce((total, order) => total + order.cashToCollect, 0);
+
+export const getCollectedTotalForDay = (
+  orders: MessengerOrder[],
+  day = new Date()
+) =>
+  getCollectedOrdersForDay(orders, day).reduce(
+    (total, order) => total + order.cashToCollect,
+    0
+  );

--- a/tests/messenger-collection-summary.spec.ts
+++ b/tests/messenger-collection-summary.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import type { MessengerOrder } from '../src/features/mensajero/types';
+import {
+  getCollectedOrdersForDay,
+  getCollectedTotal,
+  getCollectedTotalForDay,
+  isMessengerOrderCollected,
+} from '../src/features/mensajero/utils/collectionSummary';
+
+const baseOrder: MessengerOrder = {
+  id: 'order-base',
+  deliveryId: 'delivery-base',
+  paymentId: 'payment-base',
+  customerName: 'Cliente',
+  buyerName: 'Cliente',
+  phone: '70000000',
+  address: 'Campus UMSS',
+  city: 'Cochabamba',
+  items: [],
+  cashToCollect: 0,
+  paymentMethod: 'cash_on_delivery',
+  paymentStatus: 'PENDIENTE',
+  paymentStatusLabel: 'Pendiente de cobro',
+  paymentCollectedAt: null,
+  collectedBy: null,
+  deliveryMethod: 'Delivery',
+  deliveryStatus: 'accepted',
+  assignedAt: null,
+  createdAt: null,
+  updatedAt: null,
+};
+
+function buildOrder(
+  id: string,
+  overrides: Partial<MessengerOrder>
+): MessengerOrder {
+  return {
+    ...baseOrder,
+    id,
+    deliveryId: `delivery-${id}`,
+    paymentId: `payment-${id}`,
+    ...overrides,
+  };
+}
+
+test.describe('messenger collection summary', () => {
+  test('counts only delivered orders with collected payment status', () => {
+    const collected = buildOrder('collected', {
+      cashToCollect: 100,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      paymentCollectedAt: new Date('2026-06-04T12:00:00.000Z'),
+    });
+    const deliveredPendingPayment = buildOrder('pending-payment', {
+      cashToCollect: 80,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'PENDIENTE',
+      paymentCollectedAt: new Date('2026-06-04T13:00:00.000Z'),
+    });
+    const collectedButNotDelivered = buildOrder('not-delivered', {
+      cashToCollect: 60,
+      deliveryStatus: 'in_transit',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      paymentCollectedAt: new Date('2026-06-04T14:00:00.000Z'),
+    });
+
+    expect(isMessengerOrderCollected(collected)).toBe(true);
+    expect(isMessengerOrderCollected(deliveredPendingPayment)).toBe(false);
+    expect(isMessengerOrderCollected(collectedButNotDelivered)).toBe(false);
+    expect(
+      getCollectedTotal([
+        collected,
+        deliveredPendingPayment,
+        collectedButNotDelivered,
+      ])
+    ).toBe(100);
+  });
+
+  test('uses paymentCollectedAt to calculate the courier workday total', () => {
+    const workday = new Date('2026-06-04T15:00:00.000Z');
+    const today = buildOrder('today', {
+      cashToCollect: 120,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      paymentCollectedAt: new Date('2026-06-04T09:00:00.000Z'),
+      updatedAt: new Date('2026-06-03T23:00:00.000Z'),
+    });
+    const yesterday = buildOrder('yesterday', {
+      cashToCollect: 90,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      paymentCollectedAt: new Date('2026-06-03T22:00:00.000Z'),
+      updatedAt: new Date('2026-06-04T10:00:00.000Z'),
+    });
+    const noCollectedDate = buildOrder('no-date', {
+      cashToCollect: 70,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      paymentCollectedAt: null,
+      updatedAt: new Date('2026-06-04T11:00:00.000Z'),
+    });
+
+    expect(getCollectedOrdersForDay([today, yesterday, noCollectedDate], workday))
+      .toHaveLength(1);
+    expect(getCollectedTotalForDay([today, yesterday, noCollectedDate], workday))
+      .toBe(120);
+  });
+});


### PR DESCRIPTION
## Resumen
Se agrega al dashboard del mensajero una tarjeta que muestra el total de dinero cobrado durante la jornada actual, calculando únicamente los pedidos entregados con fecha de hoy.

## URL de los cambios
- URL:
- Ruta o pantalla afectada: `/courier` — Dashboard del mensajero (secciones: Asignados, Aceptados, No entregados)

## Cómo probar
1. Iniciar sesión como mensajero y navegar a `/courier`.
2. Tener al menos un pedido con `deliveryStatus === 'delivered'` y `paymentCollectedAt` con fecha de hoy.
3. Verificar que la tarjeta "Cobrado en la jornada" aparece en el resumen superior del dashboard.
4. Registrar un nuevo cobro desde un pedido en estado `in_transit` y confirmar que el monto de la tarjeta se actualiza automáticamente.

## Resultado esperado
- La tarjeta "Cobrado en la jornada" muestra la suma de `cashToCollect` de todos los pedidos entregados hoy por el mensajero autenticado.
- Pedidos entregados en días anteriores no se suman en esa tarjeta, pero siguen apareciendo en el historial.
- El valor se actualiza en tiempo real al registrar nuevos cobros, sin necesidad de recargar la página.

## Evidencia visual
| Antes | Después |
| --- | --- |
| <!-- imagen --> | <!-- imagen --> |

## Tipo de cambio
- [x] Nueva funcionalidad

## Issues relacionados


## Checklist del autor
- [x] Probé el cambio localmente
- [ ] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [ ] Revisé mi propio código antes de pedir review

## Notas para quien revisa
- El cálculo del total de jornada vive en un `useMemo` separado (`todayCollectedTotal`) para no afectar `deliveredOrders`, que sigue siendo el listado completo sin filtro de fecha usado en el historial.
- El filtro de "hoy" se hace comparando la fecha del campo `paymentCollectedAt` (con fallback