### PR TITLE
fix: soportar dominios UMSS en registro/edicion de usuarios y sincron…

### DIFF
--- a/seed/data/users.mjs
+++ b/seed/data/users.mjs
@@ -5,6 +5,7 @@ export const Users = {
     displayName: 'Ana Mamani',
     photoURL:
       'https://ui-avatars.com/api/?name=Ana+Mamani&background=0D8ABC&color=fff',
+    phoneNumber: '71234567',
     authType: 'google',
     roles: ['comprador'],
     institutionalId: 'EST-2024-001',
@@ -16,6 +17,7 @@ export const Users = {
     displayName: 'Carlos Flores',
     photoURL:
       'https://ui-avatars.com/api/?name=Carlos+Flores&background=FF6B35&color=fff',
+    phoneNumber: '71234568',
     authType: 'email',
     roles: ['comprador'],
     institutionalId: 'DOC-2023-042',
@@ -27,6 +29,7 @@ export const Users = {
     displayName: 'María Álvarez',
     photoURL:
       'https://ui-avatars.com/api/?name=Maria+Alvarez&background=6B5B95&color=fff',
+    phoneNumber: '71234569',
     authType: 'google',
     roles: ['comprador'],
     institutionalId: 'EST-2024-009',
@@ -38,6 +41,7 @@ export const Users = {
     displayName: 'Juan Paredes',
     photoURL:
       'https://ui-avatars.com/api/?name=Juan+Paredes&background=88B04B&color=fff',
+    phoneNumber: '71234570',
     authType: 'email',
     roles: ['comprador'],
     institutionalId: 'EST-2023-015',
@@ -49,6 +53,7 @@ export const Users = {
     displayName: 'Pedro Quiroga',
     photoURL:
       'https://ui-avatars.com/api/?name=Pedro+Quiroga&background=FFA07A&color=fff',
+    phoneNumber: '71234571',
     authType: 'google',
     roles: ['vendedor'],
     institutionalId: 'ADM-2022-010',
@@ -60,6 +65,7 @@ export const Users = {
     displayName: 'Luis Torrez',
     photoURL:
       'https://ui-avatars.com/api/?name=Luis+Torrez&background=20B2AA&color=fff',
+    phoneNumber: '71234572',
     authType: 'email',
     roles: ['mensajero'],
     institutionalId: 'SRV-2023-007',
@@ -71,6 +77,7 @@ export const Users = {
     displayName: 'Nadia Guzmán',
     photoURL:
       'https://ui-avatars.com/api/?name=Nadia+Guzman&background=FF69B4&color=fff',
+    phoneNumber: '71234573',
     authType: 'google',
     roles: ['mensajero'],
     institutionalId: 'SRV-2023-011',
@@ -82,6 +89,7 @@ export const Users = {
     displayName: 'Roberto Sánchez',
     photoURL:
       'https://ui-avatars.com/api/?name=Roberto+Sanchez&background=8A2BE2&color=fff',
+    phoneNumber: '71234574',
     authType: 'email',
     roles: ['operador_inv'],
     institutionalId: 'OPR-2021-003',
@@ -93,6 +101,7 @@ export const Users = {
     displayName: 'Administrador SANSÍ',
     photoURL:
       'https://ui-avatars.com/api/?name=Admin+SANSI&background=2C3E50&color=fff',
+    phoneNumber: '71234575',
     authType: 'email',
     roles: ['admin'],
     institutionalId: 'ADM-2020-001',
@@ -105,6 +114,7 @@ export const Users = {
     displayName: 'Marko uwu',
     photoURL:
       'https://ui-avatars.com/api/?name=Marko+uwu&background=88B04B&color=fff',
+    phoneNumber: '71234576',
     authType: 'email',
     roles: ['admin', 'vendedor', 'mensajero', 'operador_inv', 'comprador'],
     institutionalId: 'SUP-2026-000',

--- a/seed/index.mjs
+++ b/seed/index.mjs
@@ -133,6 +133,7 @@ async function seedFirestoreUsers() {
       email: user.email,
       displayName: user.displayName,
       photoURL: user.photoURL,
+      phoneNumber: user.phoneNumber ?? null,
       roles: user.roles,
       institutionalId: user.institutionalId,
       isActive: user.isActive,

--- a/src/features/admin/users/components/RegisterUserModal.tsx
+++ b/src/features/admin/users/components/RegisterUserModal.tsx
@@ -88,16 +88,22 @@ export default function RegisterUserModal({
       newErrors.displayName = 'Error: El formato de nombre no permite espacios excesivos.';
     }
 
-    // 2. Email validation - only @est.umss.edu
+    // 2. Email validation - allow institutional UMSS domains
     const trimmedEmail = email.trim().toLowerCase();
+    const allowedDomains = [
+      'est.umss.edu',
+      'ms.umss.edu',
+      'umss.edu.bo',
+      'umss.edu',
+    ];
     if (!trimmedEmail) {
       newErrors.email = 'El correo electrónico es obligatorio.';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
       newErrors.email = 'Por favor, ingrese un formato de correo electrónico válido.';
     } else {
       const domain = trimmedEmail.split('@')[1];
-      if (domain !== 'est.umss.edu') {
-        newErrors.email = 'Por favor, ingrese un formato de correo electrónico válido.';
+      if (!allowedDomains.includes(domain)) {
+        newErrors.email = 'Solo se permiten cuentas institucionales UMSS.';
       }
     }
 
@@ -243,7 +249,7 @@ export default function RegisterUserModal({
             </label>
             <input
               type="email"
-              placeholder="usuario@est.umss.edu"
+              placeholder="usuario@umss.edu"
               value={email}
               disabled={isLoading}
               onChange={(e) => handleEmailChange(e.target.value)}
@@ -261,7 +267,7 @@ export default function RegisterUserModal({
               `}
             />
             <p className="mt-1 text-[11px] text-(--theme-text)/40">
-              Solo se permite el dominio @est.umss.edu
+              Solo se permiten dominios institucionales: @est.umss.edu, @ms.umss.edu, @umss.edu.bo, @umss.edu
             </p>
             {errors.email && (
               <p className="mt-0.5 text-[11px] text-red-500">{errors.email}</p>

--- a/src/features/admin/users/components/UserEditModal.tsx
+++ b/src/features/admin/users/components/UserEditModal.tsx
@@ -73,8 +73,15 @@ export default function UserEditModal({
       setError("Ingrese un correo electrónico válido.");
       return;
     }
-    if (!email.trim().split('@')[1]?.endsWith('umss.edu')) {
-      setError("Solo se permite el dominio @umss.edu.");
+    const allowedDomains = [
+      'est.umss.edu',
+      'ms.umss.edu',
+      'umss.edu.bo',
+      'umss.edu',
+    ];
+    const domain = email.trim().split('@')[1];
+    if (!domain || !allowedDomains.includes(domain)) {
+      setError("Solo se permiten cuentas institucionales UMSS.");
       return;
     }
     if (phone && (phone.length !== 8 || !/^[67]/.test(phone))) {
@@ -178,11 +185,11 @@ export default function UserEditModal({
               <input
                 className="w-full p-2.5 rounded-xl text-[13px] bg-[var(--theme-bg)] border border-[var(--theme-border)] text-[var(--theme-text)] placeholder:text-[var(--theme-text)]/30 outline-none focus:border-[#88b04b] transition-colors"
                 value={email}
-                placeholder="usuario@est.umss.edu"
+                placeholder="usuario@umss.edu"
                 onChange={(e) => { setEmail(e.target.value); setError(""); }}
               />
               <p className="text-[10px] text-[var(--theme-text)]/30 mt-1">
-                Solo se permite el dominio @est.umss.edu
+                Solo se permiten dominios institucionales: @est.umss.edu, @ms.umss.edu, @umss.edu.bo, @umss.edu
               </p>
             </div>
 

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -3,7 +3,14 @@ import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { adminAuth, adminDb } from '../../lib/firebase-admin';
 
 const ALLOWED_ROLES = ['admin', 'vendedor', 'mensajero', 'operador_inv', 'comprador'] as const;
+const ALLOWED_INSTITUTIONAL_DOMAINS = [
+  'est.umss.edu',
+  'ms.umss.edu',
+  'umss.edu.bo',
+  'umss.edu',
+] as const;
 type AllowedRole = (typeof ALLOWED_ROLES)[number];
+type AllowedInstitutionalDomain = (typeof ALLOWED_INSTITUTIONAL_DOMAINS)[number];
 const devAdminBypassEnabled =
   import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
   import.meta.env.PUBLIC_APP_ENV !== 'production';
@@ -94,6 +101,19 @@ async function requireAdmin(request: Request): Promise<AdminGuardResult> {
   }
 }
 
+function getEmailDomain(email: string) {
+  return email.split('@')[1] ?? '';
+}
+
+function isAllowedInstitutionalEmail(email: string) {
+  const domain = getEmailDomain(email);
+  return ALLOWED_INSTITUTIONAL_DOMAINS.includes(domain as AllowedInstitutionalDomain);
+}
+
+function isValidPhoneNumber(phoneNumber: string) {
+  return phoneNumber.length === 8 && /^[67]/.test(phoneNumber);
+}
+
 function validateCreateUserPayload(payload: CreateUserRequest) {
   const displayName = payload.displayName?.trim();
   const email = payload.email?.trim().toLowerCase();
@@ -109,7 +129,18 @@ function validateCreateUserPayload(payload: CreateUserRequest) {
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return { error: 'Ingrese un correo electronico valido.' };
   }
+  if (!isAllowedInstitutionalEmail(email)) {
+    return {
+      error:
+        'Solo se permiten dominios institucionales: @est.umss.edu, @ms.umss.edu, @umss.edu.bo, @umss.edu',
+    };
+  }
   if (!phoneNumber) return { error: 'El telefono es obligatorio.' };
+  if (!isValidPhoneNumber(phoneNumber)) {
+    return {
+      error: 'El telefono debe tener 8 digitos e iniciar con 6 o 7.',
+    };
+  }
   if (roles.length === 0) return { error: 'El rol es obligatorio.' };
   if (roles.some((role) => !ALLOWED_ROLES.includes(role as AllowedRole))) {
     return { error: 'El rol seleccionado no es valido.' };
@@ -133,6 +164,19 @@ function validateUpdateUserPayload(payload: UpdateUserRequest) {
   if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return { error: 'Ingrese un correo electronico valido.' };
   }
+  if (email && !isAllowedInstitutionalEmail(email)) {
+    return {
+      error:
+        'Solo se permiten dominios institucionales: @est.umss.edu, @ms.umss.edu, @umss.edu.bo, @umss.edu',
+    };
+  }
+
+  const phoneNumber = payload.phoneNumber?.trim();
+  if (phoneNumber && !isValidPhoneNumber(phoneNumber)) {
+    return {
+      error: 'El telefono debe tener 8 digitos e iniciar con 6 o 7.',
+    };
+  }
 
   const roles = payload.roles?.map((r) => r.trim());
   if (roles !== undefined) {
@@ -147,7 +191,7 @@ function validateUpdateUserPayload(payload: UpdateUserRequest) {
       uid,
       ...(payload.displayName?.trim() && { displayName: payload.displayName.trim() }),
       ...(email && { email }),
-      ...(payload.phoneNumber?.trim() && { phoneNumber: payload.phoneNumber.trim() }),
+      ...(phoneNumber && { phoneNumber }),
       ...(roles && { roles: roles as AllowedRole[] }),
       ...(typeof payload.isActive === 'boolean' && { isActive: payload.isActive }),
     },


### PR DESCRIPTION
Corrige la validación de correo para usuarios registrados/editar usuarios para aceptar los dominios institucionales UMSS y sincroniza el campo phoneNumber en los datos seed para que los usuarios de prueba tengan ese campo disponible.

URL de los cambios
URL: https://github.com/ProcesosAgilesUMSS/sansistore/pull/new/fix/registrar-usuarios-dominios-umss,edu
Ruta o pantalla afectada:
Admin > Gestión de usuarios
Modal Registrar usuario
Modal Editar usuario
Endpoint src/pages/api/users.ts
Cómo probar
Abrir la pantalla de administración de usuarios.
Intentar registrar un nuevo usuario con un correo de cualquiera de estos dominios:
@est.umss.edu
@ms.umss.edu
@umss.edu.bo
@umss.edu
Editar un usuario existente y cambiar su email a alguno de esos dominios o actualizar su teléfono.
Resultado esperado
El formulario ya no rechaza correos institucionales válidos de UMSS distintos a @est.umss.edu.
La API backend también permite esos dominios y valida el teléfono con 8 dígitos iniciando en 6 o 7.
Los datos seed ahora incluyen phoneNumber en los usuarios generados.
Evidencia visual
No aplica

Tipo de cambio
 Nueva funcionalidad
 Corrección de bug
 Refactor
 Documentación
 Configuración o mantenimiento
Issues relacionados
No aplica

Checklist del autor
 Probé el cambio localmente
 Agregué la URL o ruta donde se revisa el cambio
 Agregué evidencia visual o indiqué que no aplica
 No hay errores ni warnings nuevos conocidos
 Revisé mi propio código antes de pedir review
Notas para quien revisa
Revisa tanto el RegisterUserModal.tsx y UserEditModal.tsx como src/pages/api/users.ts.
El backend ahora valida dominios y teléfono igual que el frontend.
La rama remota creada/push fue fix/registrar-usuarios-dominios-umss,edu.