### PR TITLE
Add clear cart feature and tests

### DIFF
--- a/src/features/cart/components/CartView.tsx
+++ b/src/features/cart/components/CartView.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Loader2,
   ShoppingBag,
+  Trash2,
 } from 'lucide-react';
 import { doc, getDoc } from 'firebase/firestore';
 import { CartItemRow } from './CartItemRow';
@@ -15,6 +16,7 @@ import { LocationSelectorModal } from './LocationSelectorModal';
 import { PaymentConfirmModal } from './PaymentConfirmModal';
 import { OrderSuccessModal } from './OrderSuccessModal';
 import { RemoveItemModal } from './RemoveItemModal';
+import { ClearCartModal } from './ClearCartModal';
 import type { CartItemWithProduct } from '../types';
 import { useCartContext, CartProvider } from './CartContext';
 import { db } from '../../../lib/firebase';
@@ -29,6 +31,7 @@ function CartViewInner() {
     updateQuantity,
     setQuantity,
     removeItem,
+    clearCart,
     items,
   } = useCartContext();
   const { user, authReady } = useAuthUser();
@@ -42,6 +45,7 @@ function CartViewInner() {
     null
   );
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showClearCartModal, setShowClearCartModal] = useState(false);
   const [showLocationModal, setShowLocationModal] = useState(false);
   const [showPaymentConfirmModal, setShowPaymentConfirmModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
@@ -309,9 +313,19 @@ function CartViewInner() {
 
       <div className="grid gap-4 md:gap-6 md:grid-cols-3 md:items-start">
         <section className="min-w-0 rounded-xl border border-border-light bg-card-bg-light p-3 sm:p-4 md:col-span-2">
-          <h2 className="mb-2 text-base sm:text-lg font-semibold">
-            Productos ({enriched.length})
-          </h2>
+          <div className="mb-4 flex items-center justify-between border-b border-border-light pb-2">
+            <h2 className="text-base sm:text-lg font-semibold">
+              Productos ({enriched.length})
+            </h2>
+            <button
+              type="button"
+              onClick={() => setShowClearCartModal(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+            >
+              <Trash2 size={14} />
+              Vaciar carrito
+            </button>
+          </div>
           {enriched.map((item) => {
             const effectiveStock = Math.max(
               0,
@@ -525,6 +539,15 @@ function CartViewInner() {
         )}
         {showSuccessModal && (
           <OrderSuccessModal onClose={() => setShowSuccessModal(false)} />
+        )}
+        {showClearCartModal && (
+          <ClearCartModal
+            onClose={() => setShowClearCartModal(false)}
+            onConfirm={async () => {
+              await clearCart();
+              setShowClearCartModal(false);
+            }}
+          />
         )}
       </div>
     </div>

--- a/src/features/cart/components/ClearCartModal.tsx
+++ b/src/features/cart/components/ClearCartModal.tsx
@@ -1,0 +1,67 @@
+import { Trash2, X } from 'lucide-react';
+
+interface Props {
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function ClearCartModal({ onClose, onConfirm }: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="clear-cart-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative z-10 w-full max-w-sm rounded-2xl border border-border-light bg-card-bg-light p-6 shadow-2xl">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-500/15 text-red-500 dark:text-red-400">
+            <Trash2 size={18} />
+          </div>
+          <h2
+            id="clear-cart-title"
+            className="text-lg font-bold text-text-light"
+          >
+            Vaciar carrito
+          </h2>
+        </div>
+
+        <p className="mt-4 text-sm leading-relaxed text-text-light opacity-70">
+          ¿Está seguro/a de que quieres eliminar todos los productos del carrito? Esta acción no se puede deshacer.
+        </p>
+
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-full border border-border-light bg-transparent px-4 py-3 text-sm font-semibold text-text-light transition hover:bg-secondary-bg-light active:scale-95"
+          >
+            Cancelar
+          </button>
+
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex-1 rounded-full bg-red-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-red-700 active:scale-95"
+          >
+            Vaciar
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-border-light text-text-light opacity-70 transition hover:opacity-100"
+          aria-label="Cerrar modal"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cart/hooks/useCart.ts
+++ b/src/features/cart/hooks/useCart.ts
@@ -10,8 +10,8 @@ import {
   onSnapshot,
 } from 'firebase/firestore';
 import { auth, db } from '../../../lib/firebase';
-import { getLocalCart, addToLocalCart, updateLocalCartQuantity, setQuantityLocalCart, removeFromLocalCart, getTotalUnits, saveLocalCart } from '../utils/localCart';
-import { syncCartToFirestore, upsertCartItem, deleteCartItem } from '../services/cartFirestore';
+import { getLocalCart, addToLocalCart, updateLocalCartQuantity, setQuantityLocalCart, removeFromLocalCart, getTotalUnits, saveLocalCart, clearLocalCart } from '../utils/localCart';
+import { syncCartToFirestore, upsertCartItem, deleteCartItem, clearCartFirestore } from '../services/cartFirestore';
 import { notifyCartUpdate } from '../store/cartStore';
 import type { LocalCartItem, CartProduct, CartItemWithProduct } from '../types';
 
@@ -331,6 +331,20 @@ export function useCart() {
 
   const clearError = useCallback(() => setError(null), []);
 
+  const clearCart = useCallback(async () => {
+    clearLocalCart();
+    setItems([]);
+    setTotalUnits(0);
+    notifyCartUpdate(0);
+    if (uidRef.current) {
+      try {
+        await clearCartFirestore(uidRef.current);
+      } catch (error) {
+        console.error('Failed to clear firestore cart:', error);
+      }
+    }
+  }, []);
+
   return {
     items,
     itemsWithProducts,
@@ -341,6 +355,7 @@ export function useCart() {
     updateQuantity,
     setQuantity,
     removeItem,
+    clearCart,
     clearError,
   };
 }

--- a/src/features/cart/services/cartFirestore.ts
+++ b/src/features/cart/services/cartFirestore.ts
@@ -47,3 +47,11 @@ export async function deleteCartItem(uid: string, productId: string): Promise<vo
   const ref = doc(db, 'users', uid, 'cartItems', productId);
   await deleteDoc(ref);
 }
+
+export async function clearCartFirestore(uid: string): Promise<void> {
+  const batch = writeBatch(db);
+  const colRef = cartCol(uid);
+  const snap = await getDocs(colRef);
+  snap.docs.forEach((d) => batch.delete(d.ref));
+  await batch.commit();
+}

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -127,6 +127,43 @@ async function updateTestInventory(productId: string, data: Record<string, unkno
   await mirrorDocumentToDefaultEmulator('inventory', productId, data);
 }
 
+async function createTestAuthUser({
+  uid,
+  email,
+  displayName,
+}: {
+  uid: string;
+  email: string;
+  displayName: string;
+}) {
+  if (admin.apps.length === 0) {
+    admin.initializeApp({ projectId: PROJECT_ID });
+  }
+
+  process.env.FIREBASE_AUTH_EMULATOR_HOST =
+    process.env.FIREBASE_AUTH_EMULATOR_HOST || '127.0.0.1:9199';
+
+  try {
+    await admin.auth().createUser({
+      uid,
+      email,
+      password: '12345678',
+      displayName,
+    });
+  } catch {
+    // Ignore if already created
+  }
+
+  const db = admin.firestore();
+  await db.collection('users').doc(uid).set({
+    uid,
+    email,
+    displayName,
+    roles: ['comprador'],
+    isActive: true,
+  });
+}
+
 async function seedLocalCart(
   page: Page,
   productId: string,
@@ -407,5 +444,89 @@ test.describe('Cart - Carrito', () => {
     });
 
     await expect(page.getByTestId(`cart-item-image-fallback-${productId}`)).toBeVisible();
+  });
+
+  test('should clear local storage cart for guest/anonymous user', async ({ page }) => {
+    await page.goto('/productos/leche-pil-natural-900-ml');
+    const addToCartBtn = page.getByRole('button', { name: 'Agregar al carrito' });
+    await expect(addToCartBtn).toBeVisible();
+    await addToCartBtn.click();
+    await expect(page.getByLabel(/Carrito, [^0]/)).toBeVisible({ timeout: 10_000 });
+
+    await page.goto('/carrito');
+    await expectFilledCartPage(page);
+    
+    await expect(page.locator('a').filter({ hasText: 'Leche PIL Natural 900 ml' }).first()).toBeVisible();
+    const clearCartBtn = page.getByRole('button', { name: 'Vaciar carrito' });
+    await expect(clearCartBtn).toBeVisible();
+
+    await clearCartBtn.click();
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.getByRole('heading', { name: 'Vaciar carrito' })).toBeVisible();
+
+    await modal.getByRole('button', { name: 'Cancelar' }).click();
+    await expect(modal).not.toBeVisible();
+    await expect(page.locator('a').filter({ hasText: 'Leche PIL Natural 900 ml' }).first()).toBeVisible();
+
+    await clearCartBtn.click();
+    await expect(modal).toBeVisible();
+    await modal.getByRole('button', { name: 'Vaciar' }).click();
+
+    await expect(modal).not.toBeVisible();
+    await expect(page.getByText('Tu carrito está vacío')).toBeVisible();
+    
+    const localStorageCart = await page.evaluate((key) => window.localStorage.getItem(key), CART_KEY);
+    expect(localStorageCart === null || JSON.parse(localStorageCart).length === 0).toBe(true);
+  });
+
+  test('should clear Firestore cart for authenticated user', async ({ page }, testInfo) => {
+    const workerId = testInfo.workerIndex;
+    const uid = `user-clear-cart-${workerId}`;
+    const email = `clear.cart.${workerId}@est.umss.edu`;
+    const displayName = `Test Clear Cart ${workerId}`;
+    const productId = `test-clear-prod-${workerId}`;
+    const productName = `Product Clear Cart ${workerId}`;
+
+    await createTestAuthUser({ uid, email, displayName });
+
+    await createTestProduct({
+      productId,
+      name: productName,
+      price: 15,
+    });
+
+    const db = getTestDb();
+    await db.collection('users').doc(uid).collection('cartItems').doc(productId).set({
+      cartItemId: `cart-${uid}-1`,
+      userId: uid,
+      productId,
+      quantity: 3,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    await loginWithEmail(page, email);
+
+    await page.goto('/carrito');
+    await expectFilledCartPage(page);
+    await expect(page.locator('a').filter({ hasText: productName }).first()).toBeVisible();
+    
+    const clearCartBtn = page.getByRole('button', { name: 'Vaciar carrito' });
+    await expect(clearCartBtn).toBeVisible();
+
+    await clearCartBtn.click();
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+    await modal.getByRole('button', { name: 'Vaciar' }).click();
+
+    await expect(modal).not.toBeVisible();
+    await expect(page.getByText('Tu carrito está vacío')).toBeVisible();
+
+    await expect.poll(async () => {
+      const snap = await db.collection('users').doc(uid).collection('cartItems').get();
+      return snap.empty;
+    }, {
+      timeout: 15_000,
+    }).toBe(true);
   });
 });


### PR DESCRIPTION
This PR adds the functionality to clear the entire shopping cart (for both guest and authenticated users) with a confirmation modal and its corresponding end-to-end integration tests.

### Changes:
* **UI/UX:** Added the "Vaciar carrito" (Clear Cart) button next to the title in the cart section.
* **Modal:** Created `ClearCartModal` to request confirmation before clearing the cart and prevent accidental deletions.
* **Persistence:** Implemented atomic deletion in Firestore for authenticated users using `writeBatch`, and cleared `localStorage` for guest users.
* **E2E Tests:** Added Playwright tests validating the flow for both guests and authenticated users in an isolated and concurrent environment.

Resolves the following issues:
* Closes #554
* Closes #555
