### PR TITLE
feat: guardar motivo en rechazo de pedido asignado (HU #568)

### DIFF
--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -282,12 +282,20 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     if (!order) return;
 
     const previousOrder = order;
-    setOrder({ ...order, deliveryStatus: status });
+    const updatedOrder = { ...order, deliveryStatus: status };
+    
+    // Si es rechazo y hay motivo, incluirlo
+    if (status === 'pending_reassignment' && (order as any).rejectionReason) {
+      updatedOrder.rejectionReason = (order as any).rejectionReason;
+    }
+
+    setOrder(updatedOrder);
     setMessage('');
     setError('');
 
     try {
       await setMessengerOrderStatus(previousOrder, status);
+      // TODO: Guardar rejectionReason en Firestore si existe
       setMessage(getStatusUpdateMessage(status));
       await loadOrder({ showLoading: false });
     } catch (statusError) {
@@ -297,14 +305,25 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     }
   };
 
-  const confirmAssignedOrderAction = async () => {
+  const confirmAssignedOrderAction = async (reason?: string) => {
     if (!pendingAssignedAction || savingAssignedAction) return;
 
-    const nextStatus =
-      pendingAssignedAction.action === 'accept' ? 'accepted' : 'pending_reassignment';
+    const { action } = pendingAssignedAction;
+
+    // Validar motivo solo para rechazo
+    if (action === 'reject' && !reason?.trim()) {
+      setError('Debes seleccionar un motivo para rechazar el pedido.');
+      return;
+    }
+
+    const nextStatus = action === 'accept' ? 'accepted' : 'pending_reassignment';
 
     setSavingAssignedAction(true);
     try {
+      // Guardar motivo localmente antes de actualizar
+      if (action === 'reject' && reason) {
+        setOrder((prev) => prev ? { ...prev, rejectionReason: reason } : null);
+      }
       await updateStatus(nextStatus);
       setPendingAssignedAction(null);
     } finally {

--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -282,11 +282,12 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     if (!order) return;
 
     const previousOrder = order;
+    const rejectionReason = (order as any).rejectionReason;
     const updatedOrder = { ...order, deliveryStatus: status };
     
     // Si es rechazo y hay motivo, incluirlo
-    if (status === 'pending_reassignment' && (order as any).rejectionReason) {
-      updatedOrder.rejectionReason = (order as any).rejectionReason;
+    if (status === 'pending_reassignment' && rejectionReason) {
+      updatedOrder.rejectionReason = rejectionReason;
     }
 
     setOrder(updatedOrder);
@@ -294,8 +295,12 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     setError('');
 
     try {
-      await setMessengerOrderStatus(previousOrder, status);
-      // TODO: Guardar rejectionReason en Firestore si existe
+      // Pasar el motivo a Firestore si es rechazo
+      await setMessengerOrderStatus(
+        previousOrder,
+        status,
+        status === 'pending_reassignment' ? rejectionReason : undefined
+      );
       setMessage(getStatusUpdateMessage(status));
       await loadOrder({ showLoading: false });
     } catch (statusError) {

--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -278,11 +278,13 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     return { subtotal, deliveryCost };
   }, [order]);
 
-  const updateStatus = async (status: MessengerOrder['deliveryStatus']) => {
+  const updateStatus = async (
+    status: MessengerOrder['deliveryStatus'],
+    rejectionReason?: string
+  ) => {
     if (!order) return;
 
     const previousOrder = order;
-    const rejectionReason = (order as any).rejectionReason;
     const updatedOrder = { ...order, deliveryStatus: status };
     
     // Si es rechazo y hay motivo, incluirlo
@@ -295,7 +297,6 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     setError('');
 
     try {
-      // Pasar el motivo a Firestore si es rechazo
       await setMessengerOrderStatus(
         previousOrder,
         status,
@@ -325,11 +326,7 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
 
     setSavingAssignedAction(true);
     try {
-      // Guardar motivo localmente antes de actualizar
-      if (action === 'reject' && reason) {
-        setOrder((prev) => prev ? { ...prev, rejectionReason: reason } : null);
-      }
-      await updateStatus(nextStatus);
+      await updateStatus(nextStatus, action === 'reject' ? reason : undefined);
       setPendingAssignedAction(null);
     } finally {
       setSavingAssignedAction(false);

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -1405,18 +1405,15 @@ export default function MessengerDashboard({
         );
 
         try {
-            // Llamar al servicio con el motivo
-            if (status === 'pending_reassignment' && options.reason) {
-            // Aquí necesitas una función que guarde el motivo en Firestore
-            // Por ahora, solo cambiamos el estado
-            await setMessengerOrderStatus(targetOrder, status);
-            // TODO: Guardar rejectionReason en Firestore
-            } else {
-            await setMessengerOrderStatus(targetOrder, status);
-            }
+            // Pasar el motivo a Firestore si es rechazo
+            await setMessengerOrderStatus(
+                targetOrder,
+                status,
+                status === 'pending_reassignment' ? options.reason : undefined
+            );
             setMessage(getStatusUpdateMessage(status));
             if (options.redirectToDetail) {
-            navigateToDeliveryOrderDetail(orderId);
+                navigateToDeliveryOrderDetail(orderId);
             }
         } catch (error) {
             console.error(error);

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -1380,38 +1380,54 @@ export default function MessengerDashboard({
     const updateOrderStatus = async (
         orderId: string,
         status: MessengerOrder['deliveryStatus'],
-        options: { redirectToDetail?: boolean } = {}
-    ) => {
+        options: { redirectToDetail?: boolean; reason?: string } = {}
+        ) => {
         const targetOrder = orders.find((order) => order.id === orderId);
         if (!targetOrder) return;
 
+        // Si es rechazo y hay motivo, guardarlo en el estado local
+        const updatedOrder = status === 'pending_reassignment' && options.reason
+            ? { ...targetOrder, rejectionReason: options.reason }
+            : targetOrder;
+
         setOrders((currentOrders) =>
             currentOrders.map((order) =>
-                order.id === orderId
-                    ? {
-                        ...order,
-                        deliveryStatus: status,
-                    }
-                    : order
+            order.id === orderId
+                ? {
+                    ...order,
+                    deliveryStatus: status,
+                    ...(status === 'pending_reassignment' && options.reason
+                    ? { rejectionReason: options.reason }
+                    : {}),
+                }
+                : order
             )
         );
 
         try {
+            // Llamar al servicio con el motivo
+            if (status === 'pending_reassignment' && options.reason) {
+            // Aquí necesitas una función que guarde el motivo en Firestore
+            // Por ahora, solo cambiamos el estado
             await setMessengerOrderStatus(targetOrder, status);
+            // TODO: Guardar rejectionReason en Firestore
+            } else {
+            await setMessengerOrderStatus(targetOrder, status);
+            }
             setMessage(getStatusUpdateMessage(status));
             if (options.redirectToDetail) {
-                navigateToDeliveryOrderDetail(orderId);
+            navigateToDeliveryOrderDetail(orderId);
             }
         } catch (error) {
             console.error(error);
             setMessage('No se pudo actualizar el estado en Firestore.');
             setOrders((currentOrders) =>
-                currentOrders.map((order) =>
-                    order.id === orderId ? targetOrder : order
-                )
+            currentOrders.map((order) =>
+                order.id === orderId ? targetOrder : order
+            )
             );
         }
-    };
+        };
 
     const markAsDelivered = (order: MessengerOrder) => {
         setConfirmPaymentOrder(order);
@@ -1488,20 +1504,31 @@ export default function MessengerDashboard({
         openAssignedActionConfirmation(orderId, 'reject');
     };
 
-    const confirmAssignedOrderAction = async () => {
+    const confirmAssignedOrderAction = async (reason?: string) => {
         if (!pendingAssignedAction || savingAssignedAction) return;
 
         const { order, action } = pendingAssignedAction;
-        const nextStatus =
-            action === 'accept' ? 'accepted' : 'pending_reassignment';
-
-        setSavingAssignedAction(true);
-        try {
-            await updateOrderStatus(order.id, nextStatus, { redirectToDetail: true });
-            setPendingAssignedAction(null);
-        } finally {
-            setSavingAssignedAction(false);
+        
+        // Si es rechazo y no hay motivo, no continuar
+        if (action === 'reject' && !reason?.trim()) {
+            setMessage('Debes seleccionar un motivo para rechazar el pedido.');
+            return;
         }
+
+    const nextStatus =
+        action === 'accept' ? 'accepted' : 'pending_reassignment';
+
+    setSavingAssignedAction(true);
+    try {
+        // Pasar el motivo al updateOrderStatus
+        await updateOrderStatus(order.id, nextStatus, { 
+        redirectToDetail: true,
+        reason: action === 'reject' ? reason : undefined 
+        });
+        setPendingAssignedAction(null);
+    } finally {
+        setSavingAssignedAction(false);
+    }
     };
 
     const registerUndeliveredOrder = async (reason: string, notes: string) => {

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle2, LoaderCircle, PackageCheck, X, XCircle } from 'lucide-react';
+import { useState } from 'react';
 import { parseOrderId } from '../../cart/services/orderService';
 import type { MessengerOrder } from '../types';
 import { formatBolivianos } from '../utils/money';
@@ -10,7 +11,7 @@ interface ConfirmAssignedOrderActionModalProps {
   action: AssignedOrderAction;
   isSaving: boolean;
   onClose: () => void;
-  onConfirm: () => Promise<void>;
+  onConfirm: (reason?: string) => Promise<void>;
 }
 
 const actionConfig = {
@@ -47,6 +48,15 @@ const actionConfig = {
   }
 >;
 
+const rejectionReasons = [
+  'Pedido muy lejos de mi zona',
+  'No tengo disponibilidad horaria',
+  'El pedido es demasiado grande para mi vehículo',
+  'Problemas con mi vehículo',
+  'No conozco la zona de entrega',
+  'Otro motivo',
+];
+
 export type { AssignedOrderAction };
 
 export default function ConfirmAssignedOrderActionModal({
@@ -61,10 +71,35 @@ export default function ConfirmAssignedOrderActionModal({
   const displayId = order.displayId ?? friendlyName;
   const Icon = config.Icon;
 
+  const [reason, setReason] = useState('');
+  const [customReason, setCustomReason] = useState('');
+  const [showCustomInput, setShowCustomInput] = useState(false);
+
   const confirmAction = async () => {
     if (isSaving) return;
-    await onConfirm();
+
+    // Validar motivo solo para rechazo
+    if (action === 'reject') {
+      const finalReason = reason === 'Otro motivo' ? customReason : reason;
+      if (!finalReason.trim()) {
+        alert('Debes seleccionar o escribir un motivo para rechazar el pedido.');
+        return;
+      }
+      await onConfirm(finalReason);
+    } else {
+      await onConfirm();
+    }
   };
+
+  const handleReasonSelect = (selectedReason: string) => {
+    setReason(selectedReason);
+    setShowCustomInput(selectedReason === 'Otro motivo');
+    if (selectedReason !== 'Otro motivo') {
+      setCustomReason('');
+    }
+  };
+
+  const isRejectAction = action === 'reject';
 
   return (
     <div
@@ -140,6 +175,38 @@ export default function ConfirmAssignedOrderActionModal({
             <PackageCheck className="mt-0.5 shrink-0 text-primary" size={18} />
             <p>{config.warning}</p>
           </div>
+
+          {/* Campo de motivo - solo para rechazo */}
+          {isRejectAction && (
+            <div className="space-y-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4">
+              <p className="text-sm font-bold">Motivo del rechazo:</p>
+              <div className="flex flex-wrap gap-2">
+                {rejectionReasons.map((reasonOption) => (
+                  <button
+                    key={reasonOption}
+                    className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+                      reason === reasonOption
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border-light hover:border-primary/50'
+                    }`}
+                    onClick={() => handleReasonSelect(reasonOption)}
+                    type="button"
+                  >
+                    {reasonOption}
+                  </button>
+                ))}
+              </div>
+              {showCustomInput && (
+                <textarea
+                  placeholder="Escribe tu motivo..."
+                  className="w-full rounded-xl border border-border-light p-3 text-sm"
+                  value={customReason}
+                  onChange={(e) => setCustomReason(e.target.value)}
+                  rows={2}
+                />
+              )}
+            </div>
+          )}
         </div>
 
         <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, LoaderCircle, PackageCheck, X, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, LoaderCircle, PackageCheck, X, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { parseOrderId } from '../../cart/services/orderService';
 import type { MessengerOrder } from '../types';
@@ -74,6 +74,7 @@ export default function ConfirmAssignedOrderActionModal({
   const [reason, setReason] = useState('');
   const [customReason, setCustomReason] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
+  const [errorModal, setErrorModal] = useState<string | null>(null);
 
   const confirmAction = async () => {
     if (isSaving) return;
@@ -82,7 +83,7 @@ export default function ConfirmAssignedOrderActionModal({
     if (action === 'reject') {
       const finalReason = reason === 'Otro motivo' ? customReason : reason;
       if (!finalReason.trim()) {
-        alert('Debes seleccionar o escribir un motivo para rechazar el pedido.');
+        setErrorModal('Debes seleccionar o escribir un motivo para rechazar el pedido.');
         return;
       }
       await onConfirm(finalReason);
@@ -102,138 +103,167 @@ export default function ConfirmAssignedOrderActionModal({
   const isRejectAction = action === 'reject';
 
   return (
-    <div
-      className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="assigned-order-action-title"
-    >
-      <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-        <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
-          <div className="flex items-center gap-4">
-            <span
-              className={`flex h-12 w-12 items-center justify-center rounded-2xl ${config.iconClassName}`}
-            >
-              <Icon size={24} />
-            </span>
-
-            <div>
-              <h2
-                className="text-xl font-black tracking-normal"
-                id="assigned-order-action-title"
+    <>
+      <div
+        className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) onClose();
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="assigned-order-action-title"
+      >
+        <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
+          <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+            <div className="flex items-center gap-4">
+              <span
+                className={`flex h-12 w-12 items-center justify-center rounded-2xl ${config.iconClassName}`}
               >
-                {config.title}
-              </h2>
-              <p className="text-sm font-medium opacity-70">
-                {config.description}
-              </p>
-            </div>
-          </div>
+                <Icon size={24} />
+              </span>
 
-          <button
-            aria-label="Cerrar"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-            disabled={isSaving}
-            onClick={onClose}
-            type="button"
-          >
-            <X size={16} />
-          </button>
-        </header>
-
-        <div className="space-y-6 px-6 py-6">
-          <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
-              <p className="mt-1 text-sm font-bold">{displayId}</p>
-            </div>
-
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
-              <p className="mt-1 text-sm font-bold">{order.customerName}</p>
-            </div>
-
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Zona</p>
-              <p className="mt-1 text-sm font-bold">{order.city}</p>
-            </div>
-
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">
-                Monto a cobrar
-              </p>
-              <p className="mt-1 text-sm font-bold">
-                {formatBolivianos(order.cashToCollect)}
-              </p>
-            </div>
-          </div>
-
-          <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
-            <PackageCheck className="mt-0.5 shrink-0 text-primary" size={18} />
-            <p>{config.warning}</p>
-          </div>
-
-          {/* Campo de motivo - solo para rechazo */}
-          {isRejectAction && (
-            <div className="space-y-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4">
-              <p className="text-sm font-bold">Motivo del rechazo:</p>
-              <div className="flex flex-wrap gap-2">
-                {rejectionReasons.map((reasonOption) => (
-                  <button
-                    key={reasonOption}
-                    className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
-                      reason === reasonOption
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-border-light hover:border-primary/50'
-                    }`}
-                    onClick={() => handleReasonSelect(reasonOption)}
-                    type="button"
-                  >
-                    {reasonOption}
-                  </button>
-                ))}
+              <div>
+                <h2
+                  className="text-xl font-black tracking-normal"
+                  id="assigned-order-action-title"
+                >
+                  {config.title}
+                </h2>
+                <p className="text-sm font-medium opacity-70">
+                  {config.description}
+                </p>
               </div>
-              {showCustomInput && (
-                <textarea
-                  placeholder="Escribe tu motivo..."
-                  className="w-full rounded-xl border border-border-light p-3 text-sm"
-                  value={customReason}
-                  onChange={(e) => setCustomReason(e.target.value)}
-                  rows={2}
-                />
-              )}
             </div>
-          )}
-        </div>
 
-        <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
-          <button
-            className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={isSaving}
-            onClick={onClose}
-            type="button"
-          >
-            Cancelar
-          </button>
+            <button
+              aria-label="Cerrar"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+              disabled={isSaving}
+              onClick={onClose}
+              type="button"
+            >
+              <X size={16} />
+            </button>
+          </header>
 
-          <button
-            className={`inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full px-5 text-sm font-black uppercase transition disabled:cursor-not-allowed disabled:opacity-50 ${config.buttonClassName}`}
-            disabled={isSaving}
-            onClick={confirmAction}
-            type="button"
-          >
-            {isSaving ? (
-              <LoaderCircle className="animate-spin" size={16} />
-            ) : (
-              <Icon size={16} />
+          <div className="space-y-6 px-6 py-6">
+            <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
+              <div>
+                <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
+                <p className="mt-1 text-sm font-bold">{displayId}</p>
+              </div>
+
+              <div>
+                <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
+                <p className="mt-1 text-sm font-bold">{order.customerName}</p>
+              </div>
+
+              <div>
+                <p className="text-xs font-bold uppercase opacity-50">Zona</p>
+                <p className="mt-1 text-sm font-bold">{order.city}</p>
+              </div>
+
+              <div>
+                <p className="text-xs font-bold uppercase opacity-50">
+                  Monto a cobrar
+                </p>
+                <p className="mt-1 text-sm font-bold">
+                  {formatBolivianos(order.cashToCollect)}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
+              <PackageCheck className="mt-0.5 shrink-0 text-primary" size={18} />
+              <p>{config.warning}</p>
+            </div>
+
+            {/* Campo de motivo - solo para rechazo */}
+            {isRejectAction && (
+              <div className="space-y-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4">
+                <p className="text-sm font-bold">Motivo del rechazo:</p>
+                <div className="flex flex-wrap gap-2">
+                  {rejectionReasons.map((reasonOption) => (
+                    <button
+                      key={reasonOption}
+                      className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+                        reason === reasonOption
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border-light hover:border-primary/50'
+                      }`}
+                      onClick={() => handleReasonSelect(reasonOption)}
+                      type="button"
+                    >
+                      {reasonOption}
+                    </button>
+                  ))}
+                </div>
+                {showCustomInput && (
+                  <textarea
+                    placeholder="Escribe tu motivo..."
+                    className="w-full rounded-xl border border-border-light p-3 text-sm"
+                    value={customReason}
+                    onChange={(e) => setCustomReason(e.target.value)}
+                    rows={2}
+                  />
+                )}
+              </div>
             )}
-            {config.buttonLabel}
-          </button>
-        </footer>
-      </section>
-    </div>
+          </div>
+
+          <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
+            <button
+              className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isSaving}
+              onClick={onClose}
+              type="button"
+            >
+              Cancelar
+            </button>
+
+            <button
+              className={`inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full px-5 text-sm font-black uppercase transition disabled:cursor-not-allowed disabled:opacity-50 ${config.buttonClassName}`}
+              disabled={isSaving}
+              onClick={confirmAction}
+              type="button"
+            >
+              {isSaving ? (
+                <LoaderCircle className="animate-spin" size={16} />
+              ) : (
+                <Icon size={16} />
+              )}
+              {config.buttonLabel}
+            </button>
+          </footer>
+        </section>
+      </div>
+
+      {/* Modal de error */}
+      {errorModal && (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+          onClick={() => setErrorModal(null)}
+        >
+          <div className="w-full max-w-md rounded-[28px] border border-(--theme-error-border) bg-card-bg-light p-6 shadow-2xl">
+            <div className="flex items-center gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-(--theme-error-bg) text-(--theme-error)">
+                <AlertTriangle size={24} />
+              </span>
+              <div>
+                <h3 className="text-lg font-black">Error</h3>
+                <p className="text-sm font-semibold opacity-80">{errorModal}</p>
+              </div>
+            </div>
+            <button
+              className="mt-6 w-full rounded-full border border-border-light bg-card-bg-light py-3 text-sm font-black uppercase transition hover:bg-secondary-bg-light"
+              onClick={() => setErrorModal(null)}
+              type="button"
+            >
+              Entendido
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -325,7 +325,8 @@ const getStatusForORder = (status: DeliveryStatus) => {
 
 export async function setMessengerOrderStatus(
   order: MessengerOrder,
-  status: DeliveryStatus
+  status: DeliveryStatus,
+  rejectionReason?: string
 ) {
   assertCanTransitionDeliveryStatus(order.deliveryStatus, status);
 
@@ -334,6 +335,12 @@ export async function setMessengerOrderStatus(
     status,
     updatedAt: serverTimestamp(),
   };
+
+  // Si es rechazo y hay motivo, guardarlo
+  if (status === 'pending_reassignment' && rejectionReason) {
+    dataToUpdate.rejectionReason = rejectionReason;
+    dataToUpdate.rejectedAt = serverTimestamp();
+  }
 
   if (status === 'in_transit') {
     dataToUpdate.inTransitAt = serverTimestamp();
@@ -348,11 +355,18 @@ export async function setMessengerOrderStatus(
   await updateDoc(deliveryRef, dataToUpdate);
 
   if (order.id) {
-    await updateDoc(doc(db, 'orders', order.id), {
+    const orderUpdateData: Record<string, unknown> = {
       status: getOrderStatusForDeliveryStatus(status),
       deliveryStatus: getOrderDeliveryStatusForDeliveryStatus(status),
       updatedAt: serverTimestamp(),
-    });
+    };
+
+    if (status === 'pending_reassignment' && rejectionReason) {
+      orderUpdateData.rejectionReason = rejectionReason;
+      orderUpdateData.rejectedAt = serverTimestamp();
+    }
+
+    await updateDoc(doc(db, 'orders', order.id), orderUpdateData);
   }
 }
 

--- a/src/features/mensajero/types.ts
+++ b/src/features/mensajero/types.ts
@@ -76,11 +76,12 @@ export interface MessengerOrder {
   assignedAt: Date | null;
   createdAt: Date | null;
   updatedAt: Date | null;
-
   reprogrammedAt: Date | null;
   newDeliveryAt: Date | null;
   reprogramReason: string | null;
+  rejectionReason?: string;
 }
+
 export interface MessengerShiftOrderSnapshot {
   id: string;
   deliveryId: string;


### PR DESCRIPTION
## Resumen

Se agregó el guardado del motivo de rechazo al rechazar un pedido asignado. Ahora el mensajero puede seleccionar o escribir un motivo, y este se guarda en el estado local del pedido para su posterior registro.

## URL de los cambios

- URL: http://localhost:4321/courier
- Ruta o pantalla afectada: Panel del mensajero → Pedidos asignados → Botón "Rechazar"

## Cómo probar

1. Iniciar sesión como mensajero.
2. Ir al panel de pedidos asignados.
3. Seleccionar un pedido en estado ASIGNADO y hacer clic en "Rechazar".
4. En el modal, seleccionar o escribir un motivo de rechazo.
5. Confirmar el rechazo.

## Resultado esperado

- El modal muestra el campo de motivo con opciones predefinidas y campo de texto libre.
- El motivo es obligatorio para confirmar el rechazo.
- Al confirmar, el pedido cambia a estado PENDIENTE REASIGNACION y el motivo queda guardado localmente.

## Evidencia visual

No aplica.

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #568

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

- El motivo se captura en el modal `ConfirmAssignedOrderActionModal` y se pasa al handler correspondiente.
- Los handlers en `MessengerDashboard` y `DeliveryOrderDetailPage` reciben el motivo y lo guardan localmente.
- Falta implementar el guardado en Firestore (se puede hacer en un PR posterior).