### PR TITLE
Fix/UI fixes

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -196,7 +196,6 @@ export default function Navbar() {
   const showOperadorInvFeatures = user && roles.length > 0 && roles.some(r => ['operador_inv', 'admin'].includes(r));
   const showMensajeroFeatures = user && roles.length > 0 && roles.some(r => ['mensajero', 'admin'].includes(r));
   const showAdminFeatures = user && roles.length > 0 && roles.some(r => ['admin'].includes(r));
-  const showMisPedidos = user && roles.length > 0 && roles.some(r => ['comprador', 'admin'].includes(r));
 
   return (
     <>
@@ -326,17 +325,6 @@ export default function Navbar() {
                           Mi Perfil
                         </a>
 
-                        {showMisPedidos && (
-                          <a
-                            role="menuitem"
-                            href="/mis-pedidos"
-                            className="flex items-center gap-2 px-4 py-2.5 text-[13px] font-semibold text-text-light opacity-70 transition-colors hover:bg-border-light/40 hover:text-primary hover:opacity-100"
-                          >
-                            <Package size={14} />
-                            Mis pedidos
-                          </a>
-                        )}
-
                         {canAccessCourier && (
                           <a
                             role="menuitem"
@@ -441,15 +429,6 @@ export default function Navbar() {
                       className="text-[13px] font-semibold text-primary opacity-90 transition-all hover:opacity-100"
                     >
                       Mis direcciones
-                    </a>
-                  )}
-
-                  {showMisPedidos && (
-                    <a
-                      href="/mis-pedidos"
-                      className="text-[13px] font-semibold text-primary opacity-90 transition-all hover:opacity-100"
-                    >
-                      Mis pedidos
                     </a>
                   )}
 

--- a/src/features/location/components/ConfirmModal.tsx
+++ b/src/features/location/components/ConfirmModal.tsx
@@ -29,11 +29,11 @@ export default function ConfirmModal({
             onClick={onCancel}
         >
             <div
-                className="w-full max-w-sm overflow-hidden rounded-2xl bg-(--theme-card-bg) border border-[#88B04B]/20 shadow-xl"
+                className="w-full max-w-sm overflow-hidden rounded-2xl bg-(--theme-card-bg) border border-(--theme-border) shadow-xl"
                 onClick={(e) => e.stopPropagation()}
             >
-                <div className="flex items-center justify-between border-b border-[#88B04B]/10 px-5 py-4">
-                    <h3 className="font-outfit font-bold text-(--theme-text) text-lg">
+                <div className="flex items-center justify-between border-b border-(--theme-border) px-5 py-4">
+                    <h3 className="font-bold text-(--theme-text) text-lg">
                         {title}
                     </h3>
                     <button
@@ -45,7 +45,7 @@ export default function ConfirmModal({
                 </div>
 
                 <div className="px-5 py-4">
-                    <p className="font-inter text-(--theme-text)/80">
+                    <p className="text-(--theme-text)/80">
                         {message}
                     </p>
                 </div>
@@ -53,13 +53,13 @@ export default function ConfirmModal({
                 <div className="flex gap-3 px-5 pb-5 pt-2">
                     <button
                         onClick={onCancel}
-                        className="flex-1 rounded-full border border-[#88B04B]/40 py-2.5 font-outfit text-xs font-bold uppercase tracking-wider text-[#88B04B] transition-all hover:bg-[#88B04B]/5"
+                        className="flex-1 rounded-full border border-(--theme-border) py-2.5 text-xs font-bold uppercase tracking-wider text-(--theme-text) transition-all hover:bg-(--theme-secondary-bg)"
                     >
                         {cancelText}
                     </button>
                     <button
                         onClick={onConfirm}
-                        className="flex-1 rounded-full bg-red-500 py-2.5 font-outfit text-xs font-bold uppercase tracking-wider text-white transition-all hover:bg-red-600"
+                        className="flex-1 rounded-full bg-(--theme-danger) text-white hover:opacity-90 py-2.5 text-xs font-bold uppercase tracking-wider transition-all"
                     >
                         {confirmText}
                     </button>

--- a/src/features/location/components/ErrorModal.tsx
+++ b/src/features/location/components/ErrorModal.tsx
@@ -23,20 +23,20 @@ export default function ErrorModal({
             onClick={onClose}
         >
             <div
-                className="w-full max-w-sm overflow-hidden rounded-2xl bg-(--theme-card-bg) border border-red-500/30 shadow-xl"
+                className="w-full max-w-sm overflow-hidden rounded-2xl bg-(--theme-card-bg) border border-(--theme-border) shadow-xl"
                 onClick={(e) => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="flex items-center justify-between border-b border-red-500/20 px-5 py-4">
+                <div className="flex items-center justify-between border-b border-(--theme-border) px-5 py-4">
                     <div className="flex items-center gap-2">
-                        <AlertCircle size={20} className="text-red-500" />
-                        <h3 className="font-outfit font-bold text-(--theme-text) text-lg">
+                        <AlertCircle size={20} className="text-(--theme-danger)" />
+                        <h3 className="font-bold text-(--theme-text) text-lg">
                             {title}
                         </h3>
                     </div>
                     <button
                         onClick={onClose}
-                        className="flex h-8 w-8 items-center justify-center rounded-full bg-(--theme-secondary-bg) text-(--theme-text) hover:bg-red-500 hover:text-white transition-all duration-200"
+                        className="flex h-8 w-8 items-center justify-center rounded-full bg-(--theme-secondary-bg) text-(--theme-text) hover:bg-(--theme-danger) hover:text-white transition-all duration-200"
                     >
                         <X size={18} />
                     </button>
@@ -44,7 +44,7 @@ export default function ErrorModal({
 
                 {/* Body  */}
                 <div className="px-5 py-4">
-                    <p className="font-inter text-(--theme-text)/80">
+                    <p className="text-(--theme-text)/80">
                         {message}
                     </p>
                 </div>
@@ -53,7 +53,7 @@ export default function ErrorModal({
                 <div className="flex gap-3 px-5 pb-5 pt-2">
                     <button
                         onClick={onClose}
-                        className="flex-1 rounded-full bg-red-500 py-2.5 font-outfit text-xs font-bold uppercase tracking-wider text-white transition-all hover:bg-red-600"
+                        className="flex-1 rounded-full bg-(--theme-danger) py-2.5 text-xs font-bold uppercase tracking-wider text-white transition-all hover:opacity-90"
                     >
                         Entendido
                     </button>

--- a/src/features/location/components/LocationCard.tsx
+++ b/src/features/location/components/LocationCard.tsx
@@ -100,24 +100,24 @@ export default function LocationCard({
                     group flex items-center gap-3 rounded-[1.25rem] border px-4 py-3 
                     transition-all duration-300 cursor-pointer
                     ${isSelected
-                        ? 'border-[#88B04B] bg-[#88B04B]/10 shadow-[0_0_0_2px_rgba(136,176,75,0.15)]'
-                        : 'border-(--theme-border) bg-(--theme-card-bg) hover:border-[#88B04B]'
+                      ? 'border-2 border-primary bg-primary/5'
+                      : 'border-(--theme-border) bg-(--theme-card-bg) hover:border-primary'
                     }
                     ${isDeleting ? 'opacity-50 pointer-events-none' : ''}
                 `}
             >
-                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#88B04B]/10 text-[#88B04B] transition-colors duration-300">
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-(--theme-secondary-bg) text-(--theme-text) transition-colors duration-300">
                     {TYPE_ICONS[type]}
                 </div>
 
                 <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                        <span className="font-outfit text-sm font-extrabold leading-none text-(--theme-text) transition-colors duration-300  truncate block w-full">
+                        <span className="text-sm font-extrabold leading-none text-(--theme-text) transition-colors duration-300  truncate block w-full">
                             {label}
                         </span>
                     </div>
 
-                    <p className="mt-1 font-inter text-[10px] font-bold uppercase tracking-widest text-[#88B04B] truncate block w-full">
+                    <p className="mt-1 text-[10px] font-bold uppercase tracking-widest text-primary truncate block w-full">
                         {type}
                     </p>
                 </div>
@@ -129,12 +129,12 @@ export default function LocationCard({
                         className={`
                             flex h-8 w-8 items-center justify-center rounded-full transition-all
                             ${isDefault
-                                ? 'text-[#88B04B] opacity-100'
-                                : 'text-[#88B04B] opacity-40 hover:opacity-100'
+                                ? 'text-primary opacity-100'
+                                : 'text-(--theme-text) opacity-40 hover:opacity-100 hover:text-primary'
                             }
                         `}
                     >
-                        <Star size={16} fill={isDefault ? '#88B04B' : 'none'} />
+                        <Star size={16} fill={isDefault ? 'currentColor' : 'none'} />
                     </button>
 
                     <button
@@ -142,8 +142,8 @@ export default function LocationCard({
                         aria-label={`Editar ${label}`}
                         className="
                             flex h-8 w-8 items-center justify-center rounded-full
-                            text-blue-500 opacity-40 transition-all
-                            hover:opacity-100
+                            text-(--theme-text) opacity-40 transition-all
+                            hover:opacity-100 hover:text-primary
                         "
                     >
                         <Pencil size={16} />
@@ -155,8 +155,8 @@ export default function LocationCard({
                         aria-label={`Eliminar ${label}`}
                         className="
                             flex h-8 w-8 items-center justify-center rounded-full
-                            text-red-500 opacity-40 transition-all
-                            hover:opacity-100
+                            text-(--theme-danger) opacity-40 transition-all
+                            hover:opacity-100 hover:bg-(--theme-danger-bg)
                             disabled:opacity-20 disabled:cursor-not-allowed
                         "
                     >

--- a/src/features/location/components/LocationSection.tsx
+++ b/src/features/location/components/LocationSection.tsx
@@ -55,16 +55,16 @@ export default function LocationSection() {
             <div className="flex items-center gap-3">
 
                 {selectedLocation ? (
-                    <div className="flex items-center gap-2.5 rounded-full border border-[#88B04B]/30 bg-[#88B04B]/5 px-4 py-2.5 transition-colors duration-300 min-w-0 max-w-xs sm:max-w-md">
-                        <MapPin size={14} className="shrink-0 text-[#88B04B]" />
-                        <span className="font-outfit text-sm font-bold text-(--theme-text) transition-colors duration-300 truncate">
+                    <div className="flex items-center gap-2.5 rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) px-4 py-2.5 transition-colors duration-300 min-w-0 max-w-xs sm:max-w-md">
+                        <MapPin size={14} className="shrink-0 text-primary" />
+                        <span className="text-sm font-bold text-(--theme-text) transition-colors duration-300 truncate">
                             {selectedLocation.label}
                         </span>
                     </div>
                 ) : (
-                    <div className="flex items-center gap-2 rounded-full border border-dashed border-[#88B04B]/25 px-4 py-2.5 transition-colors duration-300">
-                        <MapPin size={14} className="shrink-0 text-[#88B04B]/40" />
-                        <span className="font-outfit text-sm font-bold text-(--theme-text)/30 transition-colors duration-300">
+                    <div className="flex items-center gap-2 rounded-full border border-dashed border-primary/30 px-4 py-2.5 transition-colors duration-300">
+                        <MapPin size={14} className="shrink-0 text-primary opacity-40" />
+                        <span className="text-sm font-bold text-(--theme-text)/30 transition-colors duration-300">
                             Sin destino
                         </span>
                     </div>
@@ -73,9 +73,9 @@ export default function LocationSection() {
                 <button
                     onClick={() => setModalView('list')}
                     className="
-                        rounded-full border-2 border-[#88B04B] px-6 py-2.5
-                        font-outfit text-xs font-black uppercase tracking-widest
-                        text-[#88B04B] transition-all hover:bg-[#88B04B] hover:text-white
+                        rounded-full border-2 border-primary px-6 py-2.5
+                        text-xs font-black uppercase tracking-widest
+                        text-primary transition-all hover:bg-primary hover:text-white
                         active:scale-95
                     "
                 >
@@ -112,12 +112,12 @@ export default function LocationSection() {
                     }}
                 >
                     <div
-                        className="w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
+                        className="w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden rounded-[2.5rem] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <div className="flex flex-shrink-0 items-center justify-between border-b border-[#88B04B]/10 px-7 py-5">
+                        <div className="flex flex-shrink-0 items-center justify-between border-b border-(--theme-border) px-7 py-5">
                             {/* editando o creando */}
-                            <h2 className="font-outfit text-lg font-black tracking-tight text-(--theme-text) transition-colors duration-300">
+                            <h2 className="text-lg font-black tracking-tight text-(--theme-text) transition-colors duration-300">
                                 {editingLocation ? "Editar Ubicación" : "Nueva Ubicación"}
                             </h2>
                             <button
@@ -129,7 +129,7 @@ export default function LocationSection() {
                                 className="
                                     flex h-9 w-9 items-center justify-center rounded-full
                                     bg-(--theme-secondary-bg) text-(--theme-text)
-                                    hover:bg-[#88B04B] hover:text-white transition-all duration-200
+                                    hover:bg-primary hover:text-white transition-all duration-200
                                 "
                             >
                                 <X size={18} />
@@ -146,9 +146,9 @@ export default function LocationSection() {
             )}
 
             {toast && (
-                <div className="fixed bottom-6 left-1/2 z-[200] flex -translate-x-1/2 items-center gap-2 rounded-full bg-[#88B04B] px-5 py-2.5 shadow-lg">
+                <div className="fixed bottom-6 left-1/2 z-[200] flex -translate-x-1/2 items-center gap-2 rounded-full bg-primary px-5 py-2.5 shadow-lg">
                     <CheckCircle size={15} className="text-white" />
-                    <span className="font-outfit text-sm font-bold text-white">
+                    <span className="text-sm font-bold text-white">
                         {editingLocation ? "Ubicación actualizada" : "Ubicación guardada correctamente"}
                     </span>
                 </div>

--- a/src/features/location/components/LocationsModal.tsx
+++ b/src/features/location/components/LocationsModal.tsx
@@ -44,10 +44,10 @@ export default function LocationsModal({
             onClick={onClose}
         >
             <div
-                className="w-full max-w-sm overflow-hidden rounded-[2.5rem] border border-[#88B04B]/20 bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
+                className="w-full max-w-sm overflow-hidden rounded-[2.5rem] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl transition-colors duration-300"
                 onClick={(e) => e.stopPropagation()}
             >
-                <div className="flex items-center justify-between border-b border-[#88B04B]/10 px-7 py-5">
+                <div className="flex items-center justify-between border-b border-(--theme-border) px-7 py-5">
                     <h2 className="font-outfit text-lg font-black tracking-tight text-(--theme-text) transition-colors duration-300">
                         Mis Ubicaciones
                     </h2>
@@ -57,7 +57,7 @@ export default function LocationsModal({
                         className="
                             flex h-9 w-9 items-center justify-center rounded-full
                             bg-(--theme-secondary-bg) text-(--theme-text)
-                            hover:bg-[#88B04B] hover:text-white transition-all duration-200
+                            hover:bg-primary hover:text-white transition-all duration-200
                         "
                     >
                         <X size={18} />
@@ -67,12 +67,12 @@ export default function LocationsModal({
                 <div className="flex max-h-[22rem] flex-col gap-3 overflow-y-auto p-5 custom-scrollbar">
                     {loading ? (
                         <div className="flex flex-col items-center gap-3 py-12 text-(--theme-text)/40">
-                            <Loader2 size={28} className="animate-spin text-[#88B04B]/60" />
+                            <Loader2 size={28} className="animate-spin text-primary/60" />
                             <p className="font-outfit text-sm font-bold">Cargando ubicaciones...</p>
                         </div>
                     ) : locations.length === 0 ? (
                         <div className="flex flex-col items-center gap-3 py-12 text-(--theme-text)/40">
-                            <MapPin size={32} className="text-[#88B04B]/40" />
+                            <MapPin size={32} className="text-primary/40" />
                             <p className="font-outfit text-sm font-bold">No hay destinos guardados</p>
                         </div>
                     ) : (
@@ -95,9 +95,9 @@ export default function LocationsModal({
                         onClick={onAddNew}
                         className="
                             flex w-full items-center justify-center gap-2 rounded-full
-                            border-2 border-[#88B04B]/40 py-3
-                            font-outfit text-[11px] font-black uppercase tracking-[0.15em] text-[#88B04B]
-                            transition-all hover:border-[#88B04B] hover:bg-[#88B04B]/5 active:scale-95
+                            border-2 border-primary/40 py-3
+                            text-[11px] font-black uppercase tracking-[0.15em] text-primary
+                            transition-all hover:border-primary hover:bg-primary/5 active:scale-95
                         "
                     >
                         <Plus size={16} strokeWidth={3} />
@@ -109,8 +109,8 @@ export default function LocationsModal({
                         onClick={handleConfirm}
                         className="
                             flex w-full items-center justify-center rounded-full py-3
-                            font-outfit text-[11px] font-black uppercase tracking-[0.15em] text-white
-                            bg-[#88B04B] transition-all active:scale-95
+                            text-[11px] font-black uppercase tracking-[0.15em] text-white
+                            bg-primary transition-all active:scale-95
                             disabled:opacity-40 disabled:cursor-not-allowed
                         "
                     >

--- a/src/features/location/components/MapPicker.tsx
+++ b/src/features/location/components/MapPicker.tsx
@@ -72,7 +72,7 @@ export default function MapPicker({ onSave, editingLocation }: MapPickerProps) {
             </h1>
 
             {showError && errorMessage && (
-                <div className="bg-red-500 text-white px-3 py-3 rounded-xl mb-2.5 text-sm whitespace-pre-line">
+                <div className="bg-(--theme-danger-bg) text-white px-3 py-3 rounded-xl mb-2.5 text-sm whitespace-pre-line">
                     {errorMessage}
                 </div>
             )}
@@ -155,7 +155,7 @@ export default function MapPicker({ onSave, editingLocation }: MapPickerProps) {
             <button
                 type="submit"
                 disabled={isSaving}
-                className="bg-(--color-primary) text-white py-3 rounded-full font-bold mt-1.5 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                className="bg-primary transition-all active:scale-95 text-white py-3 rounded-full font-bold mt-1.5 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
                 {isSaving ? "Guardando..." : (isEditMode ? "Actualizar" : "Guardar")}
             </button>

--- a/src/features/profile/ProfileView.tsx
+++ b/src/features/profile/ProfileView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 import { auth, db } from '../../lib/firebase';
+import { Package } from 'lucide-react';
 
 interface ProfileData {
   displayName: string;
@@ -21,6 +22,7 @@ export default function ProfileView() {
     secondaryMail: 'No registrado',
     photoURL: '',
   });
+  const [roles, setRoles] = useState<string[]>([]);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -41,6 +43,7 @@ export default function ProfileView() {
 
           phone = data.phone || 'No registrado';
           secondaryMail = data.secondaryMail || 'No registrado';
+          setRoles(data.roles || []);
         }
 
         setProfile({
@@ -129,6 +132,35 @@ export default function ProfileView() {
           </dd>
 
         </dl>
+
+        {(() => {
+          const isComprador = roles.length === 0 || roles.includes('comprador') || roles.includes('admin');
+          if (!isComprador) return null;
+
+          return (
+            <div className="mb-6 rounded-2xl border border-border-light bg-bg-light p-4">
+              <h3 className="mb-2 text-xs font-bold uppercase tracking-widest text-text-light opacity-50">
+                Gestión de Compras
+              </h3>
+              <a
+                href="/mis-pedidos"
+                className="group flex items-center justify-between rounded-xl border border-border-light bg-card-bg-light p-3 transition-all hover:border-primary hover:shadow-sm"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
+                    <Package size={18} />
+                  </div>
+                  <div>
+                    <h4 className="font-bold text-text-light text-sm">Mis pedidos y devoluciones</h4>
+                  </div>
+                </div>
+                <span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
+                  →
+                </span>
+              </a>
+            </div>
+          );
+        })()}
 
         <div className="flex justify-end mt-4">
           <a


### PR DESCRIPTION
## Resumen

Se unificaron y centralizaron las vistas del usuario bajo los estándares del proyecto. En primer lugar, se trasladó el acceso a "Mis Pedidos" desde la barra de navegación global (Navbar) hacia el perfil de usuario (/me), condicionando su visibilidad estrictamente al rol de comprador (Task #494). En segundo lugar, se refactorizó visualmente el módulo completo de gestión de ubicaciones (/location) para alinearlo con los tokens de diseño de UI.md, solucionando problemas de visualización en el modo oscuro y removiendo fuentes no estandarizadas (Task #621).

## URL de los cambios

- URL: `http://localhost:4321/me` y `http://localhost:4321/location`
- Ruta o pantalla afectada: `/me` (Perfil de usuario), `/location` (Gestión de ubicaciones) y Navbar (Componente global).

## Cómo probar

<!-- Pasos concretos para validar el cambio. Debe ser fácil de seguir por quien revisa. -->

1. Inicia sesión con una cuenta que tenga asignado el rol de comprador o admin.
2. Revisa el Navbar global tanto en entorno de escritorio como en la vista móvil lateral: comprueba que la opción "Mis pedidos" ya no aparece en estos menús globales.
3. Dirígete a la pantalla de Mi Perfil (/me) y verifica que debajo de los datos de contacto se renderiza la nueva sección "Gestión de Compras" con el acceso interactivo a tus pedidos. Haz clic para asegurar que redirige correctamente a /mis-pedidos.
4. Inicia sesión con un usuario que no tenga rol de comprador ni administrador (por ejemplo, un usuario con rol exclusivo de mensajero) y valida que la sección de pedidos en /me no se renderice.

1. Ve a la pantalla de direcciones (/location).
2. Activa el Modo Oscuro desde el botón correspondiente del Navbar.
3. Abre el modal de "Gestionar ubicaciones", selecciona una tarjeta, marca una ubicación como predeterminada (estrella), abre el flujo de edición (lápiz) y el de eliminación (basurero) para desplegar los modales de confirmación.
4. Intenta guardar una ubicación fuera de los límites permitidos para forzar el despliegue del recuadro de error en el formulario del mapa.
5. Comprueba que todos los textos, bordes, fondos y estados críticos cambien armónicamente sin colores brillantes remanentes o tipografías inusuales.

## Resultado esperado

<!-- ¿Qué debería ver o comprobar quien revisa al seguir los pasos? -->

- El Navbar se visualiza limpio y sin enlaces redundantes globales.
- La vista /me restringe y muestra correctamente las tarjetas de acceso según el rol de la sesión activa.
- Todos los componentes del módulo de ubicaciones (LocationSection, LocationCard, LocationsModal, ConfirmModal, ErrorModal y MapPicker) responden de manera nativa al cambio de tema (Light/Dark) al utilizar los tokens --theme-* y la fuente estándar Inter, eliminando por completo los colores fijos hexadecimales y la familia font-outfit.

## Evidencia visual

<!-- Adjunta capturas, video o GIF de la vista trabajada. Si no aplica, escribe "No aplica". -->

<img width="593" height="852" alt="image" src="https://github.com/user-attachments/assets/1418e675-de24-4026-a870-2a79e483815c" />

## Tipo de cambio

- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [X] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

<!-- Ejemplo: Closes #123, Related #456. Si no aplica, escribe "No aplica". -->

Closes #494, Closes #621

## Checklist del autor

- [X] Probé el cambio localmente
- [X] Agregué la URL o ruta donde se revisa el cambio
- [X] Agregué evidencia visual o indiqué que no aplica
- [X] No hay errores ni warnings nuevos conocidos
- [X] Revisé mi propio código antes de pedir review

## Notas para quien revisa

<!-- Riesgos, decisiones técnicas, casos límite o algo específico que quieras que se revise. -->
