### PR TITLE
fix: use regex for umss.edu domain validation in users API and UserEd…

### DIFF
--- a/src/features/admin/users/components/UserEditModal.tsx
+++ b/src/features/admin/users/components/UserEditModal.tsx
@@ -73,19 +73,9 @@ export default function UserEditModal({
       setError("Ingrese un correo electrónico válido.");
       return;
     }
-    const allowedDomains = [
-      'umss.edu',
-      'umss.edu.bo',
-      'est.umss.edu',
-      'est.umss.edu.bo',
-      'mi.umss.edu',
-      'ms.umss.edu',
-      'fcyt.umss.edu.bo',
-      'dicyt.umss.edu.bo',
-      'posgrado.umss.edu.bo',
-    ];
     const domain = email.trim().split('@')[1];
-    if (!domain || !allowedDomains.includes(domain)) {
+    const validUmssDomain = /(?:^|\.)umss\.edu(?:\.|$)/.test(domain ?? '');
+    if (!domain || !validUmssDomain) {
       setError("Solo se permiten cuentas institucionales UMSS.");
       return;
     }

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -3,19 +3,8 @@ import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { adminAuth, adminDb } from '../../lib/firebase-admin';
 
 const ALLOWED_ROLES = ['admin', 'vendedor', 'mensajero', 'operador_inv', 'comprador'] as const;
-const ALLOWED_INSTITUTIONAL_DOMAINS = [
-  'umss.edu',
-  'umss.edu.bo',
-  'est.umss.edu',
-  'est.umss.edu.bo',
-  'mi.umss.edu',
-  'ms.umss.edu',
-  'fcyt.umss.edu.bo',
-  'dicyt.umss.edu.bo',
-  'posgrado.umss.edu.bo',
-] as const;
+
 type AllowedRole = (typeof ALLOWED_ROLES)[number];
-type AllowedInstitutionalDomain = (typeof ALLOWED_INSTITUTIONAL_DOMAINS)[number];
 const devAdminBypassEnabled =
   import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
   import.meta.env.PUBLIC_APP_ENV !== 'production';
@@ -112,7 +101,7 @@ function getEmailDomain(email: string) {
 
 function isAllowedInstitutionalEmail(email: string) {
   const domain = getEmailDomain(email);
-  return ALLOWED_INSTITUTIONAL_DOMAINS.includes(domain as AllowedInstitutionalDomain);
+  return /(?:^|\.)umss\.edu(?:\.|$)/.test(domain);
 }
 
 function isValidPhoneNumber(phoneNumber: string) {


### PR DESCRIPTION
## Resumen
Corrige la validación de correo institucional en el modal de edición de usuario y en el endpoint `/api/users`, reemplazando una validación frágil por una regex que acepta cualquier subdominio de `umss.edu` sin importar variantes o extensiones.

## URL de los cambios
- URL: `http://localhost:4321/admin`
- Ruta o pantalla afectada: Panel Admin → Usuarios → Editar usuario

## Cómo probar
1. Ir a `/admin` → sección **Usuarios** → editar cualquier usuario
2. En el campo Email, intentar guardar con un correo inválido como `test@gmail.com` o `hacker@falsoumss.edu` → debe rechazarlo
3. Probar con correos válidos:
   - `usuario@umss.edu` → debe aceptar
   - `usuario@umss.edu.bo` → debe aceptar
   - `usuario@est.umss.edu` → debe aceptar
   - `usuario@fcyt.umss.edu` → debe aceptar
   - `usuario@cualquier.subdominio.umss.edu` → debe aceptar
4. Repetir lo mismo desde el endpoint directamente con un PATCH a `/api/users`

## Resultado esperado
- Cualquier correo cuyo dominio sea `umss.edu` o un subdominio de `umss.edu` es aceptado
- Correos con dominios que solo contienen la cadena `umss.edu` sin ser subdominios reales (ej. `falsoumss.edu`) son rechazados
- El mensaje de error es claro: "Solo se permiten cuentas institucionales UMSS"

## Evidencia visual
| Antes | Después |
| --- | --- |
| Solo aceptaba dominios hardcodeados específicos | Acepta cualquier subdominio de umss.edu |

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
No aplica

## Checklist del autor
- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa
- La validación usa la regex `/(?:^|\.)umss\.edu(?:\.|$)/` tanto en el frontend (`UserEditModal.tsx`) como en el backend (`users.ts`), asegurando consistencia en ambas capas.
- El caso `falsoumss.edu` es bloqueado correctamente porque la regex exige un punto o inicio de cadena antes de `umss.edu`.
- Se modificaron dos archivos: `src/features/admin/users/components/UserEditModal.tsx` y `src/pages/api/users.ts`.