### PR TITLE
fix: Delete messenger view button

### DIFF
--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -465,14 +465,7 @@ function PendingOrderCard({
                                 <CheckCircle2 size={17} />
                                 Registrar pago
                             </button>
-                            <button
-                                className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                onClick={() => onCancelNoPayment(order)}
-                                type="button"
-                            >
-                                <DollarSign size={17} />
-                                Cancelar por falta de pago
-                            </button>
+
                             <button
                                 className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
                                 onClick={() => onNotDelivered(order)}


### PR DESCRIPTION
## Resumen
Se quito de la vista de mensajero el boton de "Cancelar por falta de pago" y solo se visualizara en los detalles


## URL de los cambios

/courier




## Resultado esperado

Que se visualice el boton solo al apretar el "ver  detalle"

## Evidencia visual

<img width="910" height="349" alt="image" src="https://github.com/user-attachments/assets/528e92f1-cb23-4ad9-a778-24b23a9c4aae" />
<img width="730" height="496" alt="image" src="https://github.com/user-attachments/assets/e2b88a61-cdb4-462f-93ac-48f533a25c6c" />


## Tipo de cambio

- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [x] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados


## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [ ] Revisé mi propio código antes de pedir review

## Notas para quien revisa


