### PR TITLE
fix: keep courier order detail visible

### DIFF
--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -100,6 +100,8 @@ const canCancelByNoPayment = (order: MessengerOrder) => {
 
 function CopyableOrderId({ order }: { order: MessengerOrder }) {
   const { uuid, friendlyName } = parseOrderId(order.id);
+  const displayId = order.displayId ?? friendlyName;
+  const showTechnicalId = !order.displayId;
 
   return (
     <button
@@ -108,8 +110,10 @@ function CopyableOrderId({ order }: { order: MessengerOrder }) {
       title="Copiar ID del pedido"
       type="button"
     >
-      <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
-      <h1 className="text-3xl font-black tracking-normal">{friendlyName}</h1>
+      {showTechnicalId && (
+        <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
+      )}
+      <h1 className="text-3xl font-black tracking-normal">{displayId}</h1>
     </button>
   );
 }

--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -1,0 +1,590 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  DollarSign,
+  LoaderCircle,
+  MapPin,
+  Package,
+  Phone,
+  Send,
+  Truck,
+  XCircle,
+} from 'lucide-react';
+import PaymentSuccessModal from '../modals/PaymentSuccessModal';
+import ConfirmPaymentModal from '../modals/Confirmpaymentmodal';
+import UndeliveredModal from '../modals/UndeliveredModal';
+import CancelNoPaymentModal from '../modals/CancelNoPaymentModal';
+import ConfirmAssignedOrderActionModal, {
+  type AssignedOrderAction,
+} from '../modals/ConfirmAssignedOrderActionModal';
+import { auth } from '../../../lib/firebase';
+import { parseOrderId } from '../../cart/services/orderService';
+import {
+  getMessengerOrderById,
+  markMessengerOrderAsCancelledByNoPayment,
+  markMessengerOrderAsNotDelivered,
+  registerMessengerCashPayment,
+  setMessengerOrderStatus,
+} from '../services/messengerOrdersService';
+import type { MessengerOrder } from '../types';
+import { getDeliveryStatusLabel } from '../utils/deliveryStatusFlow';
+import { formatBolivianos } from '../utils/money';
+import './MessengerDashboard.css';
+
+const DEV_COURIER_ID = 'user-nadia';
+
+const formatDate = (date: Date | null | undefined) => {
+  if (!date) return 'Fecha no disponible';
+  return new Intl.DateTimeFormat('es-BO', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const buildBuyerMapUrl = (order: MessengerOrder) => {
+  const url = new URL('/mapa', window.location.origin);
+
+  if (order.deliveryLat != null && order.deliveryLng != null) {
+    url.searchParams.set('lat', String(order.deliveryLat));
+    url.searchParams.set('lng', String(order.deliveryLng));
+  }
+
+  url.searchParams.set('order', order.id);
+  return url.toString();
+};
+
+const storeBuyerMapOrder = (order: MessengerOrder) => {
+  localStorage.setItem(
+    'courier_panel_order',
+    JSON.stringify({
+      customerName: order.customerName,
+      phone: order.phone,
+      address: order.address,
+      reference: order.reference || order.locationLabel,
+      items: order.items.map((item) => ({
+        name: item.name,
+        quantity: item.quantity,
+      })),
+      cashToCollect: order.cashToCollect,
+    })
+  );
+};
+
+const getStatusUpdateMessage = (status: MessengerOrder['deliveryStatus']) => {
+  if (status === 'accepted') return 'Pedido aceptado correctamente.';
+  if (status === 'in_transit') return 'Entrega iniciada correctamente.';
+  if (status === 'pending_reassignment') {
+    return 'Pedido rechazado y enviado a reasignacion.';
+  }
+  if (status === 'not_delivered') return 'Pedido marcado como no entregado.';
+  if (status === 'cancelled') return 'Pedido cancelado por falta de pago.';
+  if (status === 'delivered') return 'Pago registrado y pedido entregado.';
+  return `Estado actualizado a ${getDeliveryStatusLabel(status)}.`;
+};
+
+const canCancelByNoPayment = (order: MessengerOrder) => {
+  const paymentText = `${order.paymentStatus} ${order.paymentStatusLabel}`
+    .toLowerCase()
+    .trim();
+
+  return (
+    (order.deliveryStatus === 'accepted' || order.deliveryStatus === 'in_transit') &&
+    !paymentText.includes('cobrado') &&
+    !paymentText.includes('pagado') &&
+    !paymentText.includes('cancelado')
+  );
+};
+
+function CopyableOrderId({ order }: { order: MessengerOrder }) {
+  const { uuid, friendlyName } = parseOrderId(order.id);
+
+  return (
+    <button
+      className="block text-left"
+      onClick={() => void navigator.clipboard?.writeText(order.id)}
+      title="Copiar ID del pedido"
+      type="button"
+    >
+      <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
+      <h1 className="text-3xl font-black tracking-normal">{friendlyName}</h1>
+    </button>
+  );
+}
+
+function DetailActions({
+  order,
+  onAssignedAction,
+  onCancelNoPayment,
+  onDelivered,
+  onInTransit,
+  onNotDelivered,
+}: {
+  order: MessengerOrder;
+  onAssignedAction: (action: AssignedOrderAction) => void;
+  onCancelNoPayment: () => void;
+  onDelivered: () => void;
+  onInTransit: () => void;
+  onNotDelivered: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+      <a
+        className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+        href={buildBuyerMapUrl(order)}
+        onClick={() => storeBuyerMapOrder(order)}
+      >
+        <Send size={17} />
+        Abrir Maps
+      </a>
+
+      {order.deliveryStatus === 'assigned' && (
+        <>
+          <button
+            className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+            onClick={() => onAssignedAction('accept')}
+            type="button"
+          >
+            <CheckCircle2 size={17} />
+            Aceptar pedido
+          </button>
+          <button
+            className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+            onClick={() => onAssignedAction('reject')}
+            type="button"
+          >
+            <XCircle size={17} />
+            Rechazar
+          </button>
+        </>
+      )}
+
+      {order.deliveryStatus === 'accepted' && (
+        <button
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl bg-blue-600 px-6 text-sm font-bold text-white shadow-lg transition hover:bg-blue-700"
+          onClick={onInTransit}
+          type="button"
+        >
+          <Truck size={17} />
+          Iniciar entrega
+        </button>
+      )}
+
+      {order.deliveryStatus === 'in_transit' && (
+        <button
+          className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+          onClick={onDelivered}
+          type="button"
+        >
+          <CheckCircle2 size={17} />
+          Registrar pago
+        </button>
+      )}
+
+      {(order.deliveryStatus === 'accepted' || order.deliveryStatus === 'in_transit') && (
+        <button
+          className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+          onClick={onNotDelivered}
+          type="button"
+        >
+          <AlertTriangle size={17} />
+          No entregado
+        </button>
+      )}
+
+      {canCancelByNoPayment(order) && (
+        <button
+          className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+          onClick={onCancelNoPayment}
+          type="button"
+        >
+          <DollarSign size={17} />
+          Cancelar por falta de pago
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }) {
+  const [courierId, setCourierId] = useState<string | null>(null);
+  const [order, setOrder] = useState<MessengerOrder | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [pendingAssignedAction, setPendingAssignedAction] = useState<{
+    order: MessengerOrder;
+    action: AssignedOrderAction;
+  } | null>(null);
+  const [savingAssignedAction, setSavingAssignedAction] = useState(false);
+  const [undeliveredOrder, setUndeliveredOrder] = useState<MessengerOrder | null>(null);
+  const [savingUndelivered, setSavingUndelivered] = useState(false);
+  const [cancelNoPaymentOrder, setCancelNoPaymentOrder] =
+    useState<MessengerOrder | null>(null);
+  const [savingCancelNoPayment, setSavingCancelNoPayment] = useState(false);
+  const [confirmPaymentOrder, setConfirmPaymentOrder] = useState<MessengerOrder | null>(
+    null
+  );
+  const [paymentSuccessOpen, setPaymentSuccessOpen] = useState(false);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, (user) => {
+      setCourierId(user?.uid ?? DEV_COURIER_ID);
+    });
+  }, []);
+
+  const loadOrder = useCallback(async (options: { showLoading?: boolean } = {}) => {
+    if (!courierId) return;
+
+    const showLoading = options.showLoading ?? true;
+    if (showLoading) {
+      setLoading(true);
+    }
+    setError('');
+
+    try {
+      const currentOrder = await getMessengerOrderById(courierId, orderId);
+      setOrder(currentOrder);
+      if (!currentOrder) {
+        setError('No se encontro este pedido para el mensajero actual.');
+      }
+    } catch (loadError) {
+      console.error(loadError);
+      setError('No se pudo cargar el detalle del pedido.');
+    } finally {
+      if (showLoading) {
+        setLoading(false);
+      }
+    }
+  }, [courierId, orderId]);
+
+  useEffect(() => {
+    // This page must refresh from Firestore when the courier session resolves.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadOrder({ showLoading: true });
+  }, [loadOrder]);
+
+  const totals = useMemo(() => {
+    const subtotal =
+      order?.items.reduce((total, item) => total + item.price * item.quantity, 0) ?? 0;
+    const deliveryCost = Math.max((order?.cashToCollect ?? 0) - subtotal, 0);
+
+    return { subtotal, deliveryCost };
+  }, [order]);
+
+  const updateStatus = async (status: MessengerOrder['deliveryStatus']) => {
+    if (!order) return;
+
+    const previousOrder = order;
+    setOrder({ ...order, deliveryStatus: status });
+    setMessage('');
+    setError('');
+
+    try {
+      await setMessengerOrderStatus(previousOrder, status);
+      setMessage(getStatusUpdateMessage(status));
+      await loadOrder({ showLoading: false });
+    } catch (statusError) {
+      console.error(statusError);
+      setOrder(previousOrder);
+      setError('No se pudo actualizar el estado del pedido.');
+    }
+  };
+
+  const confirmAssignedOrderAction = async () => {
+    if (!pendingAssignedAction || savingAssignedAction) return;
+
+    const nextStatus =
+      pendingAssignedAction.action === 'accept' ? 'accepted' : 'pending_reassignment';
+
+    setSavingAssignedAction(true);
+    try {
+      await updateStatus(nextStatus);
+      setPendingAssignedAction(null);
+    } finally {
+      setSavingAssignedAction(false);
+    }
+  };
+
+  const registerUndeliveredOrder = async (reason: string, notes: string) => {
+    if (!undeliveredOrder || !courierId) return;
+
+    const previousOrder = undeliveredOrder;
+    setSavingUndelivered(true);
+    setOrder({ ...previousOrder, deliveryStatus: 'not_delivered' });
+
+    try {
+      await markMessengerOrderAsNotDelivered({
+        order: previousOrder,
+        reason,
+        notes,
+        courierId,
+      });
+      setMessage(getStatusUpdateMessage('not_delivered'));
+      setUndeliveredOrder(null);
+      await loadOrder({ showLoading: false });
+    } catch (incidentError) {
+      console.error(incidentError);
+      setOrder(previousOrder);
+      setError('No se pudo registrar el incidente.');
+    } finally {
+      setSavingUndelivered(false);
+    }
+  };
+
+  const registerCancelNoPayment = async (notes: string) => {
+    if (!cancelNoPaymentOrder) return;
+
+    const previousOrder = cancelNoPaymentOrder;
+    setSavingCancelNoPayment(true);
+    setOrder({
+      ...previousOrder,
+      deliveryStatus: 'cancelled',
+      paymentStatus: 'CANCELADO',
+      paymentStatusLabel: 'Cancelado por falta de pago',
+    });
+
+    try {
+      await markMessengerOrderAsCancelledByNoPayment({
+        order: previousOrder,
+        notes,
+        courierId,
+      });
+      setMessage(getStatusUpdateMessage('cancelled'));
+      setCancelNoPaymentOrder(null);
+      await loadOrder({ showLoading: false });
+    } catch (cancelError) {
+      console.error(cancelError);
+      setOrder(previousOrder);
+      setError('No se pudo cancelar el pedido por falta de pago.');
+    } finally {
+      setSavingCancelNoPayment(false);
+    }
+  };
+
+  const confirmPayment = async (targetOrder: MessengerOrder, secret: string) => {
+    if (!courierId) throw new Error('No se pudo identificar al mensajero.');
+    if (secret !== targetOrder.secret) throw new Error('Codigo incorrecto.');
+
+    const previousOrder = targetOrder;
+    setOrder({
+      ...targetOrder,
+      deliveryStatus: 'delivered',
+      paymentStatus: 'COBRADO',
+      paymentStatusLabel: 'Cobrado',
+      collectedBy: courierId,
+      paymentCollectedAt: new Date(),
+    });
+
+    try {
+      await registerMessengerCashPayment(targetOrder, courierId);
+      setConfirmPaymentOrder(null);
+      setPaymentSuccessOpen(true);
+      setMessage(getStatusUpdateMessage('delivered'));
+      await loadOrder({ showLoading: false });
+    } catch (paymentError) {
+      console.error(paymentError);
+      setOrder(previousOrder);
+      throw paymentError;
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="mx-auto flex min-h-[55vh] max-w-5xl items-center justify-center px-4">
+        <div className="messenger-order-card flex items-center gap-3 rounded-[28px] border p-8 text-sm font-bold">
+          <LoaderCircle className="animate-spin" size={20} />
+          Cargando detalle del pedido...
+        </div>
+      </section>
+    );
+  }
+
+  if (!order) {
+    return (
+      <section className="mx-auto max-w-5xl px-4 py-10">
+        <a
+          className="messenger-map-button mb-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl border-2 px-5 text-sm font-bold transition"
+          href="/courier"
+        >
+          <ArrowLeft size={17} />
+          Volver a entregas
+        </a>
+        <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-bold">
+          {error || 'No se encontro este pedido.'}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-10">
+      <a
+        className="messenger-map-button mb-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl border-2 px-5 text-sm font-bold transition"
+        href="/courier"
+      >
+        <ArrowLeft size={17} />
+        Volver a entregas
+      </a>
+
+      <article className="messenger-order-card rounded-[28px] border p-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)]">
+        <div className="flex flex-col gap-5 border-b border-border-light pb-6 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="mb-3 flex flex-wrap items-center gap-3">
+              <CopyableOrderId order={order} />
+              <span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
+                {getDeliveryStatusLabel(order.deliveryStatus)}
+              </span>
+              <span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
+                {order.paymentStatusLabel.toUpperCase()}
+              </span>
+            </div>
+            <p className="messenger-copy text-sm font-semibold">
+              Ultima actividad: {formatDate(order.updatedAt ?? order.assignedAt)}
+            </p>
+          </div>
+
+          <div className="messenger-cash-box rounded-2xl border-2 p-5 lg:min-w-72">
+            <p className="text-xs font-medium uppercase">Monto a cobrar</p>
+            <p className="mt-2 text-3xl font-black">
+              {formatBolivianos(order.cashToCollect)}
+            </p>
+            <p className="messenger-copy mt-1 text-xs">en efectivo</p>
+          </div>
+        </div>
+
+        {(message || error) && (
+          <div
+            className={`mt-6 rounded-2xl border px-4 py-3 text-sm font-bold ${
+              error
+                ? 'border-red-500/40 bg-red-500/10 text-red-500'
+                : 'border-primary/30 bg-primary/10 text-primary'
+            }`}
+          >
+            {error || message}
+          </div>
+        )}
+
+        <div className="grid gap-8 pt-6 lg:grid-cols-[1fr_1fr]">
+          <div className="space-y-6">
+            <section>
+              <p className="messenger-muted mb-3 text-xs font-bold uppercase">
+                Cliente
+              </p>
+              <div className="messenger-copy space-y-4 text-sm">
+                <p className="text-xl font-black">{order.customerName}</p>
+                <p className="flex items-center gap-2">
+                  <Phone size={16} />
+                  <a className="hover:text-green-600" href={`tel:${order.phone}`}>
+                    {order.phone}
+                  </a>
+                </p>
+                <p className="flex items-start gap-2">
+                  <MapPin className="mt-0.5 shrink-0" size={16} />
+                  <span>
+                    {order.address}
+                    <span className="messenger-muted block text-xs">{order.city}</span>
+                  </span>
+                </p>
+                {order.reference && (
+                  <p className="messenger-reference border-l-4 px-3 py-3 text-xs font-medium">
+                    {order.reference}
+                  </p>
+                )}
+              </div>
+            </section>
+
+            <DetailActions
+              order={order}
+              onAssignedAction={(action) => setPendingAssignedAction({ order, action })}
+              onCancelNoPayment={() => setCancelNoPaymentOrder(order)}
+              onDelivered={() => setConfirmPaymentOrder(order)}
+              onInTransit={() => void updateStatus('in_transit')}
+              onNotDelivered={() => setUndeliveredOrder(order)}
+            />
+          </div>
+
+          <div>
+            <p className="messenger-muted mb-3 text-xs font-medium">Productos</p>
+            <div className="space-y-3">
+              {order.items.length > 0 ? (
+                order.items.map((item) => (
+                  <p
+                    className="messenger-copy flex items-center gap-2 text-sm"
+                    key={item.id}
+                  >
+                    <Package size={16} />
+                    <span>
+                      {item.quantity}x {item.name} - {formatBolivianos(item.price)}
+                    </span>
+                  </p>
+                ))
+              ) : (
+                <p className="messenger-copy text-sm font-semibold">
+                  Este pedido no tiene productos visibles.
+                </p>
+              )}
+            </div>
+
+            <div className="mt-6 space-y-3 rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5 text-sm font-bold">
+              <p className="flex justify-between gap-3">
+                <span>Subtotal</span>
+                <span>{formatBolivianos(totals.subtotal)}</span>
+              </p>
+              <p className="flex justify-between gap-3">
+                <span>Costo de entrega</span>
+                <span>{formatBolivianos(totals.deliveryCost)}</span>
+              </p>
+              <p className="flex justify-between gap-3 pt-4 text-primary">
+                <span>Total final</span>
+                <span>{formatBolivianos(order.cashToCollect)}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      {pendingAssignedAction && (
+        <ConfirmAssignedOrderActionModal
+          action={pendingAssignedAction.action}
+          isSaving={savingAssignedAction}
+          order={pendingAssignedAction.order}
+          onClose={() => setPendingAssignedAction(null)}
+          onConfirm={confirmAssignedOrderAction}
+        />
+      )}
+
+      {undeliveredOrder && (
+        <UndeliveredModal
+          isSaving={savingUndelivered}
+          order={undeliveredOrder}
+          onClose={() => setUndeliveredOrder(null)}
+          onConfirm={registerUndeliveredOrder}
+        />
+      )}
+
+      {cancelNoPaymentOrder && (
+        <CancelNoPaymentModal
+          isSaving={savingCancelNoPayment}
+          order={cancelNoPaymentOrder}
+          onClose={() => setCancelNoPaymentOrder(null)}
+          onConfirm={registerCancelNoPayment}
+        />
+      )}
+
+      {confirmPaymentOrder && (
+        <ConfirmPaymentModal
+          order={confirmPaymentOrder}
+          onClose={() => setConfirmPaymentOrder(null)}
+          onConfirm={confirmPayment}
+        />
+      )}
+
+      {paymentSuccessOpen && (
+        <PaymentSuccessModal onClose={() => setPaymentSuccessOpen(false)} />
+      )}
+    </section>
+  );
+}

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -112,6 +112,8 @@ function CopyableOrderId({
     codeClassName: string;
 }) {
     const { uuid, friendlyName } = parseOrderId(order.id);
+    const displayId = order.displayId ?? friendlyName;
+    const showTechnicalId = !order.displayId;
     const copyOrderId = () => {
         void navigator.clipboard?.writeText(order.id);
     };
@@ -123,8 +125,10 @@ function CopyableOrderId({
             title="Copiar ID del pedido"
             type="button"
         >
-            <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
-            <h3 className={codeClassName}>{friendlyName}</h3>
+            {showTechnicalId && (
+                <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
+            )}
+            <h3 className={codeClassName}>{displayId}</h3>
         </button>
     );
 }

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -52,6 +52,13 @@ import ConfirmAssignedOrderActionModal, {
 
 const DEV_COURIER_ID = 'user-nadia';
 
+const buildDeliveryOrderDetailUrl = (orderId: string) =>
+    `/delivery/order/${encodeURIComponent(orderId)}`;
+
+const navigateToDeliveryOrderDetail = (orderId: string) => {
+    window.location.href = buildDeliveryOrderDetailUrl(orderId);
+};
+
 const formatDate = (date: Date | null | undefined) => {
     if (!date) return 'Fecha no disponible';
     return new Intl.DateTimeFormat('es-BO', {
@@ -461,16 +468,17 @@ function PendingOrderCard({
                         Abrir Maps
                     </a>
 
-                    {order.deliveryStatus !== 'assigned' && (
-                        <button
-                            className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                            onClick={() => onDetail(order)}
-                            type="button"
-                        >
-                            <Eye size={17} />
-                            Ver detalle
-                        </button>
-                    )}
+                    <a
+                        className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+                        href={buildDeliveryOrderDetailUrl(order.id)}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            onDetail(order);
+                        }}
+                    >
+                        <Eye size={17} />
+                        Ver detalle
+                    </a>
 
                     {order.deliveryStatus === 'assigned' && (
                         <>
@@ -1367,7 +1375,8 @@ export default function MessengerDashboard({
 
     const updateOrderStatus = async (
         orderId: string,
-        status: MessengerOrder['deliveryStatus']
+        status: MessengerOrder['deliveryStatus'],
+        options: { redirectToDetail?: boolean } = {}
     ) => {
         const targetOrder = orders.find((order) => order.id === orderId);
         if (!targetOrder) return;
@@ -1386,6 +1395,9 @@ export default function MessengerDashboard({
         try {
             await setMessengerOrderStatus(targetOrder, status);
             setMessage(getStatusUpdateMessage(status));
+            if (options.redirectToDetail) {
+                navigateToDeliveryOrderDetail(orderId);
+            }
         } catch (error) {
             console.error(error);
             setMessage('No se pudo actualizar el estado en Firestore.');
@@ -1465,7 +1477,7 @@ export default function MessengerDashboard({
     };
 
     const markAsInTransit = (orderId: string) => {
-        void updateOrderStatus(orderId, 'in_transit');
+        void updateOrderStatus(orderId, 'in_transit', { redirectToDetail: true });
     };
 
     const rejectOrder = (orderId: string) => {
@@ -1481,7 +1493,7 @@ export default function MessengerDashboard({
 
         setSavingAssignedAction(true);
         try {
-            await updateOrderStatus(order.id, nextStatus);
+            await updateOrderStatus(order.id, nextStatus, { redirectToDetail: true });
             setPendingAssignedAction(null);
         } finally {
             setSavingAssignedAction(false);
@@ -1516,6 +1528,7 @@ export default function MessengerDashboard({
             });
             setMessage('Problema registrado y pedido marcado como no entregado.');
             setUndeliveredOrder(null);
+            navigateToDeliveryOrderDetail(targetOrder.id);
         } catch (error) {
             console.error(error);
             setMessage('No se pudo registrar el incidente en Firestore.');
@@ -1557,6 +1570,7 @@ export default function MessengerDashboard({
 
             setMessage('Pedido cancelado por falta de pago.');
             setCancelNoPaymentOrder(null);
+            navigateToDeliveryOrderDetail(targetOrder.id);
         } catch (error) {
             console.error(error);
             setMessage('No se pudo cancelar el pedido por falta de pago.');
@@ -1764,7 +1778,9 @@ export default function MessengerDashboard({
                                             onAccept={acceptOrder}
                                             onCancelNoPayment={setCancelNoPaymentOrder}
                                             onDelivered={markAsDelivered}
-                                            onDetail={setDetailOrder}
+                                            onDetail={(order) =>
+                                                navigateToDeliveryOrderDetail(order.id)
+                                            }
                                             onInTransit={markAsInTransit}
                                             onNotDelivered={setUndeliveredOrder}
                                             onReject={rejectOrder}

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -58,6 +58,7 @@ export default function ConfirmAssignedOrderActionModal({
 }: ConfirmAssignedOrderActionModalProps) {
   const config = actionConfig[action];
   const { friendlyName } = parseOrderId(order.id);
+  const displayId = order.displayId ?? friendlyName;
   const Icon = config.Icon;
 
   const confirmAction = async () => {
@@ -112,7 +113,7 @@ export default function ConfirmAssignedOrderActionModal({
           <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
             <div>
               <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
-              <p className="mt-1 text-sm font-bold">{friendlyName}</p>
+              <p className="mt-1 text-sm font-bold">{displayId}</p>
             </div>
 
             <div>

--- a/src/features/mensajero/modals/Confirmpaymentmodal.tsx
+++ b/src/features/mensajero/modals/Confirmpaymentmodal.tsx
@@ -19,6 +19,7 @@ export default function ConfirmPaymentModal({
     const [saving, setSaving] = useState(false);
 
     const [error, setError] = useState('');
+    const orderDisplayId = order.displayId ?? parseOrderId(order.id).friendlyName;
 
 const canSubmit = secret.trim().length > 0 && !saving;
 
@@ -73,9 +74,9 @@ const canSubmit = secret.trim().length > 0 && !saving;
                         <div className="flex justify-between items-center">
                             <span className="messenger-muted text-xs font-bold uppercase">
                                 Orden
-                            </span>
+                                </span>
                                 <span className="text-sm font-black">
-                                    {parseOrderId(order.id).friendlyName}
+                                    {orderDisplayId}
                                 </span>
                         </div>
                         <div className="flex justify-between items-center">

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -253,6 +253,14 @@ export async function getMessengerOrders(
   return getVisibleMessengerOrders(orders);
 }
 
+export async function getMessengerOrderById(
+  courierId: string,
+  orderId: string
+): Promise<MessengerOrder | null> {
+  const orders = await getMessengerOrders(courierId);
+  return orders.find((order) => order.id === orderId) ?? null;
+}
+
 export function subscribeToMessengerOrders(
   courierId: string,
   onChange: (orders: MessengerOrder[]) => void,

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -144,6 +144,13 @@ const formatCourierZoneName = (zoneName: string | null): string | undefined => {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
 };
 
+const formatOrderDisplayId = (value: unknown): string | undefined => {
+  const code = asString(value);
+  if (!code) return undefined;
+
+  return code.startsWith('#') ? code : `#${code}`;
+};
+
 const readPayment = async (paymentId: string | null): Promise<PaymentData> => {
   if (!paymentId) return {};
 
@@ -197,6 +204,7 @@ const mapMessengerOrder = async (
 
   return {
     id: orderId || deliveryId,
+    displayId: formatOrderDisplayId(delivery.orderCode),
     deliveryId,
     paymentId,
     customerName,

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -144,11 +144,9 @@ const formatCourierZoneName = (zoneName: string | null): string | undefined => {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
 };
 
-const formatOrderDisplayId = (value: unknown): string | undefined => {
-  const code = asString(value);
-  if (!code) return undefined;
-
-  return code.startsWith('#') ? code : `#${code}`;
+const readOrderDisplayId = (orderId: string): string | undefined => {
+  const [, friendlyName] = orderId.split('_');
+  return asString(friendlyName) ?? asString(orderId);
 };
 
 const readPayment = async (paymentId: string | null): Promise<PaymentData> => {
@@ -204,7 +202,7 @@ const mapMessengerOrder = async (
 
   return {
     id: orderId || deliveryId,
-    displayId: formatOrderDisplayId(delivery.orderCode),
+    displayId: readOrderDisplayId(orderId || deliveryId),
     deliveryId,
     paymentId,
     customerName,

--- a/src/features/mensajero/types.ts
+++ b/src/features/mensajero/types.ts
@@ -43,6 +43,7 @@ export interface MessengerOrderItem {
 
 export interface MessengerOrder {
   id: string;
+  displayId?: string;
   deliveryId: string;
   secret?: string;
   paymentId: string | null;

--- a/src/pages/delivery/order/[orderId].astro
+++ b/src/pages/delivery/order/[orderId].astro
@@ -1,0 +1,17 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navbar from '../../../components/Navbar';
+import RouteGuard from '../../../components/RouteGuard';
+import DeliveryOrderDetailPage from '../../../features/mensajero/components/DeliveryOrderDetailPage';
+
+const { orderId } = Astro.params;
+---
+
+<Layout title="Detalle de entrega | SansiStore">
+  <Navbar client:load />
+  <main class="min-h-screen bg-bg-light pt-14 text-text-light">
+    <RouteGuard client:load allowedRoles={['mensajero']} roleName="Mensajero">
+      <DeliveryOrderDetailPage client:load orderId={orderId ?? ''} />
+    </RouteGuard>
+  </main>
+</Layout>

--- a/tests/courier-smoke.spec.ts
+++ b/tests/courier-smoke.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, type Page } from '@playwright/test';
 
+const acceptedOrderCode = 'pu4-qsc';
+const juanOrderCustomer = 'Juan Paredes';
+const carlosOrderCustomer = 'Carlos Flores';
+
 async function loginAsCourier(page: Page, email = 'luis.mensajero@est.umss.edu') {
   await page.goto('/login');
 
@@ -34,20 +38,59 @@ async function loginAsCourier(page: Page, email = 'luis.mensajero@est.umss.edu')
   await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 });
 }
 
+async function selectCourierSection(
+  page: Page,
+  buttonName: string | RegExp,
+  headingName: string | RegExp
+) {
+  const sectionButton = page.getByRole('button', { name: buttonName });
+  const buttonPattern =
+    typeof buttonName === 'string'
+      ? buttonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : buttonName.source;
+  const buttonFlags = typeof buttonName === 'string' ? '' : buttonName.flags;
+
+  await expect(sectionButton).toBeVisible({ timeout: 15_000 });
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(({ source, flags }) => {
+          const pattern = new RegExp(source, flags);
+          const button = [...document.querySelectorAll('button')].find((item) =>
+            pattern.test(item.textContent ?? '')
+          );
+
+          return Boolean(
+            button &&
+            Object.keys(button).some((key) => key.startsWith('__reactProps'))
+          );
+        }, { source: buttonPattern, flags: buttonFlags }),
+      { timeout: 15_000 }
+    )
+    .toBe(true);
+
+  await sectionButton.click();
+  await expect(page.getByRole('heading', { name: headingName })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
 test.describe('Courier smoke tests', () => {
   test('shows totals calculated from order items and allowed zone labels', async ({
     page,
   }) => {
     await loginAsCourier(page);
     await page.goto('/courier');
-    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
+    await selectCourierSection(page, 'Pedidos aceptados', 'Pedidos aceptados');
 
     const assignedOrder = page
       .locator('article')
-      .filter({ hasText: 'pu4-qsc' });
+      .filter({ hasText: acceptedOrderCode });
     await expect(assignedOrder).toBeVisible({ timeout: 15_000 });
-    await expect(assignedOrder.getByText('1x Detergente Liquido Ola Futuro Limpieza Completa 5 L — Bs 109')).toBeVisible();
-    await expect(assignedOrder.getByText('10x Leche PIL Natural 900 ml — Bs 9.7')).toBeVisible();
+    await expect(
+      assignedOrder.getByText('1x Detergente Liquido Ola Futuro Limpieza Completa 5 L')
+    ).toBeVisible();
+    await expect(assignedOrder.getByText('10x Leche PIL Natural 900 ml')).toBeVisible();
     await expect(assignedOrder.getByText('Cancha principal FCyT')).toBeVisible();
   });
 
@@ -55,26 +98,37 @@ test.describe('Courier smoke tests', () => {
     await loginAsCourier(page);
     await page.goto('/courier');
 
-    await page.getByRole('button', { name: 'Gestión Entregas' }).click();
-    await expect(page.locator('article').filter({ hasText: 'pu4-qsc' })).toHaveCount(0);
+    await selectCourierSection(page, /Gesti.*n Entregas/, /Gesti.*n Entregas/);
+    await expect(
+      page.locator('article').filter({ hasText: acceptedOrderCode })
+    ).toHaveCount(0);
 
-    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
-    await expect(page.locator('article').filter({ hasText: 'pu4-qsc' })).toHaveCount(1);
+    await selectCourierSection(page, 'Pedidos aceptados', 'Pedidos aceptados');
+    await expect(
+      page.locator('article').filter({ hasText: acceptedOrderCode })
+    ).toHaveCount(1);
   });
 
   test('opens buyer location in the internal Leaflet map', async ({ page }) => {
     await loginAsCourier(page);
     await page.goto('/courier');
-    await page.getByRole('button', { name: 'Pedidos aceptados' }).click();
+    await selectCourierSection(page, 'Pedidos aceptados', 'Pedidos aceptados');
 
     const assignedOrder = page
       .locator('article')
-      .filter({ hasText: 'pu4-qsc' });
+      .filter({ hasText: juanOrderCustomer });
     await expect(assignedOrder).toBeVisible({ timeout: 15_000 });
 
-    await assignedOrder.getByRole('link', { name: 'Abrir Maps' }).click();
+    const mapLink = assignedOrder.getByRole('link', { name: 'Abrir Maps' });
+    await expect(mapLink).toHaveAttribute(
+      'href',
+      /\/mapa\?lat=-17\.395102&lng=-66\.145782&order=[^&]+$/
+    );
+    await mapLink.click();
 
-    await expect(page).toHaveURL("/mapa?lat=-17.395102&lng=-66.145782&order=019e74a3-e030-74ce-9d9a-4b1d37b85d11_pu4-qsc");
+    await expect(page).toHaveURL(
+      /\/mapa\?lat=-17\.395102&lng=-66\.145782&order=[^&]+$/
+    );
     await expect(page.getByText('1x Detergente Liquido Ola Futuro Limpieza Completa 5 L')).toBeVisible();
     await expect(page.getByText('10x Leche PIL Natural 900 ml')).toBeVisible();
   });
@@ -85,7 +139,9 @@ test.describe('Courier smoke tests', () => {
     await loginAsCourier(page, 'nadia.mensajero@est.umss.edu');
     await page.goto('/courier');
 
-    const assignedOrder = page.locator('article').filter({ hasText: 'wab-4ok' });
+    const assignedOrder = page
+      .locator('article')
+      .filter({ hasText: carlosOrderCustomer });
     await expect(assignedOrder).toBeVisible({ timeout: 15_000 });
 
     await assignedOrder.getByRole('button', { name: 'Aceptar pedido' }).click();

--- a/tests/failed-orders.spec.ts
+++ b/tests/failed-orders.spec.ts
@@ -5,21 +5,18 @@ const FIRESTORE_DOCUMENTS_URL =
 
 const restoreOrderByProject: Record<
   string,
-  { customer: string; orderId: string; productId: string }
+  { customer: string; productId: string }
 > = {
   chromium: {
     customer: 'Restore Chromium',
-    orderId: '019e74a6-1001-7000-bbbb-000000000001_restore-chromium',
     productId: 'galletas-agua-victoria-120-gr',
   },
   firefox: {
     customer: 'Restore Firefox',
-    orderId: '019e74a6-1002-7000-bbbb-000000000002_restore-firefox',
     productId: 'arroz-grano-de-oro-caisy-1-kg',
   },
   webkit: {
     customer: 'Restore Webkit',
-    orderId: '019e74a6-1003-7000-bbbb-000000000003_restore-webkit',
     productId: 'aceite-fino-vegetal-900-ml',
   },
 };
@@ -34,6 +31,48 @@ async function readFirestoreDocument(documentPath: string) {
   const response = await fetch(`${FIRESTORE_DOCUMENTS_URL}/${documentPath}`);
   expect(response.ok).toBeTruthy();
   return response.json();
+}
+
+async function findFirestoreOrderIdByCustomer(customerName: string) {
+  const response = await fetch(`${FIRESTORE_DOCUMENTS_URL}:runQuery`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId: 'orders' }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'customerName' },
+            op: 'EQUAL',
+            value: { stringValue: customerName },
+          },
+        },
+        limit: 1,
+      },
+    }),
+  });
+
+  expect(response.ok).toBeTruthy();
+
+  const results = (await response.json()) as Array<{
+    document?: { name?: string };
+  }>;
+  const documentName = results.find((entry) => entry.document?.name)?.document?.name;
+
+  if (!documentName) {
+    throw new Error(`No se encontro pedido para ${customerName}.`);
+  }
+
+  const segments = documentName.split('/');
+  const orderId = segments[segments.length - 1];
+
+  if (!orderId) {
+    throw new Error(`No se pudo resolver el ID del pedido para ${customerName}.`);
+  }
+
+  return orderId;
 }
 
 /**
@@ -176,6 +215,7 @@ test.describe('Pedidos con fallos', () => {
     const reservedBefore = readNumberField(inventoryBefore.fields.stockReserved);
     const availableBefore = readNumberField(inventoryBefore.fields.stockAvailable);
     const totalBefore = readNumberField(inventoryBefore.fields.stockTotal);
+    const restoredOrderId = await findFirestoreOrderIdByCustomer(restoreOrder.customer);
 
     const card = page
       .locator('button')
@@ -197,7 +237,7 @@ test.describe('Pedidos con fallos', () => {
 
     await expect
       .poll(async () => {
-        const orderDoc = await readFirestoreDocument(`orders/${restoreOrder.orderId}`);
+        const orderDoc = await readFirestoreDocument(`orders/${restoredOrderId}`);
         return orderDoc.fields.stockRestored?.booleanValue === true;
       })
       .toBe(true);

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -114,23 +114,30 @@ export default async function globalSetup() {
   console.log(
     `Waiting up to ${EMULATOR_STARTUP_TIMEOUT_MS}ms for emulators to become ready...`
   );
-  emulatorProcess = spawn(
-    process.platform === 'win32' ? 'npx.cmd' : 'npx',
-    [
-      'firebase-tools',
-      'emulators:start',
-      '--only',
-      'firestore,auth',
-      '--project',
-      'sansistore',
-      '--config',
-      'firebase.testing.json',
-    ],
-    {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      detached: false,
-    }
-  );
+  const emulatorCommand = process.platform === 'win32' ? 'cmd.exe' : 'npx';
+  const emulatorArgs =
+    process.platform === 'win32'
+      ? [
+          '/d',
+          '/s',
+          '/c',
+          'npx firebase-tools emulators:start --only firestore,auth --project sansistore --config firebase.testing.json',
+        ]
+      : [
+          'firebase-tools',
+          'emulators:start',
+          '--only',
+          'firestore,auth',
+          '--project',
+          'sansistore',
+          '--config',
+          'firebase.testing.json',
+        ];
+
+  emulatorProcess = spawn(emulatorCommand, emulatorArgs, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
 
   if (emulatorProcess.stderr) {
     emulatorProcess.stderr.on('data', (data) => {


### PR DESCRIPTION
## Resumen

Se agrega una ruta estable de detalle para pedidos del mensajero (`/delivery/order/[orderId]`) para que el pedido siga visible después de cambiar de estado. También se ajusta el flujo desde la lista para navegar al detalle al aceptar, rechazar o iniciar una entrega.

## URL de los cambios

- URL: http://localhost:4321/delivery/order/019e74a3-d006-739e-b281-04a5a451ecca_jm3-udk
- Ruta o pantalla afectada: Mensajero / Entregas / Detalle de pedido

## Cómo probar

1. Iniciar sesión como mensajero y entrar a `/courier`.
2. Abrir un pedido asignado con `Ver detalle` o aceptar un pedido desde la lista.
3. Cambiar el estado del pedido, por ejemplo `Aceptar pedido` y luego `Iniciar entrega`.

## Resultado esperado

El pedido debe permanecer visible en `/delivery/order/[orderId]` después de cambiar de estado. La pantalla debe actualizar el estado del mismo pedido y mostrar las acciones correspondientes sin obligar al mensajero a buscarlo en otra sección.

## Evidencia visual

| Antes | Después |
| --- | --- |
| No aplica | 
<img width="1245" height="656" alt="image" src="https://github.com/user-attachments/assets/c749cd28-dc02-44f2-b4db-26404b1b7f1e" />
 |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #438

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Se probó localmente con emuladores y seed. Flujo validado: `Asignado -> Aceptado`, `Aceptado -> En camino` y `Asignado -> Pendiente de reasignacion`, manteniendo siempre visible el detalle del pedido.
