### PR TITLE
feat(orders): implement refund action in rejected orders

### DIFF
--- a/src/features/orders/components/OrderActions.tsx
+++ b/src/features/orders/components/OrderActions.tsx
@@ -296,10 +296,21 @@ function RejectedOrderSection({
 		}
 	};
 
-	const handleRefund = () => {
-		alert(
-			"Para procesar la devolución del dinero, por favor contacta al administrador o sigue el proceso de reembolso correspondiente.",
-		);
+	const handleRefund = async () => {
+		setIsSubmitting(true);
+		try {
+			await returnOrder(order.id);
+			onNotification?.(
+				"success",
+				"Dinero devuelto y orden marcada como devuelta.",
+			);
+			onSuccess?.();
+		} catch (error) {
+			console.error("Error al devolver dinero:", error);
+			onNotification?.("error", "Error al procesar la devolución de dinero.");
+		} finally {
+			setIsSubmitting(false);
+		}
 	};
 
 	return (
@@ -307,9 +318,10 @@ function RejectedOrderSection({
 			<button
 				type="button"
 				onClick={handleRefund}
-				className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-medium text-(--theme-text) transition hover:bg-(--theme-secondary-bg) cursor-pointer"
+				disabled={isSubmitting}
+				className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-medium text-(--theme-text) transition hover:bg-(--theme-secondary-bg) cursor-pointer disabled:opacity-50"
 			>
-				Devolver dinero
+				{isSubmitting ? "Procesando..." : "Devolver dinero"}
 			</button>
 			<button
 				type="button"

--- a/src/features/orders/services/ordersService.ts
+++ b/src/features/orders/services/ordersService.ts
@@ -174,7 +174,7 @@ export async function paidOrder(orderId: string): Promise<void> {
 
 export async function returnOrder(orderId: string): Promise<void> {
 	const user = auth.currentUser;
-	if (!user) throw new Error("Debe estar autenticado para reservar un pedido.");
+	if (!user) throw new Error("Debe estar autenticado para devolver un pedido.");
 
 	const orderRef = doc(db, "orders", orderId);
 	await updateDoc(orderRef, {


### PR DESCRIPTION
## Resumen

Este PR implementa la acción de reembolso para pedidos con estado "RECHAZADO". Reemplaza un aviso de alerta estático por la funcionalidad real de marcar el pedido como devuelto, permitiendo gestionar correctamente el reembolso del dinero.

## URL de los cambios

- URL: https://github.com/ProcesosAgilesUMSS/sansistore/pull/new/feature/refund-rejected-order-action
- Ruta o pantalla afectada: /seller/orders
<img width="928" height="571" alt="image" src="https://github.com/user-attachments/assets/dd597448-0f19-4d76-99d9-fbd82217ea1c" />
<img width="1021" height="53" alt="image" src="https://github.com/user-attachments/assets/dbb82bdb-84c2-471b-a706-9bd02f8a0700" />


## Cómo probar

1. Iniciar sesión como vendedor en el sistema.
2. Navegar a la sección de gestión de pedidos.
3. Buscar un pedido que tenga el estado "RECHAZADO".
4. En el panel de acciones del pedido, hacer clic en el botón "Devolver dinero".
5. Verificar que el estado del pedido cambia a "DEVUELTO"

## Resultado esperado

Al presionar "Devolver dinero", el estado del pedido debe actualizarse a "DEVUELTO" en la base de datos sin errores.

## Evidencia visual
No aplica.

## Tipo de cambio

- [x] Nueva funcionalidad

## Issues relacionados
No aplica.

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos (basado en el análisis de Biome, se reportaron advertencias preexistentes en el servicio que no fueron introducidas por este PR)
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Se reemplazó el `alert` por la llamada asíncrona a `returnOrder`. Se añadió manejo de estado de carga (`isSubmitting`) para mejorar la experiencia de usuario y evitar múltiples envíos.
