### PR TITLE
fixed: update in inventory stock by product, stockAvailable wasnt cha…

### DIFF
--- a/src/features/inventory/components/OrderDispatch.tsx
+++ b/src/features/inventory/components/OrderDispatch.tsx
@@ -152,7 +152,8 @@ export const OrderDispatch: React.FC = () => {
       order.items.forEach((item) => {
         const productRef = doc(db, 'inventory', item.productId);
         batch.update(productRef, {
-          stockTotal: increment(item.quantity)
+          stockTotal: increment(item.quantity),
+          stockAvailable: increment(item.quantity)
         });
 
         const movementRef = doc(collection(db, 'inventoryMovements'));


### PR DESCRIPTION

## Resumen

Se corrigio la actualizacion de stock de productos cuando son devueltos al inventario.
FALTÓ añadir stockAvailable

## URL de los cambios

inventory/packaging

- VER DETALLES -> ACTUALIZAR STOCK -> (Ahora actualiza la tabla inventory, el campo stockTotal, y stockAvailable incrementando el stock devuelto de cada producto de la orden respectivamente)


## Cómo probar


1. Iniciar sesion como operador
2. Verificar en PANEL GENERAL, el stock fisico (stockTotal) actual, para posteriormente comparar si realmente incrementa despues de una devolucion correcta.
3. Ir a la seccion de MIS EMPAQUES
4. Ir al filtro de DEVUELTO
5. Dar a VER DETALLES
6.  Marcar cada producto a devolver
7. Clic en ACTUALIZAR STOCK
8. Verificar desde la seccion de PANEL GENERAL que el stock Fisico (stockTotal y stockAvailable) del o los productos seleccionado incrementó. 

## Resultado esperado

stockTotal y stockAvailable de cada producto de un pedido DEVUELTO debe incrementarse correctamente

## Evidencia visual

No aplica

## Tipo de cambio

- [ ] Nueva funcionalidad
- [X] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
US #68  

## Checklist del autor

- [X] Probé el cambio localmente
- [X] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [X] No hay errores ni warnings nuevos conocidos
- [X] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Ningún riesgo

