### PR TITLE
feat(mensajero): impedir aceptar pedido con entrega activa desde dash…

### DIFF
--- a/seed/data/deliveries.mjs
+++ b/seed/data/deliveries.mjs
@@ -1,17 +1,22 @@
 import { Users } from './users.mjs';
 
 export const Deliveries = {
+  // Entrega ya completada: Luis conserva una sola entrega activa (DELIVERY_006,
+  // in_transit). Un mensajero no puede tener mas de una entrega activa a la vez.
   DELIVERY_001: {
     code: 'delivery-001',
     orderCode: 'order-001',
     courier: Users.LUIS,
-    status: 'accepted',
+    status: 'delivered',
     attemptNumber: 1,
-    customerConfirmed: false,
+    customerConfirmed: true,
+    customerConfirmedAt: '2026-04-25T11:05:00.000Z',
     assignedAt: '2026-04-25T09:10:00.000Z',
     pickedUpAt: '2026-04-25T10:20:00.000Z',
+    inTransitAt: '2026-04-25T10:30:00.000Z',
+    deliveredAt: '2026-04-25T11:05:00.000Z',
     createdAt: '2026-04-25T09:05:00.000Z',
-    updatedAt: '2026-04-25T09:10:00.000Z',
+    updatedAt: '2026-04-25T11:05:00.000Z',
   },
   DELIVERY_002: {
     code: 'delivery-002',
@@ -98,17 +103,21 @@ export const Deliveries = {
     createdAt: '2026-04-25T12:02:00.000Z',
     updatedAt: '2026-04-25T12:15:00.000Z',
   },
+  // Entrega ya completada: Nadia conserva una sola entrega activa (DELIVERY_008,
+  // accepted), por lo que al intentar aceptar otro pedido debe quedar bloqueada.
   DELIVERY_009: {
     code: 'delivery-009',
     orderCode: 'order-009',
     courier: Users.NADIA,
-    status: 'in_transit',
+    status: 'delivered',
     attemptNumber: 1,
-    customerConfirmed: false,
+    customerConfirmed: true,
+    customerConfirmedAt: '2026-04-25T13:05:00.000Z',
     assignedAt: '2026-04-25T12:35:00.000Z',
     inTransitAt: '2026-04-25T12:45:00.000Z',
+    deliveredAt: '2026-04-25T13:05:00.000Z',
     createdAt: '2026-04-25T12:32:00.000Z',
-    updatedAt: '2026-04-25T12:45:00.000Z',
+    updatedAt: '2026-04-25T13:05:00.000Z',
   },
   DELIVERY_010: {
     code: 'delivery-010',

--- a/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
+++ b/src/features/mensajero/components/DeliveryOrderDetailPage.tsx
@@ -21,6 +21,7 @@ import ConfirmAssignedOrderActionModal, {
 import { auth } from '../../../lib/firebase';
 import { parseOrderId } from '../../cart/services/orderService';
 import {
+  acceptMessengerOrder,
   getMessengerOrderById,
   markMessengerOrderAsNotDelivered,
   registerMessengerCashPayment,
@@ -29,6 +30,8 @@ import {
 import type { MessengerOrder } from '../types';
 import { getDeliveryStatusLabel } from '../utils/deliveryStatusFlow';
 import { formatBolivianos } from '../utils/money';
+import { ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE } from '../utils/acceptEligibility';
+import AcceptBlockedModal from '../modals/AcceptBlockedModal';
 import './MessengerDashboard.css';
 
 const DEV_COURIER_ID = 'user-nadia';
@@ -201,6 +204,7 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     null
   );
   const [paymentSuccessOpen, setPaymentSuccessOpen] = useState(false);
+  const [acceptBlockedOpen, setAcceptBlockedOpen] = useState(false);
 
   useEffect(() => {
     return onAuthStateChanged(auth, (user) => {
@@ -266,17 +270,40 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
     setError('');
 
     try {
-      await setMessengerOrderStatus(
-        previousOrder,
-        status,
-        status === 'pending_reassignment' ? rejectionReason : undefined
-      );
+      if (status === 'accepted') {
+        // Mismo punto único que el dashboard: revalida contra Firestore que no
+        // haya otra entrega activa antes de aceptar, sin importar desde qué
+        // pantalla se dispare la acción.
+        if (!courierId) {
+          throw new Error('No se pudo identificar al mensajero.');
+        }
+        await acceptMessengerOrder(previousOrder, courierId);
+      } else {
+        await setMessengerOrderStatus(
+          previousOrder,
+          status,
+          status === 'pending_reassignment' ? rejectionReason : undefined
+        );
+      }
       setMessage(getStatusUpdateMessage(status));
       await loadOrder({ showLoading: false });
     } catch (statusError) {
       console.error(statusError);
       setOrder(previousOrder);
-      setError('No se pudo actualizar el estado del pedido.');
+      if (
+        statusError instanceof Error &&
+        statusError.message === ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE
+      ) {
+        // Misma UX que el dashboard: si el servicio bloquea por tener otra
+        // entrega activa, mostramos la modal en lugar de un error suelto.
+        setAcceptBlockedOpen(true);
+      } else {
+        setError(
+          statusError instanceof Error
+            ? statusError.message
+            : 'No se pudo actualizar el estado del pedido.'
+        );
+      }
     }
   };
 
@@ -538,6 +565,10 @@ export default function DeliveryOrderDetailPage({ orderId }: { orderId: string }
 
       {paymentSuccessOpen && (
         <PaymentSuccessModal onClose={() => setPaymentSuccessOpen(false)} />
+      )}
+
+      {acceptBlockedOpen && (
+        <AcceptBlockedModal onClose={() => setAcceptBlockedOpen(false)} />
       )}
     </section>
   );

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../lib/deliveryAvailability';
 import { parseOrderId } from '../../cart/services/orderService';
 import {
+    acceptMessengerOrder,
     closeMessengerShift,
     markMessengerOrderAsNotDelivered,
     registerMessengerCashPayment,
@@ -32,6 +33,8 @@ import {
     subscribeToMessengerShiftClosures,
 } from '../services/messengerOrdersService';
 import type { MessengerOrder, MessengerShiftClosure } from '../types';
+import { hasActiveMessengerDelivery } from '../utils/acceptEligibility';
+import AcceptBlockedModal from '../modals/AcceptBlockedModal';
 import {
     sortAcceptedOrdersByAge,
     type AcceptedOrderSort,
@@ -306,6 +309,7 @@ function PendingOrderCard({
     onInTransit,
     onNotDelivered,
     onReject,
+    acceptDisabled = false,
 }: {
     order: MessengerOrder;
     onAccept: (orderId: string) => void;
@@ -314,7 +318,9 @@ function PendingOrderCard({
     onInTransit: (orderId: string) => void;
     onNotDelivered: (order: MessengerOrder) => void;
     onReject: (orderId: string) => void;
+    acceptDisabled?: boolean;
 }) {
+    const [showAcceptBlockedModal, setShowAcceptBlockedModal] = useState(false);
     const customerLocationUrl = useMemo(() => {
         return buildBuyerMapUrl(order);
     }, [order]);
@@ -473,13 +479,23 @@ function PendingOrderCard({
                     {order.deliveryStatus === 'assigned' && (
                         <>
                             <button
+                                aria-disabled={acceptDisabled}
                                 className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
-                                onClick={() => onAccept(order.id)}
+                                onClick={() => {
+                                    if (acceptDisabled) {
+                                        setShowAcceptBlockedModal(true);
+                                    } else {
+                                        onAccept(order.id);
+                                    }
+                                }}
                                 type="button"
                             >
                                 <CheckCircle2 size={17} />
                                 Aceptar pedido
                             </button>
+                            {showAcceptBlockedModal && (
+                                <AcceptBlockedModal onClose={() => setShowAcceptBlockedModal(false)} />
+                            )}
                             <button
                                 className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
                                 onClick={() => onReject(order.id)}
@@ -1181,6 +1197,14 @@ export default function MessengerDashboard({
         [orders]
     );
 
+    // Un pedido `accepted` o `in_transit` cuenta como entrega activa y
+    // deshabilita la aceptación de otros pedidos asignados (pre-check de UX;
+    // la validación autoritativa vive en acceptMessengerOrder, en el servicio).
+    const hasActiveDelivery = useMemo(
+        () => hasActiveMessengerDelivery(orders),
+        [orders]
+    );
+
     const assignedOrderIdsKey = useMemo(
         () =>
             assignedOrders
@@ -1384,19 +1408,34 @@ export default function MessengerDashboard({
         );
 
         try {
-            // Pasar el motivo a Firestore si es rechazo
-            await setMessengerOrderStatus(
-                targetOrder,
-                status,
-                status === 'pending_reassignment' ? options.reason : undefined
-            );
+            if (status === 'accepted') {
+                // Aceptar pasa por el punto único del servicio, que revalida
+                // contra Firestore que no haya otra entrega activa antes de
+                // escribir. Así la regla se cumple aunque el estado local esté
+                // desactualizado (p. ej. otra pantalla abierta en paralelo).
+                if (!currentCourierId) {
+                    throw new Error('No se pudo identificar al mensajero.');
+                }
+                await acceptMessengerOrder(targetOrder, currentCourierId);
+            } else {
+                // Pasar el motivo a Firestore si es rechazo
+                await setMessengerOrderStatus(
+                    targetOrder,
+                    status,
+                    status === 'pending_reassignment' ? options.reason : undefined
+                );
+            }
             setMessage(getStatusUpdateMessage(status));
             if (options.redirectToDetail) {
                 navigateToDeliveryOrderDetail(orderId);
             }
         } catch (error) {
             console.error(error);
-            setMessage('No se pudo actualizar el estado en Firestore.');
+            setMessage(
+                error instanceof Error
+                    ? error.message
+                    : 'No se pudo actualizar el estado en Firestore.'
+            );
             setOrders((currentOrders) =>
             currentOrders.map((order) =>
                 order.id === orderId ? targetOrder : order
@@ -1753,6 +1792,7 @@ export default function MessengerDashboard({
                                             key={`${clientSection}-${order.deliveryId || order.id}`}
                                             order={order}
                                             onAccept={acceptOrder}
+                                            acceptDisabled={hasActiveDelivery}
                                             onDelivered={markAsDelivered}
                                             onDetail={(order) =>
                                                 navigateToDeliveryOrderDetail(order.id)

--- a/src/features/mensajero/modals/AcceptBlockedModal.tsx
+++ b/src/features/mensajero/modals/AcceptBlockedModal.tsx
@@ -1,0 +1,64 @@
+import { AlertTriangle, X } from 'lucide-react';
+import { ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE } from '../utils/acceptEligibility';
+
+interface AcceptBlockedModalProps {
+  onClose: () => void;
+}
+
+export default function AcceptBlockedModal({ onClose }: AcceptBlockedModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="accept-blocked-title"
+    >
+      <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
+        <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+          <div className="flex items-center gap-4">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-red-500/10 text-red-600">
+              <AlertTriangle size={24} />
+            </span>
+            <div>
+              <h2 className="text-xl font-black tracking-normal" id="accept-blocked-title">
+                No puedes aceptar este pedido
+              </h2>
+              <p className="text-sm font-medium opacity-70">
+                Tienes una entrega activa en curso.
+              </p>
+            </div>
+          </div>
+
+          <button
+            aria-label="Cerrar"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+            onClick={onClose}
+            type="button"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="px-6 py-6">
+          <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
+            <AlertTriangle className="mt-0.5 shrink-0 text-red-500" size={18} />
+            <p>{ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE}</p>
+          </div>
+        </div>
+
+        <footer className="border-t border-border-light bg-secondary-bg-light/50 px-6 py-5">
+          <button
+            className="inline-flex h-12 w-full items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
+            onClick={onClose}
+            type="button"
+          >
+            Entendido
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/src/features/mensajero/services/messengerOrdersService.ts
+++ b/src/features/mensajero/services/messengerOrdersService.ts
@@ -26,6 +26,10 @@ import {
   getOrderDeliveryStatusForDeliveryStatus,
   getOrderStatusForDeliveryStatus,
 } from '../utils/deliveryStatusFlow';
+import {
+  ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE,
+  isActiveDelivery,
+} from '../utils/acceptEligibility';
 
 type DeliveryStatus = MessengerOrder['deliveryStatus'];
 type OrderData = Record<string, unknown>;
@@ -150,7 +154,7 @@ const formatCourierZoneName = (zoneName: string | null): string | undefined => {
 
 const readOrderDisplayId = (orderId: string): string | undefined => {
   const [, friendlyName] = orderId.split('_');
-  return asString(friendlyName) ?? asString(orderId);
+  return asString(friendlyName) ?? asString(orderId) ?? undefined;
 };
 
 const readPayment = async (paymentId: string | null): Promise<PaymentData> => {
@@ -372,6 +376,51 @@ export async function setMessengerOrderStatus(
 
     await updateDoc(doc(db, 'orders', order.id), orderUpdateData);
   }
+}
+
+/**
+ * Lanza un error si el mensajero ya tiene una entrega activa
+ * (estado `accepted` o `in_transit`) distinta a la que intenta aceptar.
+ * Consulta Firestore en el momento (no confía en el estado local de la UI),
+ * por lo que la regla se cumple sin importar desde qué pantalla se dispare.
+ * Se filtra en memoria para no requerir un índice compuesto en Firestore.
+ */
+export async function assertCanAcceptMessengerOrder(
+  courierId: string,
+  deliveryId: string
+): Promise<void> {
+  const deliveriesQuery = query(
+    collection(db, 'deliveries'),
+    where('courierId', '==', courierId)
+  );
+  const snapshot = await getDocs(deliveriesQuery);
+
+  const hasActiveDelivery = snapshot.docs.some(
+    (deliveryDoc) =>
+      deliveryDoc.id !== deliveryId &&
+      isActiveDelivery({
+        deliveryStatus: normalizeDeliveryStatus(deliveryDoc.data().status),
+      })
+  );
+
+  if (hasActiveDelivery) {
+    throw new Error(ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE);
+  }
+}
+
+/**
+ * Punto único para aceptar un pedido asignado. Valida contra Firestore que el
+ * mensajero no tenga otra entrega activa y, solo si pasa, marca el pedido como
+ * `accepted`. Tanto el dashboard como la vista de detalle deben usar esta
+ * función para que la regla de negocio viva en un solo lugar y no se pueda
+ * colar una doble aceptación desde pantallas que no se sincronizan en vivo.
+ */
+export async function acceptMessengerOrder(
+  order: MessengerOrder,
+  courierId: string
+): Promise<void> {
+  await assertCanAcceptMessengerOrder(courierId, order.deliveryId);
+  await setMessengerOrderStatus(order, 'accepted');
 }
 
 export async function registerMessengerCashPayment(

--- a/src/features/mensajero/utils/acceptEligibility.ts
+++ b/src/features/mensajero/utils/acceptEligibility.ts
@@ -1,0 +1,41 @@
+import type { MessengerOrder } from '../types';
+
+type DeliveryStatus = MessengerOrder['deliveryStatus'];
+
+/**
+ * Estados que cuentan como una entrega activa del mensajero. Mientras exista
+ * una entrega en alguno de estos estados, no se puede aceptar otro pedido.
+ * `assigned` no bloquea: solo `accepted` y `in_transit`.
+ */
+const ACTIVE_DELIVERY_STATUSES: ReadonlyArray<DeliveryStatus> = [
+  'accepted',
+  'in_transit',
+];
+
+/**
+ * Mensaje único que se muestra cuando se bloquea la aceptación de un pedido
+ * por tener una entrega activa. Es la fuente de verdad: el servicio lo lanza y
+ * la UI lo muestra, para que el texto nunca diverja.
+ */
+export const ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE =
+  'Ya tienes una entrega activa (aceptada o en camino). Termínala antes de aceptar otro pedido.';
+
+export function isActiveDelivery(
+  order: Pick<MessengerOrder, 'deliveryStatus'>
+): boolean {
+  return ACTIVE_DELIVERY_STATUSES.includes(order.deliveryStatus);
+}
+
+/** Indica si el mensajero ya tiene al menos una entrega activa. */
+export function hasActiveMessengerDelivery(
+  orders: ReadonlyArray<Pick<MessengerOrder, 'deliveryStatus'>>
+): boolean {
+  return orders.some(isActiveDelivery);
+}
+
+/** Indica si el mensajero puede aceptar un pedido asignado. */
+export function canAcceptAssignedOrder(
+  orders: ReadonlyArray<Pick<MessengerOrder, 'deliveryStatus'>>
+): boolean {
+  return !hasActiveMessengerDelivery(orders);
+}

--- a/tests/messenger-accept-eligibility.spec.ts
+++ b/tests/messenger-accept-eligibility.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import {
+  ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE,
+  canAcceptAssignedOrder,
+  hasActiveMessengerDelivery,
+  isActiveDelivery,
+} from '../src/features/mensajero/utils/acceptEligibility';
+import type { MessengerOrder } from '../src/features/mensajero/types';
+
+type DeliveryStatus = MessengerOrder['deliveryStatus'];
+
+const order = (deliveryStatus: DeliveryStatus): Pick<MessengerOrder, 'deliveryStatus'> => ({
+  deliveryStatus,
+});
+
+test.describe('messenger accept eligibility', () => {
+  test('solo accepted e in_transit cuentan como entrega activa', () => {
+    expect(isActiveDelivery(order('accepted'))).toBe(true);
+    expect(isActiveDelivery(order('in_transit'))).toBe(true);
+
+    const inactive: DeliveryStatus[] = [
+      'assigned',
+      'delivered',
+      'not_delivered',
+      'cancelled',
+      'reprogrammed',
+      'pending_reassignment',
+    ];
+    for (const status of inactive) {
+      expect(isActiveDelivery(order(status))).toBe(false);
+    }
+  });
+
+  test('hasActiveMessengerDelivery detecta al menos una entrega activa', () => {
+    expect(hasActiveMessengerDelivery([])).toBe(false);
+    expect(
+      hasActiveMessengerDelivery([order('assigned'), order('delivered')])
+    ).toBe(false);
+    expect(
+      hasActiveMessengerDelivery([order('assigned'), order('accepted')])
+    ).toBe(true);
+    expect(
+      hasActiveMessengerDelivery([order('in_transit')])
+    ).toBe(true);
+  });
+
+  test('canAcceptAssignedOrder solo permite aceptar sin entrega activa', () => {
+    // Sin entrega activa: puede aceptar.
+    expect(canAcceptAssignedOrder([order('assigned')])).toBe(true);
+    expect(canAcceptAssignedOrder([order('delivered'), order('not_delivered')])).toBe(true);
+    expect(canAcceptAssignedOrder([])).toBe(true);
+
+    // Con una entrega aceptada o en camino: queda bloqueado.
+    expect(canAcceptAssignedOrder([order('accepted'), order('assigned')])).toBe(false);
+    expect(canAcceptAssignedOrder([order('in_transit')])).toBe(false);
+  });
+
+  test('el mensaje de bloqueo esta bien codificado (UTF-8)', () => {
+    // Protege contra el typo de encoding "TermÃ­nala": el acento debe ser "í".
+    expect(ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE).toContain('Termínala');
+    expect(ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE).not.toContain('Ã');
+  });
+});


### PR DESCRIPTION
## Resumen

Impide que un mensajero acepte un nuevo pedido cuando ya tiene una entrega activa (aceptada o en camino). La validación se centraliza en el servicio (`acceptMessengerOrder`), por lo que aplica tanto desde el dashboard como desde la vista de detalle, evitando la condición de carrera donde se podía aceptar desde otra pantalla sin revalidar.

## URL de los cambios

- URL: `http://localhost:4321/mensajero` (dashboard del mensajero, con emuladores corriendo)
- Ruta o pantalla afectada: Dashboard del mensajero y vista de detalle de entrega

## Cómo probar

1. Corre `npm run seed` para cargar datos de prueba (cada mensajero queda con **una sola** entrega activa).
2. Inicia sesión como **Nadia**, que ya tiene una entrega aceptada (`delivery-008`).
3. Intenta aceptar otro pedido asignado, tanto desde el **dashboard** como entrando a **ver detalle** de ese pedido.

## Resultado esperado

Al intentar aceptar un segundo pedido (desde dashboard o desde ver detalle), aparece la modal de bloqueo con el mensaje: *"Ya tienes una entrega activa (aceptada o en camino). Termínala antes de aceptar otro pedido."* No se cambia el estado del pedido. Si la entrega activa se finaliza, vuelve a poder aceptar.

## Evidencia visual

| Antes | Después |
| --- | --- |
| <!-- imagen --> | <!-- imagen --> |

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

No aplica

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [ ] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

- **Validación centralizada en el servicio**: el guard vive en `acceptMessengerOrder()` (en `messengerOrdersService.ts`), no en la UI. Consulta Firestore en vivo antes de escribir, por lo que no se puede saltar con estado local desactualizado (resuelve la condición de carrera entre dashboard y vista de detalle).
- **Mensaje único**: el texto de bloqueo está en una sola constante exportada (`ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE`) que importan la modal y los tests, para evitar duplicación y divergencias de encoding (ej. el typo `TermÃ­nala`).
- **Seed corregido**: se marcaron `DELIVERY_001` y `DELIVERY_009` como `delivered` para que cada mensajero tenga máximo una entrega activa al inicio.
- **Tests**: se agregaron 4 tests de lógica en `tests/messenger-accept-eligibility.spec.ts` (estados activos, detección de entrega activa, elegibilidad y encoding UTF-8 del mensaje).
