### PR TITLE
Fix/courier money decimals

### DIFF
--- a/src/features/mensajero/components/CourierBuyerMap.tsx
+++ b/src/features/mensajero/components/CourierBuyerMap.tsx
@@ -5,6 +5,7 @@ import { collection, doc, getDoc, getDocs } from 'firebase/firestore';
 import { MapContainer, Marker, Polygon, TileLayer, ZoomControl } from 'react-leaflet';
 import { db } from '../../../lib/firebase';
 import { ALLOWED_ZONES } from '../../location/utils/zoneLimits';
+import { formatBolivianos } from '../utils/money';
 import 'leaflet/dist/leaflet.css';
 
 const defaultIcon = L.icon({
@@ -215,7 +216,7 @@ export default function CourierBuyerMap() {
               Cobro
             </p>
             <p className="mt-2 text-3xl font-black">
-              Bs {order?.cashToCollect ?? 0}
+              {formatBolivianos(order?.cashToCollect ?? 0)}
             </p>
           </div>
         </div>

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -37,6 +37,7 @@ import {
     getCollectedTotalForDay,
     isMessengerOrderCollected,
 } from '../utils/collectionSummary';
+import { formatBolivianos } from '../utils/money';
 import UndeliveredModal from '../modals/UndeliveredModal';
 
 import CancelNoPaymentModal from '../modals/CancelNoPaymentModal';
@@ -44,8 +45,6 @@ import './MessengerDashboard.css';
 import ConfirmPaymentModal from '../modals/Confirmpaymentmodal';
 
 const DEV_COURIER_ID = 'user-nadia';
-
-const formatBolivianos = (amount: number) => `Bs ${amount}`;
 
 const formatDate = (date: Date | null | undefined) => {
     if (!date) return 'Fecha no disponible';

--- a/src/features/mensajero/modals/CancelNoPaymentModal.tsx
+++ b/src/features/mensajero/modals/CancelNoPaymentModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { DollarSign, LoaderCircle, X, XCircle } from 'lucide-react';
 import type { MessengerOrder } from '../types';
+import { formatBolivianos } from '../utils/money';
 
 interface CancelNoPaymentModalProps {
   order: MessengerOrder;
@@ -74,7 +75,7 @@ export default function CancelNoPaymentModal({
 
             <div>
               <p className="text-xs font-bold uppercase opacity-50">Monto</p>
-              <p className="mt-1 text-sm font-bold">Bs {order.cashToCollect}</p>
+              <p className="mt-1 text-sm font-bold">{formatBolivianos(order.cashToCollect)}</p>
             </div>
 
             <div>

--- a/src/features/mensajero/modals/Confirmpaymentmodal.tsx
+++ b/src/features/mensajero/modals/Confirmpaymentmodal.tsx
@@ -2,14 +2,13 @@ import { useState } from 'react';
 import { CheckCircle2, KeyRound, X } from 'lucide-react';
 import type { MessengerOrder } from '../types';
 import { parseOrderId } from '../../cart/services/orderService';
+import { formatBolivianos } from '../utils/money';
 
 interface ConfirmPaymentModalProps {
     order: MessengerOrder;
     onClose: () => void;
     onConfirm: (order: MessengerOrder, secret: string) => Promise<void>;
 }
-
-const formatBolivianos = (amount: number) => `Bs ${amount}`;
 
 export default function ConfirmPaymentModal({
     order,

--- a/src/features/mensajero/utils/money.ts
+++ b/src/features/mensajero/utils/money.ts
@@ -1,0 +1,9 @@
+export const roundMoney = (amount: number): number => {
+  if (!Number.isFinite(amount)) return 0;
+  return Math.round((amount + Number.EPSILON) * 100) / 100;
+};
+
+export const formatBolivianos = (amount: number): string =>
+  `Bs ${roundMoney(amount)
+    .toFixed(2)
+    .replace(/\.?0+$/, '')}`;

--- a/tests/messenger-money-format.spec.ts
+++ b/tests/messenger-money-format.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import {
+  formatBolivianos,
+  roundMoney,
+} from '../src/features/mensajero/utils/money';
+
+test.describe('messenger money formatting', () => {
+  test('rounds floating point precision noise before rendering bolivianos', () => {
+    const floatingPointTotal = 302.59999999999997;
+
+    expect(roundMoney(floatingPointTotal)).toBe(302.6);
+    expect(formatBolivianos(floatingPointTotal)).toBe('Bs 302.6');
+  });
+
+  test('keeps useful cents without adding trailing zeroes', () => {
+    expect(formatBolivianos(73.4)).toBe('Bs 73.4');
+    expect(formatBolivianos(73.456)).toBe('Bs 73.46');
+    expect(formatBolivianos(73)).toBe('Bs 73');
+  });
+});


### PR DESCRIPTION
## Resumen

Corrige el formato de los montos en el flujo de mensajero para evitar errores de precisión de punto flotante en el total a cobrar, como `302.59999999999997` a uno redondeado: `302.6`.

## URL de los cambios

- URL: http://localhost:4321/courier
- Ruta o pantalla afectada: Mensajero > Pedidos aceptados

## Cómo probar

1. Levantar emuladores, seeders y la app local.
2. Iniciar sesión con un usuario que tenga rol de mensajero.
3. Entrar a `/courier` y abrir la sección `Pedidos aceptados`.
4. Verificar que el pedido `8c1-tht` muestre `Bs 73.4` y que el resumen de `Total a Cobrar` muestre `Bs 302.6`.
5. Confirmar que no aparezca el valor con error de precisión `302.59999999999997`.

## Resultado esperado

Los montos del mensajero se muestran redondeados correctamente, con máximo 2 decimales y sin ruido de precisión flotante.

## Evidencia visual

| Antes | Después |
| --- | --- |
| 
<img width="1902" height="947" alt="image" src="https://github.com/user-attachments/assets/e10cda2d-b8b9-40d6-b92b-35bf7c16e599" />
 | 
<img width="864" height="474" alt="image" src="https://github.com/user-attachments/assets/1ac98913-dd24-48da-8df8-a64a32379b22" />
 |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [X] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #475

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Se agregó un formatter compartido para montos del módulo mensajero y se aplicó en dashboard, mapa del comprador y modales de cobro/cancelación.

Validación local:
- El pedido `8c1-tht` muestra `Bs 73.4`.
- El resumen `Total a Cobrar` muestra `Bs 302.6`.
- No aparece `302.59999999999997`.

`bun run build` pasa. Hay warnings preexistentes en componentes de `orders` por cases duplicados, no relacionados con este cambio.
