### PR TITLE
fix: fixed stockTotal updated correctly after returned orders

### DIFF
--- a/src/features/inventory/components/OrderDispatch.tsx
+++ b/src/features/inventory/components/OrderDispatch.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-// Añadidos writeBatch e increment para la actualización atómica del stock
 import { collection, query, where, onSnapshot, getDocs, doc, updateDoc, serverTimestamp, getDoc, writeBatch, increment } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth'; // Para obtener el operador actual
+import { getAuth } from 'firebase/auth'; // Operador actual
 import { db } from '@/lib/firebase';
 import { PackageSearch, PackageCheck, AlertCircle, CheckCircle2, Play, X, ListFilter, User, ArchiveRestore, CheckSquare } from 'lucide-react';
 import { parseOrderId } from '@/features/cart/services/orderService';
@@ -145,15 +144,15 @@ export const OrderDispatch: React.FC = () => {
 
       const orderRef = doc(db, 'orders', order.id);
       batch.update(orderRef, {
-        status: 'PEDIDO_CERRADO', 
+        status: 'CERRADO', 
         stockReturnedAt: serverTimestamp(),
         returnedByOperator: operatorName
       });
 
       order.items.forEach((item) => {
-        const productRef = doc(db, 'products', item.productId);
+        const productRef = doc(db, 'inventory', item.productId);
         batch.update(productRef, {
-          stock: increment(item.quantity)
+          stockTotal: increment(item.quantity)
         });
 
         const movementRef = doc(collection(db, 'inventoryMovements'));

--- a/src/features/inventory/components/StockMovementForm.tsx
+++ b/src/features/inventory/components/StockMovementForm.tsx
@@ -76,7 +76,7 @@ export const StockMovementForm: React.FC = () => {
       // Actualización atómica
       batch.set(inventoryRef, {
         stockTotal: increment(qtyChange),
-        stockAvailable: increment(qtyChange),
+        stockAvailable: increment(qtyChange),// el disponible tambien debberia ser incrementado
         updatedAt: serverTimestamp(),
         enabled: true
       }, { merge: true });


### PR DESCRIPTION
## Resumen

Se corrigio la actualizacion de stock de productos cuando son devueltos al inventario

## URL de los cambios

inventory/packaging

- VER DETALLES -> ACTUALIZAR STOCK -> (Ahora actualiza la tabla inventory, el campo stockTotal, incrementando el stock devuelto de cada producto de la orden respectivamente)


## Cómo probar


1. Iniciar sesion como operador
2. Verificar en PANEL GENERAL, el stock fisico (stockTotal) actual, para posteriormente comparar si realmente incrementa despues de una devolucion correcta.
3. Ir a la seccion de MIS EMPAQUES
4. Ir al filtro de DEVUELTO
5. Dar a VER DETALLES
6.  Marcar cada producto a devolver
7. Clic en ACTUALIZAR STOCK
8. Verificar desde la seccion de PANEL GENERAL que el stock Fisico (stockTotal) del o los productos seleccionado incrementó. 

## Resultado esperado

stockTotal de cada producto de un pedido DEVUELTO debe incrementarse correctamente

## Evidencia visual

No aplica

## Tipo de cambio

- [ ] Nueva funcionalidad
- [X] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
US #68  

## Checklist del autor

- [X] Probé el cambio localmente
- [X] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [X] No hay errores ni warnings nuevos conocidos
- [X] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Ningún riesgo
