### PR TITLE
Fix/delivery UI standard

### DIFF
--- a/src/features/mensajero/components/CourierDashboard.tsx
+++ b/src/features/mensajero/components/CourierDashboard.tsx
@@ -80,7 +80,7 @@ function OrderDetailView({
 }) {
   return (
     <section className={pageClassName}>
-      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
         <button
           type="button"
           onClick={onBack}
@@ -106,7 +106,7 @@ function OrderDetailView({
                 <h2 className="text-2xl font-black tracking-[-0.04em]">
                   {selectedOrder.displayId}
                 </h2>
-                <span className={`${badgeClass} bg-[#fff2b8] py-1 text-[#aa7300]`}>
+                <span className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}>
                   Cobrar
                 </span>
                 <span className={`${badgeClass} bg-primary/10 py-1 text-primary`}>
@@ -122,7 +122,7 @@ function OrderDetailView({
               </div>
 
               {!selectedOrderHasValidAmount ? (
-                <div className="mt-5 rounded-2xl border border-[#f59e0b]/25 bg-[#fff7ed] px-4 py-3 text-sm font-semibold text-[#9a3412] dark:border-[#f59e0b]/20 dark:bg-[#2a2117] dark:text-[#fdba74]">
+                <div className="mt-5 rounded-2xl border border-(--theme-warning-border) bg-(--theme-warning-bg) px-4 py-3 text-sm font-semibold text-(--theme-warning)">
                   {INVALID_AMOUNT_MESSAGE}
                 </div>
               ) : null}
@@ -258,7 +258,7 @@ function OrderDetailView({
                   {formatMoney(selectedOrder.total)}
                 </p>
               ) : (
-                <p className="mt-2 text-base font-semibold leading-6 text-[#9a3412] dark:text-[#fdba74]">
+                <p className="mt-2 text-base font-semibold leading-6 text-(--theme-warning)">
                   {INVALID_AMOUNT_MESSAGE}
                 </p>
               )}
@@ -490,7 +490,7 @@ export default function CourierDashboard({ embedded = false }: { embedded?: bool
 
   return (
     <section className={getPageClass(embedded)}>
-      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
         <div className="mb-10 flex flex-col gap-3">
           <p className="text-sm font-bold uppercase tracking-[0.28em] text-primary">
             Operacion de entregas
@@ -517,7 +517,7 @@ export default function CourierDashboard({ embedded = false }: { embedded?: bool
         <div className="mb-8 grid gap-5 lg:grid-cols-3">
           <article className={cardBaseClass}>
             <div className="flex items-center gap-5">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-[#fff2b8] text-[#d08a00]">
+              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-(--theme-warning-bg) text-(--theme-warning)">
                 <Box className="h-8 w-8" />
               </div>
               <div>
@@ -575,7 +575,7 @@ export default function CourierDashboard({ embedded = false }: { embedded?: bool
           </div>
 
           {errorMessage ? (
-            <div className="border-b border-[#f97316]/15 bg-[#fff7ed] px-8 py-4 text-sm font-semibold text-[#9a3412] dark:border-[#f97316]/10 dark:bg-[#2a2117] dark:text-[#fdba74]">
+            <div className="border-b border-(--theme-warning-border) bg-(--theme-warning-bg) px-8 py-4 text-sm font-semibold text-(--theme-warning)">
               {errorMessage}
             </div>
           ) : null}
@@ -641,7 +641,7 @@ export default function CourierDashboard({ embedded = false }: { embedded?: bool
                         </td>
                         <td className="px-8 py-5">
                           <span
-                            className={`${badgeClass} bg-[#fff2b8] py-1 text-[#aa7300]`}
+                            className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}
                           >
                             {order.paymentStatusLabel}
                           </span>
@@ -651,7 +651,7 @@ export default function CourierDashboard({ embedded = false }: { embedded?: bool
                             <button
                               type="button"
                               onClick={() => setSelectedOrder(order)}
-                              className="inline-flex items-center gap-2 rounded-2xl bg-text-light px-5 py-3 text-sm font-bold text-bg-light transition hover:opacity-90"
+                              className="inline-flex items-center gap-2 rounded-2xl bg-(--theme-text) px-5 py-3 text-sm font-bold text-(--theme-bg) transition hover:opacity-90"
                             >
                               <Eye className="h-4 w-4" />
                               Ver detalle

--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -167,7 +167,7 @@ function DetailActions({
 
       {order.deliveryStatus === 'accepted' && (
         <button
-          className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl bg-blue-600 px-6 text-sm font-bold text-white shadow-lg transition hover:bg-blue-700"
+          className="messenger-transit-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold shadow-lg transition"
           onClick={onInTransit}
           type="button"
         >
@@ -397,7 +397,7 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
 
   if (loading) {
     return (
-      <section className="mx-auto flex min-h-[55vh] max-w-5xl items-center justify-center px-4">
+      <section className="mx-auto flex min-h-[55vh] max-w-6xl items-center justify-center px-4">
         <div className="messenger-order-card flex items-center gap-3 rounded-[28px] border p-8 text-sm font-bold">
           <LoaderCircle className="animate-spin" size={20} />
           Cargando detalle del pedido...
@@ -408,7 +408,7 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
 
   if (!order) {
     return (
-      <section className="mx-auto max-w-5xl px-4 py-10">
+      <section className="mx-auto max-w-6xl px-4 py-10">
         <a
           className="messenger-map-button mb-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl border-2 px-5 text-sm font-bold transition"
           href="/courier"
@@ -463,7 +463,7 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
           <div
             className={`mt-6 rounded-2xl border px-4 py-3 text-sm font-bold ${
               error
-                ? 'border-red-500/40 bg-red-500/10 text-red-500'
+                ? 'border-(--theme-error-border) bg-(--theme-error-bg) text-(--theme-error)'
                 : 'border-primary/30 bg-primary/10 text-primary'
             }`}
           >

--- a/src/features/mensajero/components/MessengerDashboard.css
+++ b/src/features/mensajero/components/MessengerDashboard.css
@@ -23,19 +23,19 @@
 }
 
 .messenger-header-inner {
-  width: min(100% - 32px, 1216px);
+  width: min(100% - 32px, 1152px);
   margin-inline: auto;
   min-height: 73px;
 }
 
 .messenger-container {
-  width: min(100% - 32px, 1280px);
+  width: min(100% - 32px, 1152px);
   margin-inline: auto;
   padding-block: 8px 40px;
 }
 
 .messenger-dashboard--embedded .messenger-container {
-  width: min(100% - 32px, 1280px);
+  width: min(100% - 32px, 1152px);
   padding-block: 8px 40px;
 }
 
@@ -53,7 +53,7 @@
 }
 
 .messenger-logo-accent {
-  color: #88b04b;
+  color: var(--color-primary);
 }
 
 .messenger-buyer-link {
@@ -63,8 +63,8 @@
 }
 
 .messenger-courier-link {
-  background: #88b04b;
-  color: #0a0b0d;
+  background: var(--color-primary);
+  color: var(--color-primary-action);
 }
 
 .messenger-muted,
@@ -74,8 +74,8 @@
 
 .messenger-icon,
 .messenger-icon--featured {
-  background: color-mix(in srgb, #88b04b 16%, var(--theme-card-bg));
-  color: #6f9438;
+  background: color-mix(in srgb, var(--color-primary) 16%, var(--theme-card-bg));
+  color: var(--color-primary);
 }
 
 .messenger-icon--featured {
@@ -84,25 +84,25 @@
 
 .messenger-summary-card--featured,
 .messenger-cash-box {
-  background: color-mix(in srgb, #88b04b 14%, var(--theme-card-bg));
-  border-color: color-mix(in srgb, #88b04b 58%, var(--theme-border));
-  color: #5f8330;
+  background: color-mix(in srgb, var(--color-primary) 14%, var(--theme-card-bg));
+  border-color: color-mix(in srgb, var(--color-primary) 58%, var(--theme-border));
+  color: var(--color-primary);
 }
 
 .messenger-charge-badge {
-  background: color-mix(in srgb, #facc15 22%, var(--theme-card-bg));
-  color: #8a6100;
+  background: var(--theme-warning-bg);
+  color: var(--theme-warning);
 }
 
 .messenger-status-badge {
-  background: color-mix(in srgb, #3b82f6 14%, var(--theme-card-bg));
-  color: #1d4ed8;
+  background: var(--theme-info-bg);
+  color: var(--theme-info);
 }
 
 .messenger-reference {
-  background: color-mix(in srgb, #facc15 18%, var(--theme-card-bg));
-  border-left-color: #ffb703;
-  color: #8a6100;
+  background: var(--theme-warning-bg);
+  border-left-color: var(--theme-warning-border);
+  color: var(--theme-warning);
 }
 
 .messenger-map-button {
@@ -112,41 +112,41 @@
 }
 
 .messenger-map-button:hover {
-  border-color: #88b04b;
-  color: #6f9438;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .messenger-transit-button {
-  background: #2563eb;
-  color: #ffffff;
+  background: var(--theme-info);
+  color: var(--theme-bg);
 }
 
 .messenger-transit-button:hover {
-  background: #1d4ed8;
+  opacity: 0.9;
 }
 
 .messenger-deliver-button {
-  background: #88b04b;
-  color: #0a0b0d;
+  background: var(--color-primary);
+  color: var(--color-primary-action);
 }
 
 .messenger-deliver-button:hover {
-  background: #9fc462;
+  opacity: 0.9;
 }
 
 .messenger-reject-button {
-  background: color-mix(in srgb, #ef4444 8%, var(--theme-card-bg));
-  border-color: color-mix(in srgb, #ef4444 46%, var(--theme-border));
-  color: #dc2626;
+  background: var(--theme-error-bg);
+  border-color: var(--theme-error-border);
+  color: var(--theme-error);
 }
 
 .messenger-reject-button:hover {
-  background: color-mix(in srgb, #ef4444 14%, var(--theme-card-bg));
+  opacity: 0.9;
 }
 
 .messenger-delivered-badge {
-  background: color-mix(in srgb, #88b04b 16%, var(--theme-card-bg));
-  color: #5f8330;
+  background: var(--theme-success-bg);
+  color: var(--theme-success);
 }
 
 /* Toast */
@@ -160,65 +160,25 @@
 }
 
 .messenger-toast--success {
-  background: color-mix(in srgb, #88b04b 12%, var(--theme-card-bg));
-  border-color: #88b04b;
-  color: #4a6b1f;
+  background: var(--theme-success-bg);
+  border-color: var(--theme-success-border);
+  color: var(--theme-success);
 }
 
 .messenger-toast--success .messenger-toast-dot {
-  background: #88b04b;
-  box-shadow: 0 0 0 4px color-mix(in srgb, #88b04b 25%, transparent);
+  background: var(--theme-success);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--theme-success) 25%, transparent);
 }
 
 .messenger-toast--error {
-  background: color-mix(in srgb, #ef4444 10%, var(--theme-card-bg));
-  border-color: #ef4444;
-  color: #b91c1c;
+  background: var(--theme-error-bg);
+  border-color: var(--theme-error-border);
+  color: var(--theme-error);
 }
 
 .messenger-toast--error .messenger-toast-dot {
-  background: #ef4444;
-  box-shadow: 0 0 0 4px color-mix(in srgb, #ef4444 25%, transparent);
-}
-
-/* Dark mode */
-html[data-theme='dark'] .messenger-icon,
-html[data-theme='dark'] .messenger-icon--featured {
-  color: #b7dc78;
-}
-
-html[data-theme='dark'] .messenger-summary-card--featured,
-html[data-theme='dark'] .messenger-cash-box {
-  color: #c4e48a;
-}
-
-html[data-theme='dark'] .messenger-charge-badge,
-html[data-theme='dark'] .messenger-reference {
-  color: #fde68a;
-}
-
-html[data-theme='dark'] .messenger-status-badge {
-  color: #93c5fd;
-}
-
-html[data-theme='dark'] .messenger-map-button:hover {
-  color: #b7dc78;
-}
-
-html[data-theme='dark'] .messenger-delivered-badge {
-  color: #b7dc78;
-}
-
-html[data-theme='dark'] .messenger-reject-button {
-  color: #fca5a5;
-}
-
-html[data-theme='dark'] .messenger-toast--success {
-  color: #b7dc78;
-}
-
-html[data-theme='dark'] .messenger-toast--error {
-  color: #fca5a5;
+  background: var(--theme-error);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--theme-error) 25%, transparent);
 }
 
 /* Responsive */
@@ -245,34 +205,34 @@ html[data-theme='dark'] .messenger-toast--error {
   width: 100%;
   max-width: 360px;
   background: var(--theme-card-bg);
-  border: 1.5px solid color-mix(in srgb, #88b04b 35%, var(--theme-border));
+  border: 1.5px solid color-mix(in srgb, var(--color-primary) 35%, var(--theme-border));
   border-radius: 1.25rem;
   padding: 20px;
   box-shadow:
-    0 12px 40px color-mix(in srgb, #88b04b 12%, transparent),
+    0 12px 40px color-mix(in srgb, var(--color-primary) 12%, transparent),
     0 4px 16px rgba(0, 0, 0, 0.08);
   animation: toast-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .messenger-new-order-icon {
-  background: color-mix(in srgb, #88b04b 14%, var(--theme-card-bg));
-  color: #6f9438;
+  background: color-mix(in srgb, var(--color-primary) 14%, var(--theme-card-bg));
+  color: var(--color-primary);
 }
 
 .messenger-new-order-close {
-  background: color-mix(in srgb, #88b04b 10%, var(--theme-card-bg));
-  color: #6f9438;
+  background: color-mix(in srgb, var(--color-primary) 10%, var(--theme-card-bg));
+  color: var(--color-primary);
   border: none;
   cursor: pointer;
 }
 
 .messenger-new-order-close:hover {
-  background: color-mix(in srgb, #88b04b 20%, var(--theme-card-bg));
+  background: color-mix(in srgb, var(--color-primary) 20%, var(--theme-card-bg));
 }
 
 .messenger-new-order-progress {
   height: 3px;
-  background: color-mix(in srgb, #88b04b 20%, var(--theme-card-bg));
+  background: color-mix(in srgb, var(--color-primary) 20%, var(--theme-card-bg));
   border-radius: 9999px;
   overflow: hidden;
   margin-top: 16px;
@@ -282,7 +242,7 @@ html[data-theme='dark'] .messenger-toast--error {
   display: block;
   height: 100%;
   width: 100%;
-  background: #88b04b;
+  background: var(--color-primary);
   border-radius: 9999px;
   animation: toast-progress 5s linear forwards;
 }
@@ -290,12 +250,6 @@ html[data-theme='dark'] .messenger-toast--error {
 @keyframes toast-progress {
   from { width: 100%; }
   to   { width: 0%; }
-}
-
-/* Dark mode */
-html[data-theme='dark'] .messenger-new-order-icon,
-html[data-theme='dark'] .messenger-new-order-close {
-  color: #b7dc78;
 }
 
 /* Mobile */

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -507,7 +507,7 @@ function PendingOrderCard({
 
                     {order.deliveryStatus === 'accepted' && (
                         <button
-                            className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl bg-blue-600 px-6 text-sm font-bold text-white shadow-lg transition hover:scale-[1.02] hover:bg-blue-700"
+                            className="messenger-transit-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold shadow-lg transition hover:scale-[1.02]"
                             onClick={() => onInTransit(order.id)}
                             type="button"
                         >
@@ -605,7 +605,7 @@ function OrderDetailModal({
                 if (event.target === event.currentTarget) onClose();
             }}
         >
-            <section className="max-h-[92vh] w-full max-w-5xl overflow-y-auto rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
+            <section className="max-h-[92vh] w-full max-w-6xl overflow-y-auto rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
                 <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
                     <div>
                         <h2 className="text-2xl font-black tracking-normal">
@@ -782,7 +782,7 @@ function OrderDetailModal({
 
                             {canCancelByNoPayment(order) && (
                                 <button
-                                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 border-red-500 bg-red-50 px-6 text-sm font-bold text-red-600 transition hover:bg-red-100 active:scale-95"
+                                    className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition active:scale-95"
                                     onClick={() => {
                                         onClose();
                                         onCancelNoPayment(order);
@@ -797,7 +797,7 @@ function OrderDetailModal({
                             {(order.deliveryStatus === 'accepted' ||
                                 order.deliveryStatus === 'in_transit') && (
                                     <button
-                                        className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 border-red-500 bg-red-50 px-6 text-sm font-bold text-red-600 transition hover:bg-red-100 active:scale-95"
+                                        className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition active:scale-95"
                                         onClick={() => {
                                             onClose();
                                             onNotDelivered(order);

--- a/src/features/mensajero/modals/CancelNoPaymentModal.tsx
+++ b/src/features/mensajero/modals/CancelNoPaymentModal.tsx
@@ -42,7 +42,7 @@ export default function CancelNoPaymentModal({
       <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
         <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
           <div className="flex items-center gap-4">
-            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-red-500/10 text-red-600">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-(--theme-error-bg) text-(--theme-error)">
               <DollarSign size={24} />
             </span>
 
@@ -84,7 +84,7 @@ export default function CancelNoPaymentModal({
             </div>
           </div>
 
-          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm font-semibold text-red-600">
+          <div className="rounded-2xl border border-(--theme-error-border) bg-(--theme-error-bg) p-4 text-sm font-semibold text-(--theme-error)">
             El pedido será marcado como CANCELADO porque el cliente no realizó
             el pago contra entrega.
           </div>
@@ -92,7 +92,7 @@ export default function CancelNoPaymentModal({
           <label className="block text-sm font-bold">
             Observaciones adicionales
             <textarea
-              className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-red-500"
+              className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-(--theme-error-border)"
               onChange={(event) => setNotes(event.target.value)}
               placeholder="Ej: El cliente indicó que no realizará el pago..."
               value={notes}
@@ -110,7 +110,7 @@ export default function CancelNoPaymentModal({
           </button>
 
           <button
-            className="inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full bg-red-600 px-5 text-sm font-black uppercase text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full bg-(--theme-error) px-5 text-sm font-black uppercase text-(--theme-bg) transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={isSaving}
             onClick={confirmCancellation}
             type="button"

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -20,7 +20,7 @@ const actionConfig = {
     buttonLabel: 'Confirmar',
     Icon: CheckCircle2,
     iconClassName: 'bg-primary/15 text-primary',
-    buttonClassName: 'bg-primary text-black hover:opacity-90',
+    buttonClassName: 'bg-primary text-primary-action hover:opacity-90',
     warning:
       'El pedido pasará a Pedidos aceptados y quedará bajo tu responsabilidad.',
   },
@@ -29,8 +29,8 @@ const actionConfig = {
     description: 'Confirma que no podrás atender este pedido asignado.',
     buttonLabel: 'Confirmar',
     Icon: XCircle,
-    iconClassName: 'bg-red-500/10 text-red-600',
-    buttonClassName: 'bg-red-600 text-white hover:bg-red-700',
+    iconClassName: 'bg-(--theme-error-bg) text-(--theme-error)',
+    buttonClassName: 'bg-(--theme-error) text-(--theme-bg) hover:opacity-90',
     warning:
       'El pedido quedará pendiente de reasignación para que el vendedor seleccione otro mensajero.',
   },

--- a/src/features/mensajero/modals/Confirmpaymentmodal.tsx
+++ b/src/features/mensajero/modals/Confirmpaymentmodal.tsx
@@ -122,7 +122,7 @@ const canSubmit = secret.trim().length > 0 && !saving;
                                     disabled={saving}
                                 />
                                 {error && (
-                                    <p className="text-xs font-bold text-red-500">{error}</p>
+                                    <p className="text-xs font-bold text-(--theme-error)">{error}</p>
                                 )}
                             </div>
 

--- a/src/features/mensajero/modals/PaymentSuccessModal.tsx
+++ b/src/features/mensajero/modals/PaymentSuccessModal.tsx
@@ -46,7 +46,7 @@ export default function PaymentSuccessModal({ onClose }: Props) {
           <button
             type="button"
             onClick={onClose}
-            className="flex w-full items-center justify-center rounded-full bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90 active:scale-95"
+            className="flex w-full items-center justify-center rounded-full bg-primary px-4 py-3 text-sm font-semibold text-primary-action transition hover:opacity-90 active:scale-95"
           >
             Aceptar
           </button>

--- a/src/features/mensajero/modals/UndeliveredModal.tsx
+++ b/src/features/mensajero/modals/UndeliveredModal.tsx
@@ -175,7 +175,7 @@ export default function UndeliveredModal({
             Cancelar
           </button>
           <button
-            className="inline-flex h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-black uppercase text-black transition disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-black uppercase text-primary-action transition disabled:cursor-not-allowed disabled:opacity-50"
             disabled={!canSubmit || isSaving}
             onClick={confirmIncident}
             type="button"

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -39,8 +39,7 @@ export function AssignMessengerModal({
             <div>
               <h2
                 id="assign-messenger-title"
-                className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
-                style={{ fontFamily: 'Outfit, sans-serif' }}
+                className="mt-2 font-display text-2xl font-bold tracking-tight text-(--theme-text)"
               >
                 #{order.orderId}
               </h2>
@@ -96,7 +95,7 @@ export function AssignMessengerModal({
                         }`}
                     >
                       <div className="flex items-center gap-3">
-                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-white' : 'bg-(--theme-secondary-bg)'}`}>
+                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'}`}>
                           <UserRound size={16} />
                         </span>
                         <div>
@@ -129,7 +128,7 @@ export function AssignMessengerModal({
                 type="button"
                 onClick={onConfirm}
                 disabled={!selectedCourierId || isLoading || messengersLoading}
-                className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-white transition hover:opacity-90 disabled:opacity-50"
+                className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
               >
                 {isLoading ? 'Asignando…' : 'Confirmar asignación'}
               </button>

--- a/src/features/seller/components/AssignOrderCard.tsx
+++ b/src/features/seller/components/AssignOrderCard.tsx
@@ -65,23 +65,17 @@ export function AssignOrderCard({
   return (
     <div
       className={`overflow-hidden rounded-[1.25rem] bg-(--theme-card-bg) transition-all duration-200 hover:-translate-y-px hover:shadow-lg ${isSuccess
-        ? 'shadow-[0_0_0_3px_rgba(136,176,75,0.25)]'
+        ? 'shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-primary)_25%,transparent)]'
         : 'border-(--theme-border)'
         }`}
     >
       <div className="p-4">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <p
-              className="font-800 text-xs tracking-tight text-(--theme-text) pb-2"
-              style={{ fontFamily: 'Outfit, sans-serif' }}
-            >
+            <p className="pb-2 font-display text-xs font-800 tracking-tight text-(--theme-text)">
               # {order.orderId?.toUpperCase()}
             </p>
-            <p
-              className="font-800 text-lg tracking-tight text-(--theme-text)"
-              style={{ fontFamily: 'Outfit, sans-serif' }}
-            >
+            <p className="font-display text-lg font-800 tracking-tight text-(--theme-text)">
               {order.buyerName?.toUpperCase()}
             </p>
 
@@ -129,7 +123,7 @@ export function AssignOrderCard({
               <button
                 onClick={() => onUnassign(order.orderId, order.deliveryId ?? '')}
                 disabled={isAssigning}
-                className="flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-white transition hover:opacity-90 active:scale-95 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-primary-action transition hover:opacity-90 active:scale-95 disabled:opacity-50"
               >
                 {isAssigning ? 'Cancelando…' : 'Cancelar'}
               </button>
@@ -195,7 +189,7 @@ export function AssignOrderCard({
                 <button
                   onClick={() => onReassign(order.orderId, order.deliveryId ?? '', selectedCourierId ?? '')}
                   disabled={!selectedCourierId || isAssigning || !order.deliveryId}
-                  className="flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-white transition hover:opacity-90 active:scale-95 disabled:opacity-50"
+                  className="flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-primary-action transition hover:opacity-90 active:scale-95 disabled:opacity-50"
                 >
                   {isAssigning ? 'Reasignando…' : 'Reasignar'}
                 </button>
@@ -263,7 +257,7 @@ export function AssignOrderCard({
             <button
               onClick={() => onAssign(order.orderId, order.deliveryId ?? '')}
               disabled={!selectedCourierId || isAssigning || !order.deliveryId}
-              className="flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-white transition hover:opacity-90 active:scale-95 disabled:opacity-50"
+              className="flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-700 text-primary-action transition hover:opacity-90 active:scale-95 disabled:opacity-50"
             >
               {isAssigning ? (
                 <>

--- a/src/features/seller/components/ErrorMessage.tsx
+++ b/src/features/seller/components/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 export const ErrorMessage = ({ message }: { message: string }) => (
-  <div className="mb-6 flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-4 dark:border-red-800/40 dark:bg-red-900/20">
+  <div className="mb-6 flex items-start gap-3 rounded-2xl border border-(--theme-error-border) bg-(--theme-error-bg) px-4 py-4">
     <svg
-      className="mt-0.5 h-5 w-5 shrink-0 text-red-500"
+      className="mt-0.5 h-5 w-5 shrink-0 text-(--theme-error)"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -13,6 +13,6 @@ export const ErrorMessage = ({ message }: { message: string }) => (
         d="M12 9v3m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
       />
     </svg>
-    <p className="text-sm leading-relaxed text-red-700 dark:text-red-300">{message}</p>
+    <p className="text-sm leading-relaxed text-(--theme-error)">{message}</p>
   </div>
 )

--- a/src/features/seller/components/IncidentsPanel.tsx
+++ b/src/features/seller/components/IncidentsPanel.tsx
@@ -29,7 +29,7 @@ function StatItem({
         <p className="text-xs font-800 uppercase tracking-[0.16em] text-(--theme-text) opacity-45">
           {label}
         </p>
-        <p className="truncate text-lg font-900 text-(--theme-text)" style={{ fontFamily: 'Outfit, sans-serif' }}>
+        <p className="truncate font-display text-lg font-900 text-(--theme-text)">
           {value}
         </p>
       </div>
@@ -48,7 +48,7 @@ function IncidentRow({
     <div className="flex items-center gap-4 rounded-2xl border border-(--theme-border) bg-(--theme-card-bg) px-6 py-5 transition hover:shadow-sm">
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <p className="text-lg font-800 text-(--theme-text)" style={{ fontFamily: 'Outfit, sans-serif' }}>
+          <p className="font-display text-lg font-800 text-(--theme-text)">
             {parseOrderId(order.orderId).friendlyName}
           </p>
           <p className="text-sm text-(--theme-text) opacity-55">
@@ -58,7 +58,7 @@ function IncidentRow({
 
         <div className="mt-2 flex flex-wrap items-center gap-2">
           {order.incidentReason ? (
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-800 text-amber-800">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-(--theme-warning-border) bg-(--theme-warning-bg) px-3 py-1 text-sm font-800 text-(--theme-warning)">
               <AlertTriangle size={12} />
               {order.incidentReason}
             </span>
@@ -107,7 +107,7 @@ export default function IncidentsPanel({ embedded = false }: { embedded?: boolea
     <div
       className={
         embedded
-          ? 'mx-auto w-full max-w-4xl px-4 py-10'
+          ? 'mx-auto w-full max-w-6xl px-4 py-10'
           : 'min-h-screen bg-(--theme-bg) px-4 pb-10 pt-10 md:px-8 xl:px-10'
       }
     >
@@ -142,10 +142,10 @@ export default function IncidentsPanel({ embedded = false }: { embedded?: boolea
                 {sortedReasons.map(([reason, count]) => (
                   <span
                     key={reason}
-                    className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-1.5 text-sm font-700 text-amber-800"
+                    className="inline-flex items-center gap-2 rounded-full border border-(--theme-warning-border) bg-(--theme-warning-bg) px-4 py-1.5 text-sm font-700 text-(--theme-warning)"
                   >
                     {reason}
-                    <span className="flex h-5 w-5 items-center justify-center rounded-full bg-amber-200 text-xs font-900 text-amber-900">
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full bg-(--theme-warning-border) text-xs font-900 text-(--theme-warning)">
                       {count}
                     </span>
                   </span>
@@ -156,10 +156,10 @@ export default function IncidentsPanel({ embedded = false }: { embedded?: boolea
 
           <div className="rounded-2xl border border-(--theme-border) bg-(--theme-card-bg) p-6">
             <div className="mb-4 flex items-center gap-2.5">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-900 text-white">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-900 text-primary-action">
                 {orders.length}
               </span>
-              <p className="text-lg font-800 text-(--theme-text)" style={{ fontFamily: 'Outfit, sans-serif' }}>
+              <p className="font-display text-lg font-800 text-(--theme-text)">
                 Pedidos no entregados
               </p>
             </div>
@@ -180,8 +180,8 @@ export default function IncidentsPanel({ embedded = false }: { embedded?: boolea
           </div>
 
           {orders.length > 0 && (
-            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3">
-              <p className="text-xs font-700 text-amber-800">
+            <div className="rounded-2xl border border-(--theme-warning-border) bg-(--theme-warning-bg) px-4 py-3">
+              <p className="text-xs font-700 text-(--theme-warning)">
                 Gestiona estos pedidos desde{' '}
                 <a href="/seller/undelivered-orders" className="underline underline-offset-2 hover:opacity-80">
                   Pedidos no entregados

--- a/src/features/seller/components/ReassignModal.tsx
+++ b/src/features/seller/components/ReassignModal.tsx
@@ -65,7 +65,7 @@ export function ReassignModal({
         <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
           <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
             <div>
-              <h2 id="reassign-messenger-title" className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)" style={{ fontFamily: 'Outfit, sans-serif' }}>
+              <h2 id="reassign-messenger-title" className="mt-2 font-display text-2xl font-bold tracking-tight text-(--theme-text)">
                 #{order.orderId}
               </h2>
               <p className="mt-1 text-sm text-(--theme-text) opacity-70">El mensajero que rechazó no puede ser seleccionado.</p>
@@ -114,7 +114,7 @@ export function ReassignModal({
                       className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition hover:border-primary hover:bg-(--theme-secondary-bg) ${isSelected ? 'border-primary bg-primary/10 text-primary' : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text)'} ${isRejecting ? 'opacity-60 cursor-not-allowed' : ''}`}
                     >
                       <div className="flex items-center gap-3">
-                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-white' : 'bg-(--theme-secondary-bg)'}`}>
+                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'}`}>
                           <UserRound size={16} />
                         </span>
                         <div>
@@ -132,7 +132,7 @@ export function ReassignModal({
 
             <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button type="button" onClick={onClose} disabled={isLoading} className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50">Cancelar</button>
-              <button type="button" onClick={onConfirm} disabled={!selectedCourierId || isLoading || messengersLoading || !!error} className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-white transition hover:opacity-90 disabled:opacity-50">{isLoading ? 'Reasignando…' : 'Confirmar reasignación'}</button>
+              <button type="button" onClick={onConfirm} disabled={!selectedCourierId || isLoading || messengersLoading || !!error} className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50">{isLoading ? 'Reasignando…' : 'Confirmar reasignación'}</button>
             </div>
           </div>
         </section>

--- a/src/features/seller/components/StatusPill.tsx
+++ b/src/features/seller/components/StatusPill.tsx
@@ -7,28 +7,28 @@ export const StatusPill = ({ status }: Props) => {
     RESERVADO:
       'border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text)',
     LISTO:
-      'border border-(--theme-border) bg-primary text-white',
+      'border border-(--theme-border) bg-primary text-primary-action',
     ASIGNADO:
       'border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text)',
     'NO ENTREGADO':
-      'border border-amber-200 bg-amber-50 text-amber-800',
+      'border border-(--theme-warning-border) bg-(--theme-warning-bg) text-(--theme-warning)',
     CANCELADO:
-      'border border-red-200 bg-red-50 text-red-700',
+      'border border-(--theme-error-border) bg-(--theme-error-bg) text-(--theme-error)',
   };
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-700 tracking-wide ${styles[status] ?? 'bg-gray-100 text-gray-600'}`}
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-700 tracking-wide ${styles[status] ?? 'bg-(--theme-secondary-bg) text-(--theme-text) opacity-60'}`}
     >
       <span
         className={`h-1.5 w-1.5 rounded-full ${
           status === 'RESERVADO'
             ? 'bg-primary'
             : status === 'LISTO'
-              ? 'bg-white'
+              ? 'bg-(--theme-bg)'
               : status === 'NO ENTREGADO'
-                ? 'bg-amber-500'
+                ? 'bg-(--theme-warning)'
                 : status === 'CANCELADO'
-                  ? 'bg-red-500'
+                  ? 'bg-(--theme-error)'
                   : 'bg-primary'
         }`}
       />


### PR DESCRIPTION
## Resumen

Alinea las pantallas de delivery/mensajero con `UI.md`: reemplaza colores directos por tokens `--theme-*`, quita `Outfit` inline en las vistas relacionadas y normaliza contenedores a `max-w-6xl` donde aplica.

## URL de los cambios

- URL: http://localhost:4321
- Ruta o pantalla afectada: `/courier`, `/delivery/order/[orderId]`, `/seller/ready-orders`, `/seller/incidents`

## Cómo probar

1. Levantar emuladores y datos locales con `bun run emu` y `bun run seed`.
2. Levantar la app con `bun dev`.
3. Entrar como mensajero: `luis.mensajero@est.umss.edu` / `12345678`.
4. Revisar `/courier` y abrir el detalle de un pedido.
5. Entrar como vendedor: `pedro.vendedor@est.umss.edu` / `12345678`.
6. Revisar `/seller/ready-orders` y `/seller/incidents`.
7. Cambiar entre tema claro/oscuro y verificar que fondos, textos, bordes y estados sigan el estándar.

## Resultado esperado

Las pantallas relacionadas mantienen Navbar/Footer, usan ancho `max-w-6xl` donde aplica, no tienen `Outfit` inline, y los colores de acciones/estados/errores salen de tokens `--theme-*` sin romper navegación ni acciones existentes.

## Evidencia visual

| Antes | Después |
| --- | --- |
| 
<img width="1265" height="796" alt="image" src="https://github.com/user-attachments/assets/f6c122f3-1363-44a6-b8a3-ac9cba8fba9d" />
 | 
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/433e69a8-436b-4685-a6cf-5806dda934a8" />
 |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #618  
Related #114, #119, #566, #567, #568, #569, #570

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Este PR no cambia lógica de estados ni reglas de negocio. Solo alinea estilos y estructura visual con `UI.md`.
Apareció un warning preexistente de inventario sobre `DocumentSnapshot` no usado, fuera del alcance de delivery/mensajero.
