### PR TITLE
fix: permitir validar pago en pedidos completados

### DIFF
--- a/src/features/orders/components/OrderActions.tsx
+++ b/src/features/orders/components/OrderActions.tsx
@@ -9,6 +9,30 @@ const ACTIONS = {
   ENTREGADO: { label: "Validar pago", color: "bg-[#16A34A]", handler: paidOrder, successMsg: "Pago validado correctamente." },
 } as const;
 
+const PAYMENT_VALIDATED_STATUSES = new Set(["pagado", "paid", "validado", "verified"]);
+
+function normalizeStatus(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function isPaymentValidated(order: Order): boolean {
+  return (
+    normalizeStatus(order.status) === "pagado" ||
+    PAYMENT_VALIDATED_STATUSES.has(normalizeStatus(order.paymentStatus))
+  );
+}
+
+function canValidatePayment(order: Order): boolean {
+  const orderStatus = normalizeStatus(order.status);
+  const deliveryStatus = normalizeStatus(order.deliveryStatus);
+  const isDeliveredOrCompleted =
+    orderStatus === "entregado" ||
+    orderStatus === "completado" ||
+    deliveryStatus === "delivered";
+
+  return isDeliveredOrCompleted && !isPaymentValidated(order);
+}
+
 export default function OrderActions({
   order,
   onSuccess,
@@ -38,10 +62,13 @@ export default function OrderActions({
   };
 
   if (order.status === "RESERVADO") {
-    return <CancelOrderSection order={order} onSuccess={onSuccess} onNotification={onNotification} />;
+    return <CancelOrderSection order={order} onSuccess={onSuccess} />;
   }
 
-  const config = ACTIONS[order.status as keyof typeof ACTIONS];
+  const showPaymentValidation = canValidatePayment(order);
+  const config = showPaymentValidation
+    ? ACTIONS.ENTREGADO
+    : ACTIONS[order.status as keyof typeof ACTIONS];
   if (!config) return null;
 
   return (
@@ -49,7 +76,7 @@ export default function OrderActions({
       <button
         className={`text-white rounded tracking-tight px-4 py-1.5 ${config.color} leading-[100%] cursor-pointer disabled:opacity-50`}
         onClick={() => {
-          if (order.status === "ENTREGADO") {
+          if (showPaymentValidation) {
             setShowPaymentConfirm(true);
           } else {
             handleAction(() => config.handler(order.id), config.successMsg);
@@ -98,11 +125,9 @@ export default function OrderActions({
 function CancelOrderSection({
   order,
   onSuccess,
-  onNotification
 }: {
   order: Order;
   onSuccess?: () => void;
-  onNotification?: (type: "success" | "error", message: string) => void;
 }) {
   const [showCancelForm, setShowCancelForm] = useState(false);
   const [incidentNotes, setIncidentNotes] = useState("");

--- a/src/features/orders/services/ordersService.ts
+++ b/src/features/orders/services/ordersService.ts
@@ -19,6 +19,26 @@ import { db, auth } from "@/lib/firebase";
 import type { Order, OrderItem, ReturnRequest, Delivery } from "@features/orders/types";
 
 // --- Seller Actions ---
+const SELLER_VALIDATED_PAYMENT_STATUSES = new Set(["pagado", "paid", "validado", "verified"]);
+
+function normalizeStatus(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function isSellerPaymentValidated(value: unknown): boolean {
+  return SELLER_VALIDATED_PAYMENT_STATUSES.has(normalizeStatus(value));
+}
+
+function isDeliveredOrCompletedOrder(data: DocumentData): boolean {
+  const status = normalizeStatus(data.status);
+  const deliveryStatus = normalizeStatus(data.deliveryStatus);
+
+  return (
+    status === "entregado" ||
+    status === "completado" ||
+    deliveryStatus === "delivered"
+  );
+}
 
 export async function paidOrder(orderId: string): Promise<void> {
   const user = auth.currentUser;
@@ -32,15 +52,60 @@ export async function paidOrder(orderId: string): Promise<void> {
   }));
 
   await runTransaction(db, async (transaction) => {
-    // 1. Gather all reads
+    const orderSnap = await transaction.get(orderRef);
+    if (!orderSnap.exists()) {
+      throw new Error("El pedido no existe.");
+    }
+
+    const orderData = orderSnap.data();
+    if (!isDeliveredOrCompletedOrder(orderData)) {
+      throw new Error("Solo se puede validar el pago de pedidos entregados.");
+    }
+
+    if (
+      normalizeStatus(orderData.status) === "pagado" ||
+      isSellerPaymentValidated(orderData.paymentStatus)
+    ) {
+      throw new Error("El pago de este pedido ya fue validado.");
+    }
+
+    const paymentId =
+      typeof orderData.paymentId === "string" && orderData.paymentId.trim()
+        ? orderData.paymentId
+        : orderId;
+    const paymentRef = doc(db, "payments", paymentId);
+    const paymentSnap = await transaction.get(paymentRef);
+    const paymentData = paymentSnap.exists() ? paymentSnap.data() : null;
+
+    if (isSellerPaymentValidated(paymentData?.status)) {
+      throw new Error("El pago de este pedido ya fue validado.");
+    }
+
     const invRefs = items.map(item => doc(db, "inventory", item.productId));
     const invSnaps = await Promise.all(invRefs.map(ref => transaction.get(ref)));
 
-    // 2. Perform all writes
+    const verifiedAt = serverTimestamp();
+
     transaction.update(orderRef, {
       status: "PAGADO",
+      paymentId,
+      paymentStatus: "PAGADO",
+      paymentStatusLabel: "Pagado",
+      paymentVerifiedAt: verifiedAt,
+      paymentVerifiedBy: user.uid,
       updatedAt: serverTimestamp(),
     });
+    transaction.set(paymentRef, {
+      paymentId,
+      orderId,
+      amount: orderData.total ?? paymentData?.amount ?? null,
+      method: paymentData?.method ?? orderData.paymentMethod ?? "cash_on_delivery",
+      status: "PAGADO",
+      statusLabel: "Pagado",
+      verifiedBy: user.uid,
+      verifiedAt,
+      updatedAt: verifiedAt,
+    }, { merge: true });
 
     invSnaps.forEach((invSnap, index) => {
       if (!invSnap.exists()) {


### PR DESCRIPTION
## Resumen
Corrigi el flujo donde el vendedor perdía la opción de validar el pago cuando el comprador confirmaba primero la recepción. Ahora la validación permanece disponible para pedidos entregados o completados mientras el pago siga pendiente, y al validar se actualiza la orden.
