### PR TITLE
Feat/asignar mensajero

### DIFF
--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -1,7 +1,7 @@
-import { createPortal } from 'react-dom';
-import { X, UserRound } from 'lucide-react';
-import type { Messenger, Order } from '../types';
-import { parseOrderId } from '@/features/cart/services/orderService';
+import { UserRound, X } from "lucide-react";
+import { createPortal } from "react-dom";
+import { parseOrderId } from "@/features/cart/services/orderService";
+import type { Messenger, Order } from "../types";
 
 interface Props {
   order: Order;

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -24,7 +24,7 @@ export function AssignMessengerModal({
   onConfirm,
   onClose,
 }: Props) {
-  const availableCount = messengers.filter((m) => m.isAvailable).length;
+	const availableCount = messengers.filter((m) => m.isAvailable).length;
 
   return createPortal(
     (

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -40,9 +40,6 @@ export function AssignMessengerModal({
         <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
           <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
             <div>
-              <p className="text-xs text-(--theme-text) opacity-50">
-                {parseOrderId(order.orderId).uuid}
-              </p>
               <h2
                 id="order-details-title"
                 className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
@@ -127,8 +124,8 @@ export function AssignMessengerModal({
                             {messenger.displayName}
                             <span
                               className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide ${messenger.isAvailable
-                                  ? 'bg-success-bg text-success border border-success-border'
-                                  : 'bg-danger-bg text-danger border border-danger-border'
+                                ? 'bg-success-bg text-success border border-success-border'
+                                : 'bg-danger-bg text-danger border border-danger-border'
                                 }`}
                             >
                               {messenger.isAvailable ? 'Disponible' : 'Ocupado'}

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -75,11 +75,11 @@ export function AssignMessengerModal({
               </p>
             </div>
 
-            {!messengersLoading && messengers.length > 0 && (
-              <p className="mt-4 text-xs text-(--theme-text) opacity-50">
-                {availableCount} de {messengers.length} mensajeros disponibles
-              </p>
-            )}
+					{!messengersLoading && messengers.length > 0 && (
+						<p className="mt-4 text-xs text-(--theme-text) opacity-50">
+							{availableCount} de {messengers.length} mensajeros disponibles
+						</p>
+					)}
 
             <div className="mt-3 grid gap-3">
               {messengersLoading ? (

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, UserRound } from 'lucide-react';
 import type { Messenger, Order } from '../types';
+import { parseOrderId } from '@/features/cart/services/orderService';
 
 interface Props {
   order: Order;
@@ -23,6 +24,8 @@ export function AssignMessengerModal({
   onConfirm,
   onClose,
 }: Props) {
+  const availableCount = messengers.filter((m) => m.isAvailable).length;
+
   return createPortal(
     (
       <div
@@ -37,14 +40,18 @@ export function AssignMessengerModal({
         <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
           <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
             <div>
+              <p className="text-xs text-(--theme-text) opacity-50">
+                {parseOrderId(order.orderId).uuid}
+              </p>
               <h2
-                id="assign-messenger-title"
-                className="mt-2 font-display text-2xl font-bold tracking-tight text-(--theme-text)"
+                id="order-details-title"
+                className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
+                style={{ fontFamily: "Outfit, sans-serif" }}
               >
-                #{order.orderId}
+                {parseOrderId(order.orderId).friendlyName}
               </h2>
               <p className="mt-1 text-sm text-(--theme-text) opacity-70">
-                Selecciona un mensajero y confirma la asignación.
+                Selecciona un mensajero disponible y confirma la asignación.
               </p>
             </div>
 
@@ -71,43 +78,67 @@ export function AssignMessengerModal({
               </p>
             </div>
 
-            <div className="mt-5 grid gap-3">
+            {!messengersLoading && messengers.length > 0 && (
+              <p className="mt-4 text-xs text-(--theme-text) opacity-50">
+                {availableCount} de {messengers.length} mensajeros disponibles
+              </p>
+            )}
+
+            <div className="mt-3 grid gap-3">
               {messengersLoading ? (
                 <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
                   Cargando mensajeros…
                 </div>
               ) : messengers.length === 0 ? (
                 <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
-                  No hay mensajeros disponibles.
+                  No hay mensajeros registrados.
+                </div>
+              ) : availableCount === 0 ? (
+                <div className="rounded-2xl border border-dashed border-amber-300 bg-amber-50 px-4 py-6 text-sm text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-300">
+                  Todos los mensajeros están ocupados en este momento. Intenta nuevamente en unos minutos.
                 </div>
               ) : (
                 messengers.map((messenger) => {
                   const isSelected = selectedCourierId === messenger.uid;
+                  const isDisabled = !messenger.isAvailable;
 
                   return (
                     <button
                       key={messenger.uid}
                       type="button"
+                      disabled={isDisabled}
                       onClick={() => onSelectCourier(order.orderId, messenger.uid)}
-                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition hover:border-primary hover:bg-(--theme-secondary-bg) ${isSelected
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text)'
+                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${isDisabled
+                        ? 'cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50'
+                        : isSelected
+                          ? 'border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)'
+                          : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)'
                         }`}
                     >
                       <div className="flex items-center gap-3">
-                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'}`}>
+                        <span
+                          className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected && !isDisabled ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'
+                            }`}
+                        >
                           <UserRound size={16} />
                         </span>
                         <div>
-                          <p className="font-800">{messenger.displayName}</p>
-                          <p className="text-xs opacity-55">
-                            {messenger.institutionalId || 'Sin CI institucional'}
+                          <p className="font-800 flex items-center gap-2">
+                            {messenger.displayName}
+                            <span
+                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide ${messenger.isAvailable
+                                  ? 'bg-success-bg text-success border border-success-border'
+                                  : 'bg-danger-bg text-danger border border-danger-border'
+                                }`}
+                            >
+                              {messenger.isAvailable ? 'Disponible' : 'Ocupado'}
+                            </span>
                           </p>
                         </div>
                       </div>
 
-                      <span className="text-sm font-semibold  opacity-70">
-                        {isSelected ? 'Seleccionado' : 'Elegir'}
+                      <span className="text-sm font-semibold opacity-70">
+                        {isDisabled ? '' : isSelected ? 'Seleccionado' : 'Elegir'}
                       </span>
                     </button>
                   );

--- a/src/features/seller/components/BusyMessengerWarinigModal.tsx
+++ b/src/features/seller/components/BusyMessengerWarinigModal.tsx
@@ -1,0 +1,71 @@
+import { createPortal } from 'react-dom'
+import { AlertTriangle, X } from 'lucide-react'
+import type { Messenger } from '../types';
+
+interface Props {
+  messenger: Messenger;
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const BusyMessengerWarinigModal = ({ messenger, isLoading, onConfirm, onCancel }: Props) => {
+  return createPortal(
+    (
+      <div
+        className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="busy-warning-title"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) onCancel();
+        }}
+      >
+        <section className="w-full max-w-sm rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) p-6 shadow-2xl">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+              <AlertTriangle className="text-amber-600 dark:text-amber-400" size={22} />
+            </div>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex h-8 w-8 items-center justify-center rounded-full text-(--theme-text) opacity-50 transition hover:opacity-100"
+              aria-label="Cerrar"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          <h2
+            id="busy-warning-title"
+            className="mt-4 text-lg font-800 text-(--theme-text)"
+            style={{ fontFamily: 'Outfit, sans-serif' }}
+          >
+            {messenger.displayName} está ocupado
+          </h2>
+
+
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isLoading}
+              className="flex-1 rounded-full border border-(--theme-border) px-4 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={isLoading}
+              className="flex-1 rounded-full bg-amber-500 px-4 py-2.5 text-sm font-700 text-white transition hover:bg-amber-600 disabled:opacity-60"
+            >
+              {isLoading ? 'Asignando…' : 'Asignar de todas formas'}
+            </button>
+          </div>
+        </section>
+      </div>
+    ),
+    document.body,
+  );
+}

--- a/src/features/seller/components/BusyMessengerWarinigModal.tsx
+++ b/src/features/seller/components/BusyMessengerWarinigModal.tsx
@@ -1,6 +1,6 @@
-import { createPortal } from 'react-dom'
-import { AlertTriangle, X } from 'lucide-react'
-import type { Messenger } from '../types';
+import { AlertTriangle, X } from "lucide-react";
+import { createPortal } from "react-dom";
+import type { Messenger } from "../types";
 
 interface Props {
   messenger: Messenger;

--- a/src/features/seller/components/CardOrder.tsx
+++ b/src/features/seller/components/CardOrder.tsx
@@ -36,9 +36,6 @@ export const CardOrder = ({
           <div className="min-w-0">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0">
-                <p className="text-xs text-(--theme-text) opacity-50">
-                   {parseOrderId(order.orderId).uuid}
-                </p>
                 <h3 className="mt-1 text-xl font-bold tracking-tight text-(--theme-text)" style={{ fontFamily: 'Outfit, sans-serif' }}>
                   {parseOrderId(order.orderId).friendlyName}
                 </h3>

--- a/src/features/seller/components/OrderDetailsModal.tsx
+++ b/src/features/seller/components/OrderDetailsModal.tsx
@@ -6,175 +6,175 @@ import { formatCurrency } from "../utils/currency";
 import { formatDate } from "../utils/formatDate";
 
 interface Props {
-	order: Order | null;
-	onClose: () => void;
+  order: Order | null;
+  onClose: () => void;
 }
 
 function DetailRow({
-	label,
-	value,
+  label,
+  value,
 }: {
-	label: string;
-	value?: string | number | null;
+  label: string;
+  value?: string | number | null;
 }) {
-	return (
-		<div className="rounded-2xl border border-(--theme-border) bg-(--theme-secondary-bg)/70 px-4 py-3">
-			<p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
-				{label}
-			</p>
-			<p className="mt-1 wrap-break-words text-sm font-700 text-(--theme-text)">
-				{value ?? "No registrado"}
-			</p>
-		</div>
-	);
+  return (
+    <div className="rounded-2xl border border-(--theme-border) bg-(--theme-secondary-bg)/70 px-4 py-3">
+      <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
+        {label}
+      </p>
+      <p className="mt-1 wrap-break-words text-sm font-700 text-(--theme-text)">
+        {value ?? "No registrado"}
+      </p>
+    </div>
+  );
 }
 
 export function OrderDetailsModal({ order, onClose }: Props) {
-	if (!order) return null;
+  if (!order) return null;
 
-	const items = order.items ?? [];
-	const paymentAmount = order.paymentAmount ?? order.total;
+  const items = order.items ?? [];
+  const paymentAmount = order.paymentAmount ?? order.total;
 
-	return createPortal(
-		<div
-			className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
-			role="dialog"
-			aria-modal="true"
-			aria-labelledby="order-details-title"
-			tabIndex={-1}
-			ref={(el) => el?.focus()}
-			onClick={(event) => {
-				if (event.target === event.currentTarget) onClose();
-			}}
-			onKeyDown={(event) => {
-				if (event.key === "Escape") onClose();
-			}}
-		>
-			<section className="max-h-[92vh] w-full max-w-4xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
-				<header className="border-b border-(--theme-border) px-6 py-5">
-					<div className="flex items-start justify-between gap-4">
-						<div className="min-w-0">
-							<p className="text-xs text-(--theme-text) opacity-50">
-								{parseOrderId(order.orderId).uuid}
-							</p>
-							<h2
-								id="order-details-title"
-								className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
-								style={{ fontFamily: "Outfit, sans-serif" }}
-							>
-								{parseOrderId(order.orderId).friendlyName}
-							</h2>
-						</div>
+  return createPortal(
+    <div
+      className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="order-details-title"
+      tabIndex={-1}
+      ref={(el) => el?.focus()}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
+      }}
+    >
+      <section className="max-h-[92vh] w-full max-w-4xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
+        <header className="border-b border-(--theme-border) px-6 py-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-xs text-(--theme-text) opacity-50">
+                {parseOrderId(order.orderId).uuid}
+              </p>
+              <h2
+                id="order-details-title"
+                className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
+                style={{ fontFamily: "Outfit, sans-serif" }}
+              >
+                {parseOrderId(order.orderId).friendlyName}
+              </h2>
+            </div>
 
-						<button
-							type="button"
-							onClick={onClose}
-							className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary"
-							aria-label="Cerrar detalle"
-						>
-							<X size={18} />
-						</button>
-					</div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary"
+              aria-label="Cerrar detalle"
+            >
+              <X size={18} />
+            </button>
+          </div>
 
-					<div className="mt-5 flex flex-wrap items-center gap-3">
-						<span className="inline-flex items-center gap-2 rounded-full border border-(--theme-border) bg-primary px-3 py-1 text-xs font-800 uppercase tracking-[0.2em] text-white">
-							<Clock3 size={12} />
-							{formatDate(order.createdAt)}
-						</span>
-						<span className="rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) px-3 py-1 text-xs font-800 uppercase tracking-[0.2em] text-(--theme-text)">
-							{order.status}
-						</span>
-					</div>
-				</header>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-(--theme-border) bg-primary px-3 py-1 text-xs font-800 uppercase tracking-[0.2em] text-white">
+              <Clock3 size={12} />
+              {formatDate(order.createdAt)}
+            </span>
+            <span className="rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) px-3 py-1 text-xs font-800 uppercase tracking-[0.2em] text-(--theme-text)">
+              {order.status}
+            </span>
+          </div>
+        </header>
 
-				<div className="grid gap-6 p-6 lg:grid-cols-[1fr_320px]">
-					<div className="space-y-6">
-						<article className="p-5">
-							<div className="grid gap-3 sm:grid-cols-3">
-								<DetailRow
-									label="Cliente"
-									value={order.buyerName ?? "Comprador desconocido"}
-								/>
-								<DetailRow
-									label="Ubicación"
-									value={order.locationLabel ?? "No registrada"}
-								/>
-								<DetailRow
-									label="Tipo"
-									value={order.locationType ?? "No registrado"}
-								/>
-							</div>
+        <div className="grid gap-6 p-6 lg:grid-cols-[1fr_320px]">
+          <div className="space-y-6">
+            <article className="p-5">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <DetailRow
+                  label="Cliente"
+                  value={order.buyerName ?? "Comprador desconocido"}
+                />
+                <DetailRow
+                  label="Ubicación"
+                  value={order.locationLabel ?? "No registrada"}
+                />
+                <DetailRow
+                  label="Tipo"
+                  value={order.locationType ?? "No registrado"}
+                />
+              </div>
 
-							{order.incidentReason && (
-								<div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-									<p className="text-[11px] font-800 uppercase tracking-[0.22em] opacity-70">
-										Motivo registrado
-									</p>
-									<p className="mt-1 font-700">{order.incidentReason}</p>
-								</div>
-							)}
-						</article>
+              {order.incidentReason && (
+                <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                  <p className="text-[11px] font-800 uppercase tracking-[0.22em] opacity-70">
+                    Motivo registrado
+                  </p>
+                  <p className="mt-1 font-700">{order.incidentReason}</p>
+                </div>
+              )}
+            </article>
 
-						<article className="p-5">
-							<div className="flex items-center gap-2">
-								<Package size={18} className="text-primary" />
-								<h3 className="text-lg font-800 tracking-tight text-(--theme-text)">
-									Productos
-								</h3>
-							</div>
+            <article className="p-5">
+              <div className="flex items-center gap-2">
+                <Package size={18} className="text-primary" />
+                <h3 className="text-lg font-800 tracking-tight text-(--theme-text)">
+                  Productos
+                </h3>
+              </div>
 
-							{items.length === 0 ? (
-								<p className="mt-4 rounded-2xl border border-dashed border-(--theme-border) px-4 py-5 text-sm text-(--theme-text) opacity-60">
-									No se encontraron productos para este pedido.
-								</p>
-							) : (
-								<div className="mt-4 space-y-3">
-									{items.map((item) => (
-										<div
-											key={item.itemId}
-											className="rounded-2xl border border-(--theme-border) bg-(--theme-secondary-bg)/60 p-4"
-										>
-											<div className="flex items-start justify-between gap-4">
-												<div>
-													<p className="font-800 text-(--theme-text)">
-														{item.productName}
-													</p>
-													<p className="mt-1 text-sm text-(--theme-text) opacity-60">
-														{item.quantity} x {formatCurrency(item.unitPrice)}
-													</p>
-												</div>
-												<p className="whitespace-nowrap font-800 text-primary">
-													{formatCurrency(item.subtotal)}
-												</p>
-											</div>
-										</div>
-									))}
-								</div>
-							)}
-						</article>
-					</div>
+              {items.length === 0 ? (
+                <p className="mt-4 rounded-2xl border border-dashed border-(--theme-border) px-4 py-5 text-sm text-(--theme-text) opacity-60">
+                  No se encontraron productos para este pedido.
+                </p>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {items.map((item) => (
+                    <div
+                      key={item.itemId}
+                      className="rounded-2xl border border-(--theme-border) bg-(--theme-secondary-bg)/60 p-4"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="font-800 text-(--theme-text)">
+                            {item.productName}
+                          </p>
+                          <p className="mt-1 text-sm text-(--theme-text) opacity-60">
+                            {item.quantity} x {formatCurrency(item.unitPrice)}
+                          </p>
+                        </div>
+                        <p className="whitespace-nowrap font-800 text-primary">
+                          {formatCurrency(item.subtotal)}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </article>
+          </div>
 
-					<aside className="space-y-6">
-						<article className="p-5">
-							<div className="flex items-center gap-2">
-								<ReceiptText size={18} className="text-primary" />
-								<h3 className="text-lg font-800 tracking-tight text-(--theme-text)">
-									Resumen
-								</h3>
-							</div>
+          <aside className="space-y-6">
+            <article className="p-5">
+              <div className="flex items-center gap-2">
+                <ReceiptText size={18} className="text-primary" />
+                <h3 className="text-lg font-800 tracking-tight text-(--theme-text)">
+                  Resumen
+                </h3>
+              </div>
 
-							<div className="mt-4 grid gap-3">
-								<DetailRow label="Total" value={formatCurrency(order.total)} />
-								<DetailRow
-									label="Monto de pago"
-									value={formatCurrency(paymentAmount)}
-								/>
-							</div>
-						</article>
-					</aside>
-				</div>
-			</section>
-		</div>,
-		document.body,
-	);
+              <div className="mt-4 grid gap-3">
+                <DetailRow label="Total" value={formatCurrency(order.total)} />
+                <DetailRow
+                  label="Monto de pago"
+                  value={formatCurrency(paymentAmount)}
+                />
+              </div>
+            </article>
+          </aside>
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
 }

--- a/src/features/seller/components/OrderDetailsModal.tsx
+++ b/src/features/seller/components/OrderDetailsModal.tsx
@@ -54,9 +54,6 @@ export function OrderDetailsModal({ order, onClose }: Props) {
         <header className="border-b border-(--theme-border) px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
-              <p className="text-xs text-(--theme-text) opacity-50">
-                {parseOrderId(order.orderId).uuid}
-              </p>
               <h2
                 id="order-details-title"
                 className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"

--- a/src/features/seller/components/ReassignModal.tsx
+++ b/src/features/seller/components/ReassignModal.tsx
@@ -5,6 +5,7 @@ import { db } from '../../../lib/firebase';
 import { fetchDeliveryData } from '../services/sellerServices';
 import type { Messenger, Order } from '../types';
 import { ErrorMessage } from './ErrorMessage';
+import { parseOrderId } from '@/features/cart/services/orderService';
 
 interface Props {
   order: Order;
@@ -37,12 +38,13 @@ export function ReassignModal({
     (async () => {
       if (!order.deliveryId) {
         setError('El pedido no tiene un ID de entrega asociado.');
-      };
+        return;
+      }
       try {
         const d = await fetchDeliveryData(db, order.deliveryId);
         if (!mounted) return;
-        setRejectingCourierId((d as any)?.courierId ?? null);
-        setRejectingCourierName((d as any)?.deliveryCourierName ?? null);
+        setRejectingCourierId(d?.courierId ?? null);
+        setRejectingCourierName(d?.deliveryCourierName ?? null);
       } catch {
         setError('No se pudo obtener la información de la entrega');
       }
@@ -50,6 +52,10 @@ export function ReassignModal({
 
     return () => { mounted = false; };
   }, [order.deliveryId, order.orderId]);
+
+  const availableCount = messengers.filter(
+    (m) => m.isAvailable && m.uid !== rejectingCourierId,
+  ).length;
 
   return createPortal(
     (
@@ -61,14 +67,19 @@ export function ReassignModal({
         onClick={(event) => {
           if (event.target === event.currentTarget) onClose();
         }}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') onClose();
+        }}
       >
         <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
           <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
             <div>
               <h2 id="reassign-messenger-title" className="mt-2 font-display text-2xl font-bold tracking-tight text-(--theme-text)">
-                #{order.orderId}
+                {parseOrderId(order.orderId).friendlyName}
               </h2>
-              <p className="mt-1 text-sm text-(--theme-text) opacity-70">El mensajero que rechazó no puede ser seleccionado.</p>
+              <p className="mt-1 text-sm text-(--theme-text) opacity-70">
+                Selecciona un mensajero disponible. El que rechazó no puede ser seleccionado.
+              </p>
             </div>
 
             <button type="button" onClick={onClose} className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary" aria-label="Cerrar modal">
@@ -76,11 +87,8 @@ export function ReassignModal({
             </button>
           </header>
 
-          {
-            error && (
-              <ErrorMessage message={error} />
-            )
-          }
+          {error && <ErrorMessage message={error} />}
+
           <div className="p-6">
             <div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
               <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">Pedido pendiente</p>
@@ -88,42 +96,84 @@ export function ReassignModal({
               <p className="mt-1 text-sm text-(--theme-text) opacity-70">{order.locationLabel ?? 'Ubicación no registrada'}</p>
             </div>
 
-            <div className="mt-5 grid gap-3">
-              {rejectingCourierName && (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-4 text-sm text-(--theme-text) opacity-80">
-                  <p className="text-xs font-800 opacity-60">Mensajero que rechazó</p>
-                  <p className="mt-1 font-700">{rejectingCourierName}</p>
-                </div>
-              )}
+            {rejectingCourierName && (
+              <div className="mt-4 rounded-2xl border border-dashed border-(--theme-border) px-4 py-4 text-sm text-(--theme-text) opacity-80">
+                <p className="text-xs font-800 opacity-60">Mensajero que rechazó</p>
+                <p className="mt-1 font-700">{rejectingCourierName}</p>
+              </div>
+            )}
 
+            {!messengersLoading && messengers.length > 0 && (
+              <p className="mt-4 text-xs text-(--theme-text) opacity-50">
+                {availableCount} de {messengers.length} mensajeros disponibles para reasignar
+              </p>
+            )}
+
+            <div className="mt-3 grid gap-3">
               {messengersLoading ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">Cargando mensajeros…</div>
+                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+                  Cargando mensajeros…
+                </div>
               ) : messengers.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">No hay mensajeros disponibles.</div>
+                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+                  No hay mensajeros registrados.
+                </div>
+              ) : availableCount === 0 ? (
+                <div className="rounded-2xl border border-dashed border-warning-border bg-warning-bg px-4 py-6 text-sm text-warning">
+                  No hay mensajeros disponibles para reasignar en este momento.
+                </div>
               ) : (
                 messengers.map((messenger) => {
-                  const isRejecting = rejectingCourierId === messenger.uid;
+                  const isRejecting = messenger.uid === rejectingCourierId;
+                  const isBusy = !messenger.isAvailable;
+                  const isDisabled = isRejecting || isBusy || !!error;
                   const isSelected = selectedCourierId === messenger.uid;
 
                   return (
                     <button
                       key={messenger.uid}
                       type="button"
-                      onClick={() => !isRejecting && onSelectCourier(order.orderId, messenger.uid)}
-                      disabled={isRejecting || !!error}
-                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition hover:border-primary hover:bg-(--theme-secondary-bg) ${isSelected ? 'border-primary bg-primary/10 text-primary' : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text)'} ${isRejecting ? 'opacity-60 cursor-not-allowed' : ''}`}
+                      onClick={() => !isDisabled && onSelectCourier(order.orderId, messenger.uid)}
+                      disabled={isDisabled}
+                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${isDisabled
+                        ? 'cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50'
+                        : isSelected
+                          ? 'border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)'
+                          : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)'
+                        }`}
                     >
                       <div className="flex items-center gap-3">
-                        <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'}`}>
-                          <UserRound size={16} />
+                        <span
+                          className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected && !isDisabled ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'
+                            }`}
+                        >
+                          <UserRound aria-hidden="true" size={16} />
                         </span>
                         <div>
-                          <p className="font-800">{messenger.displayName}</p>
-                          <p className="text-xs opacity-55">{messenger.institutionalId || 'Sin CI institucional'}</p>
+                          <p className="font-800 flex items-center gap-2">
+                            {messenger.displayName}
+                            {!isRejecting && (
+                              <span
+                                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide border ${messenger.isAvailable
+                                  ? 'bg-success-bg text-success border-success-border'
+                                  : 'bg-danger-bg text-danger border-danger-border'
+                                  }`}
+                              >
+                                {messenger.isAvailable
+                                  ? 'Disponible'
+                                  : 'Ocupado'}
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-xs opacity-55">
+                            {messenger.institutionalId || 'Sin CI institucional'}
+                          </p>
                         </div>
                       </div>
 
-                      <span className="text-sm font-semibold  opacity-70">{isRejecting ? 'Rechazó' : isSelected ? 'Seleccionado' : 'Elegir'}</span>
+                      <span className="text-sm font-semibold opacity-70">
+                        {isRejecting ? 'Rechazó' : isBusy ? '' : isSelected ? 'Seleccionado' : 'Elegir'}
+                      </span>
                     </button>
                   );
                 })
@@ -131,8 +181,22 @@ export function ReassignModal({
             </div>
 
             <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-              <button type="button" onClick={onClose} disabled={isLoading} className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50">Cancelar</button>
-              <button type="button" onClick={onConfirm} disabled={!selectedCourierId || isLoading || messengersLoading || !!error} className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50">{isLoading ? 'Reasignando…' : 'Confirmar reasignación'}</button>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isLoading}
+                className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={!selectedCourierId || isLoading || messengersLoading || !!error}
+                className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
+              >
+                {isLoading ? 'Reasignando…' : 'Confirmar reasignación'}
+              </button>
             </div>
           </div>
         </section>

--- a/src/features/seller/hooks/useGetMessengers.ts
+++ b/src/features/seller/hooks/useGetMessengers.ts
@@ -1,29 +1,31 @@
 import { useEffect, useState } from "react";
-import { getMessengers } from "../services/getMessengers"
+import { subscribeToMessengers } from "../services/getMessengers";
 import { type Messenger } from "../types";
 import { db } from "../../../lib/firebase";
 
 export const useGetMessengers = () => {
   const [messengers, setMessengers] = useState<Messenger[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchMessengers = async () => {
-      setLoading(true);
-      setError(null);
+    setLoading(true);
+    setError(null);
 
-      try {
-        const data = await getMessengers(db);
+    const unsubscribe = subscribeToMessengers(
+      db,
+      (data) => {
         setMessengers(data);
-      } catch {
-        setError('No se pudieron cargar los mensajeros.');
-      } finally {
         setLoading(false);
-      }
-    };
-    fetchMessengers();
-  }, [])
+      },
+      () => {
+        setError("No se pudieron cargar los mensajeros.");
+        setLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, []);
 
   return { messengers, loading, error };
-}
+};

--- a/src/features/seller/services/getMessengers.ts
+++ b/src/features/seller/services/getMessengers.ts
@@ -24,7 +24,7 @@ export const getMessengers = async (db: Firestore): Promise<Messenger[]> => {
       const activeQ = query(
         collection(db, 'deliveries'),
         where('courierId', '==', m.uid),
-        where('status', 'in', ['ready', 'in_transit']),
+        where('status', 'in', ['accepted', 'in_transit']),
       );
       const activeSnap = await getDocs(activeQ);
 

--- a/src/features/seller/services/getMessengers.ts
+++ b/src/features/seller/services/getMessengers.ts
@@ -9,12 +9,30 @@ export const getMessengers = async (db: Firestore): Promise<Messenger[]> => {
   );
 
   const snap = await getDocs(q);
-  return snap.docs.map((d) => {
+
+  const menssengers = snap.docs.map((d) => {
     const data = d.data();
     return {
       uid: d.id,
       displayName: data.displayName ?? data.email ?? 'Mensajero',
       institutionalId: data.institutionalId ?? '',
     };
-  });
+  })
+
+  const withAvailability: Messenger[] = await Promise.all(
+    menssengers.map(async (m) => {
+      const activeQ = query(
+        collection(db, 'deliveries'),
+        where('courierId', '==', m.uid),
+        where('status', 'in', ['ready', 'in_transit']),
+      );
+      const activeSnap = await getDocs(activeQ);
+
+      return {
+        ...m,
+        isAvailable: activeSnap.empty,
+      }
+    })
+  )
+  return withAvailability;
 }

--- a/src/features/seller/services/getMessengers.ts
+++ b/src/features/seller/services/getMessengers.ts
@@ -28,11 +28,11 @@ export const getMessengers = async (db: Firestore): Promise<Messenger[]> => {
       );
       const activeSnap = await getDocs(activeQ);
 
-      return {
-        ...m,
-        isAvailable: activeSnap.empty,
-      }
-    })
-  )
-  return withAvailability;
-}
+			return {
+				...m,
+				isAvailable: activeSnap.empty,
+			};
+		}),
+	);
+	return withAvailability;
+};

--- a/src/features/seller/services/getMessengers.ts
+++ b/src/features/seller/services/getMessengers.ts
@@ -1,38 +1,89 @@
-import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import {
+  collection,
+  onSnapshot,
+  query,
+  where,
+  type Firestore,
+  type Unsubscribe,
+} from "firebase/firestore";
 import type { Messenger } from "../types";
 
-export const getMessengers = async (db: Firestore): Promise<Messenger[]> => {
-  const q = query(
-    collection(db, 'users'),
-    where('roles', 'array-contains', 'mensajero'),
-    where('isActive', '==', true),
+interface BaseMessenger {
+  uid: string;
+  displayName: string;
+  institutionalId: string;
+}
+
+export const subscribeToMessengers = (
+  db: Firestore,
+  onData: (messengers: Messenger[]) => void,
+  onError?: (err: Error) => void,
+): Unsubscribe => {
+  let baseMessengers: BaseMessenger[] = [];
+  let busyCourierCounts: Record<string, number> = {};
+  let messengersLoaded = false;
+  let deliveriesLoaded = false;
+
+  const emit = () => {
+    if (!messengersLoaded || !deliveriesLoaded) return;
+
+    const result: Messenger[] = baseMessengers.map((m) => {
+      const activeCount = busyCourierCounts[m.uid] ?? 0;
+      return {
+        ...m,
+        isAvailable: activeCount === 0,
+      };
+    });
+
+    onData(result);
+  };
+
+  const messengersQ = query(
+    collection(db, "users"),
+    where("roles", "array-contains", "mensajero"),
+    where("isActive", "==", true),
   );
 
-  const snap = await getDocs(q);
+  const unsubMessengers = onSnapshot(
+    messengersQ,
+    (snap) => {
+      baseMessengers = snap.docs.map((d) => {
+        const data = d.data();
+        return {
+          uid: d.id,
+          displayName: data.displayName ?? data.email ?? "Mensajero",
+          institutionalId: data.institutionalId ?? "",
+        };
+      });
+      messengersLoaded = true;
+      emit();
+    },
+    (err) => onError?.(err),
+  );
 
-  const menssengers = snap.docs.map((d) => {
-    const data = d.data();
-    return {
-      uid: d.id,
-      displayName: data.displayName ?? data.email ?? 'Mensajero',
-      institutionalId: data.institutionalId ?? '',
-    };
-  })
+  const deliveriesQ = query(
+    collection(db, "deliveries"),
+    where("status", "in", ["accepted", "in_transit"]),
+  );
 
-  const withAvailability: Messenger[] = await Promise.all(
-    menssengers.map(async (m) => {
-      const activeQ = query(
-        collection(db, 'deliveries'),
-        where('courierId', '==', m.uid),
-        where('status', 'in', ['accepted', 'in_transit']),
-      );
-      const activeSnap = await getDocs(activeQ);
+  const unsubDeliveries = onSnapshot(
+    deliveriesQ,
+    (snap) => {
+      const counts: Record<string, number> = {};
+      for (const doc of snap.docs) {
+        const courierId = doc.data().courierId as string | undefined;
+        if (!courierId) continue;
+        counts[courierId] = (counts[courierId] ?? 0) + 1;
+      }
+      busyCourierCounts = counts;
+      deliveriesLoaded = true;
+      emit();
+    },
+    (err) => onError?.(err),
+  );
 
-			return {
-				...m,
-				isAvailable: activeSnap.empty,
-			};
-		}),
-	);
-	return withAvailability;
+  return () => {
+    unsubMessengers();
+    unsubDeliveries();
+  };
 };

--- a/src/features/seller/services/sellerServices.ts
+++ b/src/features/seller/services/sellerServices.ts
@@ -9,6 +9,7 @@ import {
   type Firestore,
 } from 'firebase/firestore';
 import type { Order, OrderDoc } from '../types';
+import type { DeliveryData } from '../types/pendingOrders';
 
 
 function toDate(value: unknown): Date | null {
@@ -126,7 +127,7 @@ async function fetchLocationsData(
 export async function fetchDeliveryData(
   db: Firestore,
   deliveryId: string | null | undefined,
-): Promise<{ deliveryCode: string | null; deliveryCourierName: string | null; deliveryCourierInstitutionalId: string | null } | null> {
+): Promise<DeliveryData | null> {
   if (!deliveryId) return null;
 
   try {
@@ -152,7 +153,7 @@ export async function fetchDeliveryData(
       deliveryCourierName,
       deliveryCourierInstitutionalId,
       courierId: data.courierId ?? null,
-    } as any;
+    };
   } catch {
     return null;
   }

--- a/src/features/seller/types.ts
+++ b/src/features/seller/types.ts
@@ -77,8 +77,8 @@ export type OrderItemDoc = {
 };
 
 export interface Messenger {
-  uid: string;
-  displayName: string;
-  institutionalId: string;
-  isAvailable: boolean;
+	uid: string;
+	displayName: string;
+	institutionalId: string;
+	isAvailable: boolean;
 }

--- a/src/features/seller/types.ts
+++ b/src/features/seller/types.ts
@@ -80,4 +80,5 @@ export interface Messenger {
   uid: string;
   displayName: string;
   institutionalId: string;
+  isAvailable: boolean;
 }

--- a/src/features/seller/types/pendingOrders.ts
+++ b/src/features/seller/types/pendingOrders.ts
@@ -17,3 +17,10 @@ export interface PendingOrdersResponse {
   pedidos: PendingOrder[];
   total: number;
 }
+
+export interface DeliveryData {
+  deliveryCode: string | null;
+  deliveryCourierName: string | null;
+  deliveryCourierInstitutionalId: string | null;
+  courierId: string | null;
+}


### PR DESCRIPTION
## Resumen
Se restringe la asignación de pedidos a mensajeros ocupados: los mensajeros con al menos un delivery activo (`accepted` o `in_transit`) ahora se muestran deshabilitados en el selector, evitando sobrecargar a un mismo mensajero con múltiples pedidos simultáneos.

## URL de los cambios
- URL: http://localhost:4321/seller/ready-orders
- Ruta : Panel de vendedor → Pedidos listos → Modal "Asignar mensajero"

## Cómo probar
1. Ingresar como vendedor al panel de pedidos listos
2. Hacer clic en "Asignar mensajero" sobre cualquier pedido en estado LISTO
3. Verificar que los mensajeros con delivery activo (`accepted` o `in_transit`) aparecen con badge "Ocupado", deshabilitados y sin opción de selección
4. Verificar que los mensajeros sin delivery activo aparecen con badge "Disponible" y permiten ser seleccionados normalmente
5. Confirmar la asignación a un mensajero disponible y validar que el pedido pasa correctamente a estado ASIGNADO

## Resultado esperado
- Los mensajeros ocupados se muestran visualmente diferenciados y no son clickeables.
- Los mensajeros disponibles se muestran con badge verde "Disponible" y permiten selección y asignación normal.
- Si todos los mensajeros están ocupados, se muestra un mensaje informativo en lugar de la lista.


## Evidencia visual
| Antes | Después |
| --- | --- |
| <!-- imagen --> | <!-- imagen --> |

## Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
Closes #[número de la HU de asignación con disponibilidad]

## Checklist del autor
- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa
