### PR TITLE
fix: align reassignment status and modal scroll

### DIFF
--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -105,7 +105,7 @@ export default function ConfirmAssignedOrderActionModal({
   return (
     <>
       <div
-        className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+        className="fixed inset-0 z-[999] flex items-center justify-center overflow-y-auto bg-black/65 p-4 backdrop-blur-sm"
         onClick={(event) => {
           if (event.target === event.currentTarget) onClose();
         }}
@@ -113,8 +113,8 @@ export default function ConfirmAssignedOrderActionModal({
         aria-modal="true"
         aria-labelledby="assigned-order-action-title"
       >
-        <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-          <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+        <section className="flex max-h-[calc(100vh-2rem)] w-full max-w-lg flex-col overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
+          <header className="shrink-0 flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
             <div className="flex items-center gap-4">
               <span
                 className={`flex h-12 w-12 items-center justify-center rounded-2xl ${config.iconClassName}`}
@@ -146,7 +146,7 @@ export default function ConfirmAssignedOrderActionModal({
             </button>
           </header>
 
-          <div className="space-y-6 px-6 py-6">
+          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-6">
             <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
               <div>
                 <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
@@ -211,7 +211,7 @@ export default function ConfirmAssignedOrderActionModal({
             )}
           </div>
 
-          <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
+          <footer className="shrink-0 flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
             <button
               className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
               disabled={isSaving}

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -311,7 +311,7 @@ const getStatusForORder = (status: DeliveryStatus) => {
     case 'accepted':
       return 'ACEPTADO';
     case 'pending_reassignment':
-      return 'PENDIENTE REASIGNACION';
+      return 'PENDIENTE-ASIGNACION';
     case 'in_transit':
       return 'EN CAMINO';
     case 'delivered':

--- a/src/features/mensajero/utils/deliveryStatusFlow.ts
+++ b/src/features/mensajero/utils/deliveryStatusFlow.ts
@@ -30,7 +30,7 @@ const orderStatusByDeliveryStatus: Record<MessengerDeliveryStatus, string> = {
   in_transit: 'EN CAMINO',
   delivered: 'ENTREGADO',
   not_delivered: 'NO ENTREGADO',
-  pending_reassignment: 'PENDIENTE REASIGNACION',
+  pending_reassignment: 'PENDIENTE-ASIGNACION',
   cancelled: 'CANCELADO',
   reprogrammed: 'REPROGRAMADO',
 };

--- a/src/features/seller/components/RejectedOrdersPanel.tsx
+++ b/src/features/seller/components/RejectedOrdersPanel.tsx
@@ -17,7 +17,7 @@ export default function RejectedOrdersPanel({ embedded = false }: { embedded?: b
     orders: rejected,
     loading,
     error
-  } = useGetOrders({ status: 'PENDIENTE REASIGNACION', ordby: 'asc' });
+  } = useGetOrders({ status: 'PENDIENTE-ASIGNACION', ordby: 'asc' });
 
 
   const {

--- a/src/features/seller/services/assignCourierToDelivery.ts
+++ b/src/features/seller/services/assignCourierToDelivery.ts
@@ -81,7 +81,7 @@ export const reassignCourierToDelivery = async (db: Firestore, deliveryId: strin
     const orderData: any = orderSnap.data();
     sellerId = orderData.sellerId ?? '';
 
-    if (orderData.status !== 'PENDIENTE REASIGNACION') {
+    if (orderData.status !== 'PENDIENTE-ASIGNACION') {
       throw new Error('No se puede asignar mensajero a un pedido que no está en estado ASIGNADO.');
     }
 
@@ -110,7 +110,7 @@ export const reassignCourierToDelivery = async (db: Firestore, deliveryId: strin
       sellerEmail: sellerData.email ?? '',
       actionType: 'REASIGNAR',
       orderId,
-      previousStatus: 'PENDIENTE REASIGNACION',
+      previousStatus: 'PENDIENTE-ASIGNACION',
       newStatus: 'ASIGNADO',
     }).catch((err) => console.error('No se pudo registrar  la actividad del vendedor:', err));
   }

--- a/tests/delivery-status-flow.spec.ts
+++ b/tests/delivery-status-flow.spec.ts
@@ -48,7 +48,7 @@ const expectedMappings: Array<{
   {
     status: 'pending_reassignment',
     label: 'Pendiente de reasignacion',
-    orderStatus: 'PENDIENTE REASIGNACION',
+    orderStatus: 'PENDIENTE-ASIGNACION',
     orderDeliveryStatus: 'PENDING_REASSIGNMENT',
   },
   {


### PR DESCRIPTION
## Resumen

Se corrige el estado generado al rechazar un pedido asignado para usar `PENDIENTE-ASIGNACION`, según el estándar definido. También se ajusta el modal de rechazo para que no se salga de pantalla y pueda usarse correctamente en resoluciones pequeñas.

## URL de los cambios

- URL: http://localhost:4321/courier
- Ruta o pantalla afectada: `/courier`, `/delivery/order/:orderId`, `/seller/rejected-orders`

## Cómo probar

1. Iniciar sesión como mensajero y entrar a `/courier`.
2. Rechazar un pedido asignado desde el panel o desde `/delivery/order/:orderId`.
3. Verificar en Firestore que `orders.status` quede como `PENDIENTE-ASIGNACION`.
4. Iniciar sesión como vendedor y entrar a `/seller/rejected-orders`.
5. Verificar que el pedido rechazado aparezca para reasignación.

## Resultado esperado

El modal de rechazo debe poder usarse sin salirse de pantalla. Al confirmar el rechazo, el pedido debe quedar con `orders.status = PENDIENTE-ASIGNACION` y debe aparecer correctamente en la pantalla de reasignación del vendedor.

## Evidencia visual

| Antes | Después |
| --- | --- |
| . | . |

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

No aplica.

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Se mantuvo `deliveryStatus = PENDING_REASSIGNMENT` como estado técnico de delivery. El cambio aplica al estado principal del pedido: `orders.status = PENDIENTE-ASIGNACION`.