### PR TITLE
Fix/courier messenger flow

### DIFF
--- a/src/features/mensajero/components/DeliveryActionsPanel.tsx
+++ b/src/features/mensajero/components/DeliveryActionsPanel.tsx
@@ -22,12 +22,16 @@ export default function DeliveryActionsPanel() {
   };
 
   return (
-    <section className="flex min-h-[calc(100vh-3.5rem)] flex-col items-stretch gap-4 p-4 lg:flex-row">
-      <div className="rounded-xl border border-border-light bg-card-bg-light p-3 lg:hidden">
+    <section className="flex min-h-[calc(100vh-3.5rem)] flex-col items-stretch gap-4 p-4">
+      <nav className="rounded-xl border border-border-light bg-card-bg-light p-3 shadow-sm">
+        <p className="mb-3 px-2 text-xs font-semibold uppercase text-primary">
+          Delivery
+        </p>
+
         <button
           type="button"
           onClick={() => setMenuOpen((open) => !open)}
-          className="flex w-full items-center justify-between rounded-xl border border-primary bg-secondary-bg-light p-2 text-left text-sm font-semibold text-primary"
+          className="flex w-full items-center justify-between rounded-xl border border-primary bg-secondary-bg-light p-2 text-left text-sm font-semibold text-primary md:hidden"
         >
           <span>
             {sections.find((section) => section.id === activeSection)?.label}
@@ -57,14 +61,8 @@ export default function DeliveryActionsPanel() {
             })}
           </div>
         )}
-      </div>
 
-      <aside className="hidden rounded-xl border border-border-light bg-card-bg-light p-3 lg:block lg:min-h-[calc(100vh-5.5rem)] lg:w-56 lg:shrink-0">
-        <p className="mb-3 px-2 text-xs font-semibold uppercase text-primary">
-          Delivery
-        </p>
-
-        <div className="space-y-2">
+        <div className="hidden gap-2 md:grid md:grid-cols-4">
           {sections.map((section) => {
             const active = activeSection === section.id;
 
@@ -73,10 +71,10 @@ export default function DeliveryActionsPanel() {
                 key={section.id}
                 type="button"
                 onClick={() => selectSection(section.id)}
-                className={`w-full rounded-xl p-2 text-left text-sm font-medium transition ${
+                className={`w-full rounded-xl border p-3 text-center text-sm font-medium transition ${
                   active
-                    ? 'border border-primary bg-secondary-bg-light text-primary'
-                    : 'opacity-70 hover:bg-secondary-bg-light hover:text-primary hover:opacity-100'
+                    ? 'border-primary bg-secondary-bg-light text-primary'
+                    : 'border-transparent opacity-70 hover:bg-secondary-bg-light hover:text-primary hover:opacity-100'
                 }`}
               >
                 {section.label}
@@ -84,7 +82,7 @@ export default function DeliveryActionsPanel() {
             );
           })}
         </div>
-      </aside>
+      </nav>
 
       <section className="min-h-[calc(100vh-5.5rem)] min-w-0 flex-1">
         <MessengerDashboard clientSection={activeSection} embedded />

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -15,6 +15,7 @@ import {
 import { db } from '../../../lib/firebase';
 import { getCurrentZone } from '../../location/utils/zoneLimits';
 import type { MessengerOrder, MessengerOrderItem } from '../types';
+import { getVisibleMessengerOrders } from '../utils/orderVisibility';
 
 type DeliveryStatus = MessengerOrder['deliveryStatus'];
 type OrderData = Record<string, unknown>;
@@ -234,7 +235,7 @@ export async function getMessengerOrders(
     )
   );
 
-  return orders.sort((a, b) => a.id.localeCompare(b.id));
+  return getVisibleMessengerOrders(orders);
 }
 
 export function subscribeToMessengerOrders(
@@ -257,7 +258,7 @@ export function subscribeToMessengerOrders(
           )
         );
 
-        onChange(orders.sort((a, b) => a.id.localeCompare(b.id)));
+        onChange(getVisibleMessengerOrders(orders));
       } catch (error) {
         onError?.(
           error instanceof Error

--- a/src/features/mensajero/utils/orderVisibility.ts
+++ b/src/features/mensajero/utils/orderVisibility.ts
@@ -1,0 +1,54 @@
+import type { MessengerOrder } from '../types';
+
+const statusPriority: Record<MessengerOrder['deliveryStatus'], number> = {
+  assigned: 1,
+  accepted: 2,
+  in_transit: 3,
+  not_delivered: 4,
+  pending_reassignment: 4,
+  cancelled: 4,
+  delivered: 5,
+};
+
+const getOrderActivityTime = (order: MessengerOrder) =>
+  order.updatedAt?.getTime() ??
+  order.assignedAt?.getTime() ??
+  order.createdAt?.getTime() ??
+  0;
+
+const shouldReplaceOrder = (
+  current: MessengerOrder,
+  candidate: MessengerOrder
+) => {
+  const currentPriority = statusPriority[current.deliveryStatus];
+  const candidatePriority = statusPriority[candidate.deliveryStatus];
+
+  if (candidatePriority !== currentPriority) {
+    return candidatePriority > currentPriority;
+  }
+
+  const currentTime = getOrderActivityTime(current);
+  const candidateTime = getOrderActivityTime(candidate);
+
+  if (candidateTime !== currentTime) {
+    return candidateTime > currentTime;
+  }
+
+  return candidate.deliveryId.localeCompare(current.deliveryId) > 0;
+};
+
+export function getVisibleMessengerOrders(orders: MessengerOrder[]) {
+  const visibleByOrderId = new Map<string, MessengerOrder>();
+
+  for (const order of orders) {
+    const current = visibleByOrderId.get(order.id);
+
+    if (!current || shouldReplaceOrder(current, order)) {
+      visibleByOrderId.set(order.id, order);
+    }
+  }
+
+  return [...visibleByOrderId.values()].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+}

--- a/tests/courier-smoke.spec.ts
+++ b/tests/courier-smoke.spec.ts
@@ -40,6 +40,7 @@ test.describe('Courier smoke tests', () => {
   }) => {
     await loginAsCourier(page);
     await page.goto('/courier');
+    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
 
     const assignedOrder = page
       .locator('article')
@@ -50,9 +51,21 @@ test.describe('Courier smoke tests', () => {
     await expect(assignedOrder.getByText('Cancha principal FCyT')).toBeVisible();
   });
 
+  test('shows each courier order in only one active section', async ({ page }) => {
+    await loginAsCourier(page);
+    await page.goto('/courier');
+
+    await page.getByRole('button', { name: 'Gestión Entregas' }).click();
+    await expect(page.locator('article').filter({ hasText: 'pu4-qsc' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
+    await expect(page.locator('article').filter({ hasText: 'pu4-qsc' })).toHaveCount(1);
+  });
+
   test('opens buyer location in the internal Leaflet map', async ({ page }) => {
     await loginAsCourier(page);
     await page.goto('/courier');
+    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
 
     const assignedOrder = page
       .locator('article')

--- a/tests/messenger-order-visibility.spec.ts
+++ b/tests/messenger-order-visibility.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+import { getVisibleMessengerOrders } from '../src/features/mensajero/utils/orderVisibility';
+import type { MessengerOrder } from '../src/features/mensajero/types';
+
+const baseOrder: MessengerOrder = {
+  id: 'order-001',
+  deliveryId: 'delivery-001',
+  paymentId: null,
+  customerName: 'Cliente',
+  buyerName: 'Cliente',
+  phone: '70000000',
+  address: 'Campus UMSS',
+  city: 'Cochabamba',
+  items: [],
+  cashToCollect: 0,
+  paymentMethod: 'cash_on_delivery',
+  paymentStatus: 'PENDIENTE',
+  paymentStatusLabel: 'Pendiente de cobro',
+  paymentCollectedAt: null,
+  collectedBy: null,
+  deliveryMethod: 'Delivery',
+  deliveryStatus: 'assigned',
+  assignedAt: new Date('2026-04-25T10:00:00.000Z'),
+  createdAt: new Date('2026-04-25T09:55:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+};
+
+test.describe('messenger order visibility', () => {
+  test('keeps an order in only its most advanced delivery state', () => {
+    const assignedOrder: MessengerOrder = {
+      ...baseOrder,
+      deliveryId: 'delivery-005',
+      deliveryStatus: 'assigned',
+      cashToCollect: 29,
+    };
+    const inTransitOrder: MessengerOrder = {
+      ...baseOrder,
+      deliveryId: 'delivery-006',
+      deliveryStatus: 'in_transit',
+      cashToCollect: 206,
+      updatedAt: new Date('2026-04-25T11:15:00.000Z'),
+    };
+
+    const visibleOrders = getVisibleMessengerOrders([
+      assignedOrder,
+      inTransitOrder,
+    ]);
+
+    expect(visibleOrders).toHaveLength(1);
+    expect(visibleOrders[0].deliveryId).toBe('delivery-006');
+    expect(visibleOrders[0].deliveryStatus).toBe('in_transit');
+    expect(visibleOrders[0].cashToCollect).toBe(206);
+  });
+});


### PR DESCRIPTION
## Resumen

Corrige el flujo del mensajero para que un pedido no se muestre en dos secciones al mismo tiempo. También cambia la navegación lateral de Delivery por una navegación superior, reduciendo los pasos para entrar a las secciones del mensajero.

## URL de los cambios

- URL: http://localhost:4321/courier
- Ruta o pantalla afectada: Mensajero / Entregas

## Cómo probar

1. Iniciar sesión como mensajero con `luis.mensajero@est.umss.edu`.
2. Entrar a `/courier` y revisar la sección `Gestión Entregas`.
3. Cambiar a `Pedidos aceptados` desde la navegación superior y buscar el pedido `pu4-qsc`.

## Resultado esperado

El pedido `pu4-qsc` debe aparecer solo en `Pedidos aceptados` y no debe repetirse en `Gestión Entregas`. Las secciones del mensajero deben poder cambiarse desde la navegación superior en desktop y desde el menú superior en mobile.

## Evidencia visual

| Antes | Después |
| --- | --- |
| <img width="1540" height="298" alt="image" src="https://github.com/user-attachments/assets/da5c56f6-e6ad-4df0-b0a5-961bad482f5f" /> | 
<img width="1200" height="720" alt="image" src="https://github.com/user-attachments/assets/2a9b1e43-1a0f-4a94-9c8c-e7a8ff89acc8" />
 |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #436  
Closes #437

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

La corrección deduplica las entregas por `order.id` en el servicio del mensajero y conserva la entrega más avanzada/reciente. Esto evita que datos duplicados en Firestore hagan aparecer el mismo pedido en dos paneles distintos.