### PR TITLE
Feature/reportar no entregado unico

### DIFF
--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -4,7 +4,6 @@ import {
   AlertTriangle,
   ArrowLeft,
   CheckCircle2,
-  DollarSign,
   LoaderCircle,
   MapPin,
   Package,
@@ -16,7 +15,6 @@ import {
 import PaymentSuccessModal from '../modals/PaymentSuccessModal';
 import ConfirmPaymentModal from '../modals/Confirmpaymentmodal';
 import UndeliveredModal from '../modals/UndeliveredModal';
-import CancelNoPaymentModal from '../modals/CancelNoPaymentModal';
 import ConfirmAssignedOrderActionModal, {
   type AssignedOrderAction,
 } from '../modals/ConfirmAssignedOrderActionModal';
@@ -24,7 +22,6 @@ import { auth } from '../../../lib/firebase';
 import { parseOrderId } from '../../cart/services/orderService';
 import {
   getMessengerOrderById,
-  markMessengerOrderAsCancelledByNoPayment,
   markMessengerOrderAsNotDelivered,
   registerMessengerCashPayment,
   setMessengerOrderStatus,
@@ -85,19 +82,6 @@ const getStatusUpdateMessage = (status: MessengerOrder['deliveryStatus']) => {
   return `Estado actualizado a ${getDeliveryStatusLabel(status)}.`;
 };
 
-const canCancelByNoPayment = (order: MessengerOrder) => {
-  const paymentText = `${order.paymentStatus} ${order.paymentStatusLabel}`
-    .toLowerCase()
-    .trim();
-
-  return (
-    (order.deliveryStatus === 'accepted' || order.deliveryStatus === 'in_transit') &&
-    !paymentText.includes('cobrado') &&
-    !paymentText.includes('pagado') &&
-    !paymentText.includes('cancelado')
-  );
-};
-
 function CopyableOrderId({ order }: { order: MessengerOrder }) {
   const { uuid, friendlyName } = parseOrderId(order.id);
   const displayId = order.displayId ?? friendlyName;
@@ -121,22 +105,20 @@ function CopyableOrderId({ order }: { order: MessengerOrder }) {
 function DetailActions({
   order,
   onAssignedAction,
-  onCancelNoPayment,
   onDelivered,
   onInTransit,
   onNotDelivered,
 }: {
   order: MessengerOrder;
   onAssignedAction: (action: AssignedOrderAction) => void;
-  onCancelNoPayment: () => void;
   onDelivered: () => void;
   onInTransit: () => void;
   onNotDelivered: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       <a
-        className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+        className="messenger-map-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-4 text-sm font-bold transition"
         href={buildBuyerMapUrl(order)}
         onClick={() => storeBuyerMapOrder(order)}
       >
@@ -147,7 +129,7 @@ function DetailActions({
       {order.deliveryStatus === 'assigned' && (
         <>
           <button
-            className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+            className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-4 text-sm font-bold transition"
             onClick={() => onAssignedAction('accept')}
             type="button"
           >
@@ -155,7 +137,7 @@ function DetailActions({
             Aceptar pedido
           </button>
           <button
-            className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+            className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-4 text-sm font-bold transition"
             onClick={() => onAssignedAction('reject')}
             type="button"
           >
@@ -167,7 +149,7 @@ function DetailActions({
 
       {order.deliveryStatus === 'accepted' && (
         <button
-          className="messenger-transit-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold shadow-lg transition"
+          className="messenger-transit-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-4 text-sm font-bold shadow-lg transition"
           onClick={onInTransit}
           type="button"
         >
@@ -178,7 +160,7 @@ function DetailActions({
 
       {order.deliveryStatus === 'in_transit' && (
         <button
-          className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+          className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-4 text-sm font-bold transition"
           onClick={onDelivered}
           type="button"
         >
@@ -189,7 +171,7 @@ function DetailActions({
 
       {(order.deliveryStatus === 'accepted' || order.deliveryStatus === 'in_transit') && (
         <button
-          className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+          className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-4 text-sm font-bold transition"
           onClick={onNotDelivered}
           type="button"
         >
@@ -198,16 +180,6 @@ function DetailActions({
         </button>
       )}
 
-      {canCancelByNoPayment(order) && (
-        <button
-          className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-          onClick={onCancelNoPayment}
-          type="button"
-        >
-          <DollarSign size={17} />
-          Cancelar por falta de pago
-        </button>
-      )}
     </div>
   );
 }
@@ -225,9 +197,6 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
   const [savingAssignedAction, setSavingAssignedAction] = useState(false);
   const [undeliveredOrder, setUndeliveredOrder] = useState<MessengerOrder | null>(null);
   const [savingUndelivered, setSavingUndelivered] = useState(false);
-  const [cancelNoPaymentOrder, setCancelNoPaymentOrder] =
-    useState<MessengerOrder | null>(null);
-  const [savingCancelNoPayment, setSavingCancelNoPayment] = useState(false);
   const [confirmPaymentOrder, setConfirmPaymentOrder] = useState<MessengerOrder | null>(
     null
   );
@@ -356,36 +325,6 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
       setError('No se pudo registrar el incidente.');
     } finally {
       setSavingUndelivered(false);
-    }
-  };
-
-  const registerCancelNoPayment = async (notes: string) => {
-    if (!cancelNoPaymentOrder) return;
-
-    const previousOrder = cancelNoPaymentOrder;
-    setSavingCancelNoPayment(true);
-    setOrder({
-      ...previousOrder,
-      deliveryStatus: 'cancelled',
-      paymentStatus: 'CANCELADO',
-      paymentStatusLabel: 'Cancelado por falta de pago',
-    });
-
-    try {
-      await markMessengerOrderAsCancelledByNoPayment({
-        order: previousOrder,
-        notes,
-        courierId,
-      });
-      setMessage(getStatusUpdateMessage('cancelled'));
-      setCancelNoPaymentOrder(null);
-      await loadOrder({ showLoading: false });
-    } catch (cancelError) {
-      console.error(cancelError);
-      setOrder(previousOrder);
-      setError('No se pudo cancelar el pedido por falta de pago.');
-    } finally {
-      setSavingCancelNoPayment(false);
     }
   };
 
@@ -524,7 +463,6 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
             <DetailActions
               order={order}
               onAssignedAction={(action) => setPendingAssignedAction({ order, action })}
-              onCancelNoPayment={() => setCancelNoPaymentOrder(order)}
               onDelivered={() => setConfirmPaymentOrder(order)}
               onInTransit={() => void updateStatus('in_transit')}
               onNotDelivered={() => setUndeliveredOrder(order)}
@@ -587,15 +525,6 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
           order={undeliveredOrder}
           onClose={() => setUndeliveredOrder(null)}
           onConfirm={registerUndeliveredOrder}
-        />
-      )}
-
-      {cancelNoPaymentOrder && (
-        <CancelNoPaymentModal
-          isSaving={savingCancelNoPayment}
-          order={cancelNoPaymentOrder}
-          onClose={() => setCancelNoPaymentOrder(null)}
-          onConfirm={registerCancelNoPayment}
         />
       )}
 

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -21,7 +21,6 @@ import { auth } from '../../../lib/firebase';
 import { parseOrderId } from '../../cart/services/orderService';
 import {
     closeMessengerShift,
-    markMessengerOrderAsCancelledByNoPayment,
     markMessengerOrderAsNotDelivered,
     registerMessengerCashPayment,
     setMessengerOrderStatus,
@@ -43,7 +42,6 @@ import {
 import { formatBolivianos } from '../utils/money';
 import UndeliveredModal from '../modals/UndeliveredModal';
 
-import CancelNoPaymentModal from '../modals/CancelNoPaymentModal';
 import './MessengerDashboard.css';
 import ConfirmPaymentModal from '../modals/Confirmpaymentmodal';
 import ConfirmAssignedOrderActionModal, {
@@ -185,19 +183,6 @@ const openDeliveryMap = (order: MessengerOrder) => {
     window.location.href = buildBuyerMapUrl(order);
 };
 
-const canCancelByNoPayment = (order: MessengerOrder) => {
-    const paymentText = `${order.paymentStatus} ${order.paymentStatusLabel}`
-        .toLowerCase()
-        .trim();
-
-    return (
-        (order.deliveryStatus === 'accepted' || order.deliveryStatus === 'in_transit') &&
-        !paymentText.includes('cobrado') &&
-        !paymentText.includes('pagado') &&
-        !paymentText.includes('cancelado')
-    );
-};
-
 function MessageToast({ message, onDismiss }: { message: string; onDismiss: () => void }) {
     useEffect(() => {
         const timer = setTimeout(onDismiss, 3000);
@@ -313,7 +298,6 @@ function PendingOrderCard({
     order,
     onAccept,
     onDelivered,
-    onCancelNoPayment,
     onDetail,
     onInTransit,
     onNotDelivered,
@@ -322,7 +306,6 @@ function PendingOrderCard({
     order: MessengerOrder;
     onAccept: (orderId: string) => void;
     onDelivered: (order: MessengerOrder) => void;
-    onCancelNoPayment: (order: MessengerOrder) => void;
     onDetail: (order: MessengerOrder) => void;
     onInTransit: (orderId: string) => void;
     onNotDelivered: (order: MessengerOrder) => void;
@@ -583,13 +566,11 @@ function OrderDetailModal({
     order,
     onClose,
     onDelivered,
-    onCancelNoPayment,
     onNotDelivered,
 }: {
     order: MessengerOrder;
     onClose: () => void;
     onDelivered: (order: MessengerOrder) => void;
-    onCancelNoPayment: (order: MessengerOrder) => void;
     onNotDelivered: (order: MessengerOrder) => void;
 }) {
     const subtotal = order.items.reduce(
@@ -777,20 +758,6 @@ function OrderDetailModal({
                                 >
                                     <CheckCircle2 size={18} />
                                     <span>Registrar pago</span>
-                                </button>
-                            )}
-
-                            {canCancelByNoPayment(order) && (
-                                <button
-                                    className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition active:scale-95"
-                                    onClick={() => {
-                                        onClose();
-                                        onCancelNoPayment(order);
-                                    }}
-                                    type="button"
-                                >
-                                    <DollarSign size={18} />
-                                    <span>Cancelar por falta de pago</span>
                                 </button>
                             )}
 
@@ -1099,9 +1066,6 @@ export default function MessengerDashboard({
     const [undeliveredOrder, setUndeliveredOrder] =
         useState<MessengerOrder | null>(null);
     const [savingUndelivered, setSavingUndelivered] = useState(false);
-    const [cancelNoPaymentOrder, setCancelNoPaymentOrder] =
-        useState<MessengerOrder | null>(null);
-    const [savingCancelNoPayment, setSavingCancelNoPayment] = useState(false);
     const [confirmPaymentOrder, setConfirmPaymentOrder] = useState<MessengerOrder | null>(null);
     const [paymentSuccessOrder, setPaymentSuccessOrder] = useState<MessengerOrder | null>(null);
     const [pendingAssignedAction, setPendingAssignedAction] = useState<{
@@ -1570,49 +1534,6 @@ export default function MessengerDashboard({
         }
     };
 
-    const registerCancelNoPayment = async (notes: string) => {
-        if (!cancelNoPaymentOrder) return;
-
-        const targetOrder = cancelNoPaymentOrder;
-        setSavingCancelNoPayment(true);
-
-        setOrders((currentOrders) =>
-            currentOrders.map((order) =>
-                order.id === targetOrder.id
-                    ? {
-                        ...order,
-                        deliveryStatus: 'cancelled',
-                        paymentStatus: 'CANCELADO',
-                        paymentStatusLabel: 'Cancelado por falta de pago',
-                    }
-                    : order
-            )
-        );
-
-        try {
-            await markMessengerOrderAsCancelledByNoPayment({
-                order: targetOrder,
-                notes,
-                courierId: currentCourierId,
-            });
-
-            setMessage('Pedido cancelado por falta de pago.');
-            setCancelNoPaymentOrder(null);
-            navigateToDeliveryOrderDetail(targetOrder.id);
-        } catch (error) {
-            console.error(error);
-            setMessage('No se pudo cancelar el pedido por falta de pago.');
-
-            setOrders((currentOrders) =>
-                currentOrders.map((order) =>
-                    order.id === targetOrder.id ? targetOrder : order
-                )
-            );
-        } finally {
-            setSavingCancelNoPayment(false);
-        }
-    };
-        
     const confirmCloseShift = async () => {
         if (!currentCourierId) {
             setMessage('No se pudo identificar al mensajero para cerrar la jornada.');
@@ -1804,7 +1725,6 @@ export default function MessengerDashboard({
                                             key={`${clientSection}-${order.deliveryId || order.id}`}
                                             order={order}
                                             onAccept={acceptOrder}
-                                            onCancelNoPayment={setCancelNoPaymentOrder}
                                             onDelivered={markAsDelivered}
                                             onDetail={(order) =>
                                                 navigateToDeliveryOrderDetail(order.id)
@@ -1985,7 +1905,6 @@ export default function MessengerDashboard({
                 <OrderDetailModal
                     order={detailOrder}
                     onClose={() => setDetailOrder(null)}
-                    onCancelNoPayment={setCancelNoPaymentOrder}
                     onDelivered={markAsDelivered}
                     onNotDelivered={setUndeliveredOrder}
                 />
@@ -1997,14 +1916,6 @@ export default function MessengerDashboard({
                     order={undeliveredOrder}
                     onClose={() => setUndeliveredOrder(null)}
                     onConfirm={registerUndeliveredOrder}
-                />
-            )}
-            {cancelNoPaymentOrder && (
-                <CancelNoPaymentModal
-                    isSaving={savingCancelNoPayment}
-                    order={cancelNoPaymentOrder}
-                    onClose={() => setCancelNoPaymentOrder(null)}
-                    onConfirm={registerCancelNoPayment}
                 />
             )}
             {pendingAssignedAction && (

--- a/src/features/mensajero/modals/UndeliveredModal.tsx
+++ b/src/features/mensajero/modals/UndeliveredModal.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
+  DollarSign,
   HandMetal,
   LoaderCircle,
   MapPinOff,
@@ -29,6 +30,11 @@ const reasons = [
     id: 'acceso_restringido',
     label: 'Acceso restringido',
     icon: ShieldAlert,
+  },
+  {
+    id: 'falta_pago_cliente',
+    label: 'Falta de pago del cliente',
+    icon: DollarSign,
   },
   { id: 'cliente_rechazo', label: 'Cliente rechazo pedido', icon: HandMetal },
   { id: 'otro', label: 'Otro motivo', icon: MoreHorizontal },


### PR DESCRIPTION
## Resumen

Se unifica el flujo de pedidos no entregados para mensajero: ahora `Falta de pago del cliente` se registra como motivo dentro del modal de **No entregado**. También se elimina el botón separado de cancelación y se alinean los botones de acción en el detalle del pedido.

## URL de los cambios

- URL: http://localhost:4321/courier -> También revisar botón "Ver Detalle" 
- Ruta o pantalla afectada: `/courier` y `/delivery/order/:id`,

## Cómo probar

1. Iniciar sesión como mensajero.
2. Entrar a `/courier` y revisar un pedido aceptado o en camino.
3. Abrir el detalle del pedido en `/delivery/order/:id`.
4. Presionar **No entregado**
5. Seleccionar **Falta de pago

## Resultado esperado

En ambas pantallas, `/courier` y `/delivery/order/:id`, se mantiene un único flujo para reportar pedidos no entregados. El pedido queda como **NO ENTREGADO**, la entrega queda como `not_delivered`, y el motivo seleccionado queda guardado; sin usar el estado `CANCELADO` que ahora pertenece a otra sección del flujo.

## Evidencia visual

| Antes | Después |
| --- | --- |
| 
<img width="1176" height="713" alt="image" src="https://github.com/user-attachments/assets/3a24c790-a981-46e9-9dc8-c5c6fb99b2f9" />
 | 
<img width="1176" height="706" alt="image" src="https://github.com/user-attachments/assets/9475f07d-604a-4895-80ab-b7da67832883" />
 |

## Tipo de cambio

- [X] Nueva funcionalidad
- [X] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

Closes #569 

## Checklist del autor

- [X] Probé el cambio localmente
- [X] Agregué la URL o ruta donde se revisa el cambio
- [X] Agregué evidencia visual o indiqué que no aplica
- [X] No hay errores ni warnings nuevos conocidos
- [X] Revisé mi propio código antes de pedir review

## Notas para quien revisa

El flujo normal de **No entregado** se mantiene y ahora es compartido en ambas pantallas anteriormente mencionadas. La falta de pago ya no da el estado de `CANCELADO`; en su lugar se registra como motivo de no entrega para mantener estados consistentes.
