### PR TITLE
Feature/hu 142 validar cierres jornada

### DIFF
--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -16,6 +16,7 @@ import {
   ArrowLeft,
   ClipboardList,
   Activity,
+  Receipt,
 } from 'lucide-react';
 import UserManagement from '../users/components/UserManagement.tsx';
 import CategoryList from '../categories/components/CategoryList.tsx';
@@ -23,6 +24,8 @@ import OrderReceptionPanel from '../orders/components/OrderReceptionPanel.tsx';
 import DailySales from '../ventas/components/DailySales.tsx';
 import TopSellingProducts from '../ventas/top-products/components/TopSellingProducts.tsx';
 import MessengerPerformancePage from '../messengers/performance/MessengerPerformancePage.tsx';
+// ── HU #142: Validar cierres de jornada de mensajeros ──
+import CourierSessionsValidation from '../messengers/sessions/components/CourierSessionsValidation.tsx';
 // ── HU #152: Parámetros del sistema ──
 import ConfigPanel from '../settings/components/ConfigPanel.tsx';
 // ── HU #161: Reportes de ventas ──
@@ -46,6 +49,7 @@ type Section =
   | 'ventas-diarias'
   | 'mas-vendidos'
   | 'mensajeros-desempeno'
+  | 'mensajeros-cierres'   // ── HU #142 ──
   | 'parametros'     // ── HU #152 ──
   | 'reportes'       // ── HU #161 ──
   | 'reportes-cancelados'   // ── HU #163 ──
@@ -147,6 +151,8 @@ export default function AdminLayout() {
     categorias:             { title: 'Categorías',             subtitle: 'Gestiona las categorías de productos' },
     'ventas-diarias':       { title: 'Ventas diarias',         subtitle: 'Monitorea el rendimiento diario de ventas' },
     'mensajeros-desempeno': { title: 'Desempeño de mensajeros', subtitle: 'Métricas de eficiencia por mensajero' },
+    // ── HU #142 ──
+    'mensajeros-cierres':   { title: 'Validar cierres de jornada', subtitle: 'Audita el dinero recaudado por cada mensajero' },
     'mas-vendidos':         { title: 'Más vendidos',           subtitle: 'Productos con más unidades vendidas' },
     // ── HU #152 ──
     parametros:             { title: 'Parámetros del sistema', subtitle: 'Configura los parámetros globales del sistema' },
@@ -399,6 +405,19 @@ export default function AdminLayout() {
                           >
                             Desempeño
                           </button>
+                          {/* ── HU #142 ── */}
+                          <button
+                            onClick={() => { setActiveSection('mensajeros-cierres'); setSidebarOpen(false); }}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-[12px]
+                            transition-colors flex items-center gap-1.5 ${
+                              activeSection === 'mensajeros-cierres'
+                                ? 'bg-[#88b04b]/15 text-[#88b04b]'
+                                : 'text-white/40 hover:text-white/80 hover:bg-white/5'
+                            }`}
+                          >
+                            <Receipt size={11} />
+                            Validar cierres
+                          </button>
                         </div>
                       )}
                     </div>
@@ -511,6 +530,8 @@ export default function AdminLayout() {
           {activeSection === 'ventas-diarias' && <DailySales />}
           {activeSection === 'mas-vendidos' && <TopSellingProducts />}
           {activeSection === 'mensajeros-desempeno' && <MessengerPerformancePage />}
+          {/* ── HU #142 ── */}
+          {activeSection === 'mensajeros-cierres' && <CourierSessionsValidation />}
           {/*Parámetros del sistema*/}
           {activeSection === 'parametros' && <ConfigPanel />}
           {/*Reportes de ventas*/}

--- a/src/features/admin/messengers/sessions/components/CourierSessionsValidation.tsx
+++ b/src/features/admin/messengers/sessions/components/CourierSessionsValidation.tsx
@@ -1,0 +1,326 @@
+// src/features/admin/messengers/sessions/components/CourierSessionsValidation.tsx
+
+import { useState } from 'react';
+import {
+  Loader2, AlertCircle, CheckCircle2, XCircle,
+  ClipboardList, RefreshCw,
+} from 'lucide-react';
+import { useSessions } from '../useSessions';
+import type { CourierSession } from '../types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtFull(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-BO', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+  }) + ' ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+}
+
+function timeAgo(iso?: string | null): string {
+  if (!iso) return '—';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'hace un momento';
+  if (minutes < 60) return `hace ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `hace ${hours} h`;
+  const days = Math.floor(hours / 24);
+  return `hace ${days} d`;
+}
+
+function formatMoney(n: number): string {
+  return `Bs. ${n.toFixed(2)}`;
+}
+
+function differenceTone(diff: number): { bg: string; text: string; label: string } {
+  if (diff === 0) {
+    return { bg: 'bg-[#88b04b]/15 ring-1 ring-[#88b04b]/40', text: 'text-[#4a6b1f] dark:text-[#b7dc78]', label: formatMoney(0) };
+  }
+  if (diff < 0) {
+    return { bg: 'bg-red-100 dark:bg-red-500/20 ring-1 ring-red-300 dark:ring-red-500/40', text: 'text-red-700 dark:text-red-300', label: `-${formatMoney(Math.abs(diff))}` };
+  }
+  return { bg: 'bg-orange-100 dark:bg-orange-500/20 ring-1 ring-orange-300 dark:ring-orange-500/40', text: 'text-orange-700 dark:text-orange-300', label: `+${formatMoney(diff)}` };
+}
+
+// ── Subcomponentes ────────────────────────────────────────────────────────────
+
+function SessionRow({
+  session,
+  isValidating,
+  onApprove,
+  onReject,
+}: {
+  session: CourierSession;
+  isValidating: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  const diff = differenceTone(session.differenceAmount);
+  const isConsistent = session.differenceAmount === 0;
+
+  return (
+    <div
+      className={`flex items-center gap-4 px-5 py-4 rounded-xl border transition-colors ${
+        isConsistent
+          ? 'bg-[var(--theme-card-bg)] border-[var(--theme-border)]'
+          : session.differenceAmount < 0
+            ? 'bg-red-50 dark:bg-red-500/5 border-red-200 dark:border-red-500/30'
+            : 'bg-orange-50 dark:bg-orange-500/5 border-orange-200 dark:border-orange-500/30'
+      }`}
+    >
+      {/* Avatar + nombre */}
+      <div className="flex items-center gap-3 w-[220px] flex-shrink-0">
+        <div className="w-9 h-9 rounded-full bg-[#88b04b]/15 flex items-center justify-center
+          text-[#4a6b1f] dark:text-[#b7dc78] text-xs font-bold flex-shrink-0">
+          {session.courierName.split(' ').map((p) => p[0]).slice(0, 2).join('').toUpperCase()}
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--theme-text)] truncate">{session.courierName}</p>
+          <p className="text-xs text-[var(--theme-text)]/40">Cerrado {timeAgo(session.closedAt)}</p>
+        </div>
+      </div>
+
+      {/* Entregas */}
+      <div className="w-[80px] flex-shrink-0 text-sm text-[var(--theme-text)]">
+        {session.deliveriesCount}
+      </div>
+
+      {/* Esperado */}
+      <div className="w-[110px] flex-shrink-0 text-sm text-[var(--theme-text)]">
+        {formatMoney(session.expectedAmount)}
+      </div>
+
+      {/* Registrado */}
+      <div className="w-[110px] flex-shrink-0 text-sm text-[var(--theme-text)]">
+        {formatMoney(session.totalCollected)}
+      </div>
+
+      {/* Diferencia */}
+      <div className="w-[110px] flex-shrink-0">
+        <span className={`inline-block text-xs font-semibold px-2.5 py-1 rounded-full ${diff.bg} ${diff.text}`}>
+          {diff.label}
+        </span>
+      </div>
+
+      {/* Acciones */}
+      <div className="flex items-center gap-2 ml-auto flex-shrink-0">
+        <button
+          onClick={onApprove}
+          disabled={isValidating}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold
+            bg-[#88b04b]/15 text-[#4a6b1f] dark:text-[#b7dc78] hover:bg-[#88b04b]/25
+            disabled:opacity-50 transition-colors"
+        >
+          {isValidating ? <Loader2 size={13} className="animate-spin" /> : <CheckCircle2 size={13} />}
+          Aprobar
+        </button>
+        <button
+          onClick={onReject}
+          disabled={isValidating}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold
+            border border-[var(--theme-border)] text-[var(--theme-text)]/60
+            hover:bg-red-500 hover:text-white hover:border-red-500
+            disabled:opacity-50 transition-colors"
+        >
+          <XCircle size={13} />
+          Rechazar
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RejectModal({
+  session,
+  onConfirm,
+  onCancel,
+  submitting,
+}: {
+  session: CourierSession;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+  submitting: boolean;
+}) {
+  const [reason, setReason] = useState('');
+  const diff = differenceTone(session.differenceAmount);
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" onClick={onCancel} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-md bg-[var(--theme-card-bg)] border border-[var(--theme-border)] rounded-2xl shadow-2xl">
+          <div className="px-6 pt-6 pb-4 border-b border-[var(--theme-border)]">
+            <h2 className="text-[16px] font-bold text-[var(--theme-text)]">
+              Rechazar cierre de jornada
+            </h2>
+            <p className="text-[12px] text-[var(--theme-text)]/50 mt-1">
+              {session.courierName} · diferencia de{' '}
+              <span className={diff.text}>{diff.label}</span>
+            </p>
+          </div>
+
+          <div className="px-6 py-5">
+            <label className="block text-[11px] font-semibold text-[var(--theme-text)]/50 uppercase tracking-wide mb-1.5">
+              Motivo del rechazo *
+            </label>
+            <textarea
+              autoFocus
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              placeholder="Ej: el monto registrado no coincide con el total de entregas confirmadas..."
+              className="w-full p-3 rounded-xl text-[13px] bg-[var(--theme-bg)] border border-[var(--theme-border)]
+                text-[var(--theme-text)] placeholder:text-[var(--theme-text)]/30 outline-none
+                focus:border-red-400 transition-colors resize-none"
+            />
+          </div>
+
+          <div className="flex gap-3 px-6 py-4 border-t border-[var(--theme-border)]">
+            <button
+              onClick={onCancel}
+              disabled={submitting}
+              className="flex-1 py-2.5 rounded-xl text-[13px] font-medium bg-[var(--theme-bg)]
+                border border-[var(--theme-border)] text-[var(--theme-text)]/60
+                hover:text-[var(--theme-text)] transition-colors disabled:opacity-50"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={() => onConfirm(reason.trim())}
+              disabled={submitting || !reason.trim()}
+              className="flex-1 py-2.5 rounded-xl text-[13px] font-medium bg-red-600 hover:bg-red-700
+                text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed
+                flex items-center justify-center gap-2"
+            >
+              {submitting && <Loader2 size={14} className="animate-spin" />}
+              Confirmar rechazo
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────────────
+
+export default function CourierSessionsValidation() {
+  const {
+    sessions, loading, loadingMore, error, hasMore, loadMore, refresh,
+    validating, validateError, approve, reject,
+  } = useSessions();
+
+  const [rejectTarget, setRejectTarget] = useState<CourierSession | null>(null);
+  const [rejecting, setRejecting] = useState(false);
+
+  async function handleApprove(sessionId: string) {
+    await approve(sessionId);
+  }
+
+  async function handleConfirmReject(reason: string) {
+    if (!rejectTarget || !reason) return;
+    setRejecting(true);
+    const ok = await reject(rejectTarget.sessionId, reason);
+    setRejecting(false);
+    if (ok) setRejectTarget(null);
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-4">
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold text-[var(--theme-text)]">Cierres de jornada pendientes</h2>
+          <p className="text-sm text-[var(--theme-text)]/50">
+            {loading ? 'Cargando...' : `${sessions.length} jornada${sessions.length !== 1 ? 's' : ''} esperando validación`}
+          </p>
+        </div>
+        <button
+          onClick={refresh}
+          disabled={loading}
+          className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium
+            bg-[var(--theme-secondary-bg)] text-[var(--theme-text)]/60 hover:text-[var(--theme-text)]
+            disabled:opacity-50 transition-colors"
+        >
+          <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
+          Actualizar
+        </button>
+      </div>
+
+      {/* Error de validación (toast simple) */}
+      {validateError && (
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10 border
+          border-red-200 dark:border-red-500/30 rounded-xl text-sm text-red-600 dark:text-red-300">
+          <AlertCircle size={16} className="flex-shrink-0" />
+          {validateError}
+        </div>
+      )}
+
+      {/* Error de carga */}
+      {error && (
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10 border
+          border-red-200 dark:border-red-500/30 rounded-xl text-sm text-red-600 dark:text-red-300">
+          <AlertCircle size={16} className="flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {/* Loading inicial */}
+      {loading && (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 size={24} className="animate-spin text-[#88b04b]" />
+        </div>
+      )}
+
+      {/* Estado vacío */}
+      {!loading && !error && sessions.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-[var(--theme-text)]/30 select-none">
+          <ClipboardList size={40} strokeWidth={1.2} />
+          <p className="mt-3 text-sm">No hay jornadas pendientes de validación</p>
+        </div>
+      )}
+
+      {/* Lista */}
+      {!loading && sessions.length > 0 && (
+        <div className="space-y-3">
+          {sessions.map((session) => (
+            <SessionRow
+              key={session.sessionId}
+              session={session}
+              isValidating={validating === session.sessionId}
+              onApprove={() => handleApprove(session.sessionId)}
+              onReject={() => setRejectTarget(session)}
+            />
+          ))}
+
+          {hasMore && (
+            <div className="flex justify-center pt-2">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium
+                  text-[#88b04b] hover:text-[#7aa043] disabled:opacity-50 transition-colors"
+              >
+                {loadingMore && <Loader2 size={14} className="animate-spin" />}
+                Cargar más
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Modal de rechazo */}
+      {rejectTarget && (
+        <RejectModal
+          session={rejectTarget}
+          submitting={rejecting}
+          onConfirm={handleConfirmReject}
+          onCancel={() => setRejectTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/admin/messengers/sessions/components/CourierSessionsValidation.tsx
+++ b/src/features/admin/messengers/sessions/components/CourierSessionsValidation.tsx
@@ -3,105 +3,121 @@
 import { useState } from 'react';
 import {
   Loader2, AlertCircle, CheckCircle2, XCircle,
-  ClipboardList, RefreshCw,
+  ClipboardList, RefreshCw, ChevronDown,
 } from 'lucide-react';
 import { useSessions } from '../useSessions';
-import type { CourierSession } from '../types';
+import type { ShiftClosure } from '../types';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function fmtFull(iso?: string | null): string {
-  if (!iso) return '—';
-  const d = new Date(iso);
-  return d.toLocaleDateString('es-BO', {
-    day: '2-digit', month: '2-digit', year: 'numeric',
-  }) + ' ' + d.toLocaleTimeString('es-BO', { hour: '2-digit', minute: '2-digit' });
+function fmtDateKey(dateKey: string): string {
+  if (!dateKey) return '—';
+  const [year, month, day] = dateKey.split('-').map(Number);
+  if (!year || !month || !day) return dateKey;
+  return new Intl.DateTimeFormat('es-BO', { dateStyle: 'medium' })
+    .format(new Date(year, month - 1, day));
 }
 
-function timeAgo(iso?: string | null): string {
+function fmtTime(iso?: string | null): string {
   if (!iso) return '—';
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return 'hace un momento';
-  if (minutes < 60) return `hace ${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `hace ${hours} h`;
-  const days = Math.floor(hours / 24);
-  return `hace ${days} d`;
+  return new Date(iso).toLocaleTimeString('es-BO', {
+    hour: '2-digit', minute: '2-digit',
+  });
 }
 
 function formatMoney(n: number): string {
   return `Bs. ${n.toFixed(2)}`;
 }
 
-function differenceTone(diff: number): { bg: string; text: string; label: string } {
-  if (diff === 0) {
-    return { bg: 'bg-[#88b04b]/15 ring-1 ring-[#88b04b]/40', text: 'text-[#4a6b1f] dark:text-[#b7dc78]', label: formatMoney(0) };
-  }
-  if (diff < 0) {
-    return { bg: 'bg-red-100 dark:bg-red-500/20 ring-1 ring-red-300 dark:ring-red-500/40', text: 'text-red-700 dark:text-red-300', label: `-${formatMoney(Math.abs(diff))}` };
-  }
-  return { bg: 'bg-orange-100 dark:bg-orange-500/20 ring-1 ring-orange-300 dark:ring-orange-500/40', text: 'text-orange-700 dark:text-orange-300', label: `+${formatMoney(diff)}` };
+function differenceTone(totalCollected: number, expectedAmount: number) {
+  const diff = Number((totalCollected - expectedAmount).toFixed(2));
+  if (diff === 0) return {
+    diff: 0,
+    label: 'Bs. 0.00',
+    badge: 'text-[#4a6b1f] dark:text-[#b7dc78] bg-[#88b04b]/15 ring-1 ring-[#88b04b]/40',
+    row:   'bg-[var(--theme-card-bg)] border-[var(--theme-border)]',
+  };
+  if (diff < 0) return {
+    diff,
+    label: `-${formatMoney(Math.abs(diff))}`,
+    badge: 'text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-500/20 ring-1 ring-red-300 dark:ring-red-500/40',
+    row:   'bg-red-50 dark:bg-red-500/5 border-red-200 dark:border-red-500/30',
+  };
+  return {
+    diff,
+    label: `+${formatMoney(diff)}`,
+    badge: 'text-orange-700 dark:text-orange-300 bg-orange-100 dark:bg-orange-500/20 ring-1 ring-orange-300 dark:ring-orange-500/40',
+    row:   'bg-orange-50 dark:bg-orange-500/5 border-orange-200 dark:border-orange-500/30',
+  };
 }
 
-// ── Subcomponentes ────────────────────────────────────────────────────────────
+// ── Fila de cierre ────────────────────────────────────────────────────────────
 
-function SessionRow({
-  session,
+function ClosureRow({
+  closure,
   isValidating,
   onApprove,
   onReject,
 }: {
-  session: CourierSession;
+  closure: ShiftClosure;
   isValidating: boolean;
   onApprove: () => void;
   onReject: () => void;
 }) {
-  const diff = differenceTone(session.differenceAmount);
-  const isConsistent = session.differenceAmount === 0;
+  // expectedAmount = suma de todos los pedidos completados (cashToCollect)
+  const expectedAmount = closure.completedOrders.reduce(
+    (sum, o) => sum + o.cashToCollect, 0
+  );
+  const tone = differenceTone(closure.summary.totalCollected, expectedAmount);
+  const initials = closure.courierName
+    .split(' ').map((p) => p[0]).slice(0, 2).join('').toUpperCase();
 
   return (
-    <div
-      className={`flex items-center gap-4 px-5 py-4 rounded-xl border transition-colors ${
-        isConsistent
-          ? 'bg-[var(--theme-card-bg)] border-[var(--theme-border)]'
-          : session.differenceAmount < 0
-            ? 'bg-red-50 dark:bg-red-500/5 border-red-200 dark:border-red-500/30'
-            : 'bg-orange-50 dark:bg-orange-500/5 border-orange-200 dark:border-orange-500/30'
-      }`}
-    >
-      {/* Avatar + nombre */}
+    <div className={`flex items-center gap-4 px-5 py-4 rounded-xl border transition-colors ${tone.row}`}>
+
+      {/* Avatar + mensajero */}
       <div className="flex items-center gap-3 w-[220px] flex-shrink-0">
         <div className="w-9 h-9 rounded-full bg-[#88b04b]/15 flex items-center justify-center
           text-[#4a6b1f] dark:text-[#b7dc78] text-xs font-bold flex-shrink-0">
-          {session.courierName.split(' ').map((p) => p[0]).slice(0, 2).join('').toUpperCase()}
+          {initials}
         </div>
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-[var(--theme-text)] truncate">{session.courierName}</p>
-          <p className="text-xs text-[var(--theme-text)]/40">Cerrado {timeAgo(session.closedAt)}</p>
+          <p className="text-sm font-semibold text-[var(--theme-text)] truncate">
+            {closure.courierName}
+          </p>
+          <p className="text-xs text-[var(--theme-text)]/40">
+            {fmtDateKey(closure.dateKey)} · {fmtTime(closure.closedAt)}
+          </p>
         </div>
       </div>
 
-      {/* Entregas */}
+      {/* Entregas completadas */}
       <div className="w-[80px] flex-shrink-0 text-sm text-[var(--theme-text)]">
-        {session.deliveriesCount}
+        {closure.summary.completedCount}
       </div>
 
       {/* Esperado */}
       <div className="w-[110px] flex-shrink-0 text-sm text-[var(--theme-text)]">
-        {formatMoney(session.expectedAmount)}
+        {formatMoney(expectedAmount)}
       </div>
 
       {/* Registrado */}
       <div className="w-[110px] flex-shrink-0 text-sm text-[var(--theme-text)]">
-        {formatMoney(session.totalCollected)}
+        {formatMoney(closure.summary.totalCollected)}
       </div>
 
       {/* Diferencia */}
-      <div className="w-[110px] flex-shrink-0">
-        <span className={`inline-block text-xs font-semibold px-2.5 py-1 rounded-full ${diff.bg} ${diff.text}`}>
-          {diff.label}
+      <div className="w-[120px] flex-shrink-0">
+        <span className={`inline-block text-xs font-semibold px-2.5 py-1 rounded-full ${tone.badge}`}>
+          {tone.label}
         </span>
+      </div>
+
+      {/* Incidentes */}
+      <div className="w-[70px] flex-shrink-0 text-sm text-[var(--theme-text)]/60">
+        {closure.summary.notDeliveredCount + closure.summary.cancelledCount > 0
+          ? `${closure.summary.notDeliveredCount + closure.summary.cancelledCount} inc.`
+          : '—'}
       </div>
 
       {/* Acciones */}
@@ -113,7 +129,9 @@ function SessionRow({
             bg-[#88b04b]/15 text-[#4a6b1f] dark:text-[#b7dc78] hover:bg-[#88b04b]/25
             disabled:opacity-50 transition-colors"
         >
-          {isValidating ? <Loader2 size={13} className="animate-spin" /> : <CheckCircle2 size={13} />}
+          {isValidating
+            ? <Loader2 size={13} className="animate-spin" />
+            : <CheckCircle2 size={13} />}
           Aprobar
         </button>
         <button
@@ -132,37 +150,47 @@ function SessionRow({
   );
 }
 
+// ── Modal de rechazo ──────────────────────────────────────────────────────────
+
 function RejectModal({
-  session,
+  closure,
   onConfirm,
   onCancel,
   submitting,
 }: {
-  session: CourierSession;
+  closure: ShiftClosure;
   onConfirm: (reason: string) => void;
   onCancel: () => void;
   submitting: boolean;
 }) {
   const [reason, setReason] = useState('');
-  const diff = differenceTone(session.differenceAmount);
+  const expectedAmount = closure.completedOrders.reduce(
+    (sum, o) => sum + o.cashToCollect, 0
+  );
+  const tone = differenceTone(closure.summary.totalCollected, expectedAmount);
 
   return (
     <>
       <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" onClick={onCancel} />
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div className="w-full max-w-md bg-[var(--theme-card-bg)] border border-[var(--theme-border)] rounded-2xl shadow-2xl">
+        <div className="w-full max-w-md bg-[var(--theme-card-bg)] border border-[var(--theme-border)]
+          rounded-2xl shadow-2xl">
+
           <div className="px-6 pt-6 pb-4 border-b border-[var(--theme-border)]">
             <h2 className="text-[16px] font-bold text-[var(--theme-text)]">
               Rechazar cierre de jornada
             </h2>
             <p className="text-[12px] text-[var(--theme-text)]/50 mt-1">
-              {session.courierName} · diferencia de{' '}
-              <span className={diff.text}>{diff.label}</span>
+              {closure.courierName} · {fmtDateKey(closure.dateKey)} ·{' '}
+              <span className={tone.diff !== 0 ? 'text-red-500' : ''}>
+                {tone.label}
+              </span>
             </p>
           </div>
 
           <div className="px-6 py-5">
-            <label className="block text-[11px] font-semibold text-[var(--theme-text)]/50 uppercase tracking-wide mb-1.5">
+            <label className="block text-[11px] font-semibold text-[var(--theme-text)]/50
+              uppercase tracking-wide mb-1.5">
               Motivo del rechazo *
             </label>
             <textarea
@@ -171,8 +199,9 @@ function RejectModal({
               onChange={(e) => setReason(e.target.value)}
               rows={3}
               placeholder="Ej: el monto registrado no coincide con el total de entregas confirmadas..."
-              className="w-full p-3 rounded-xl text-[13px] bg-[var(--theme-bg)] border border-[var(--theme-border)]
-                text-[var(--theme-text)] placeholder:text-[var(--theme-text)]/30 outline-none
+              className="w-full p-3 rounded-xl text-[13px] bg-[var(--theme-bg)]
+                border border-[var(--theme-border)] text-[var(--theme-text)]
+                placeholder:text-[var(--theme-text)]/30 outline-none
                 focus:border-red-400 transition-colors resize-none"
             />
           </div>
@@ -190,8 +219,9 @@ function RejectModal({
             <button
               onClick={() => onConfirm(reason.trim())}
               disabled={submitting || !reason.trim()}
-              className="flex-1 py-2.5 rounded-xl text-[13px] font-medium bg-red-600 hover:bg-red-700
-                text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed
+              className="flex-1 py-2.5 rounded-xl text-[13px] font-medium bg-red-600
+                hover:bg-red-700 text-white transition-colors
+                disabled:opacity-40 disabled:cursor-not-allowed
                 flex items-center justify-center gap-2"
             >
               {submitting && <Loader2 size={14} className="animate-spin" />}
@@ -208,21 +238,21 @@ function RejectModal({
 
 export default function CourierSessionsValidation() {
   const {
-    sessions, loading, loadingMore, error, hasMore, loadMore, refresh,
+    closures, loading, loadingMore, error, hasMore, loadMore, refresh,
     validating, validateError, approve, reject,
   } = useSessions();
 
-  const [rejectTarget, setRejectTarget] = useState<CourierSession | null>(null);
-  const [rejecting, setRejecting] = useState(false);
+  const [rejectTarget, setRejectTarget] = useState<ShiftClosure | null>(null);
+  const [rejecting, setRejecting]       = useState(false);
 
-  async function handleApprove(sessionId: string) {
-    await approve(sessionId);
+  async function handleApprove(closureId: string) {
+    await approve(closureId);
   }
 
   async function handleConfirmReject(reason: string) {
     if (!rejectTarget || !reason) return;
     setRejecting(true);
-    const ok = await reject(rejectTarget.sessionId, reason);
+    const ok = await reject(rejectTarget.id, reason);
     setRejecting(false);
     if (ok) setRejectTarget(null);
   }
@@ -233,27 +263,32 @@ export default function CourierSessionsValidation() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-bold text-[var(--theme-text)]">Cierres de jornada pendientes</h2>
-          <p className="text-sm text-[var(--theme-text)]/50">
-            {loading ? 'Cargando...' : `${sessions.length} jornada${sessions.length !== 1 ? 's' : ''} esperando validación`}
+          <h2 className="text-[15px] font-semibold text-[var(--theme-text)]">
+            Cierres de jornada pendientes
+          </h2>
+          <p className="text-[11px] text-[var(--theme-text)]/50 mt-0.5">
+            {loading
+              ? 'Cargando...'
+              : `${closures.length} jornada${closures.length !== 1 ? 's' : ''} esperando validación`}
           </p>
         </div>
         <button
           onClick={refresh}
           disabled={loading}
           className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium
-            bg-[var(--theme-secondary-bg)] text-[var(--theme-text)]/60 hover:text-[var(--theme-text)]
-            disabled:opacity-50 transition-colors"
+            bg-[var(--theme-secondary-bg)] text-[var(--theme-text)]/60
+            hover:text-[var(--theme-text)] disabled:opacity-50 transition-colors"
         >
           <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
           Actualizar
         </button>
       </div>
 
-      {/* Error de validación (toast simple) */}
+      {/* Error de validación */}
       {validateError && (
-        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10 border
-          border-red-200 dark:border-red-500/30 rounded-xl text-sm text-red-600 dark:text-red-300">
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10
+          border border-red-200 dark:border-red-500/30 rounded-xl text-sm
+          text-red-600 dark:text-red-300">
           <AlertCircle size={16} className="flex-shrink-0" />
           {validateError}
         </div>
@@ -261,14 +296,15 @@ export default function CourierSessionsValidation() {
 
       {/* Error de carga */}
       {error && (
-        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10 border
-          border-red-200 dark:border-red-500/30 rounded-xl text-sm text-red-600 dark:text-red-300">
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-50 dark:bg-red-500/10
+          border border-red-200 dark:border-red-500/30 rounded-xl text-sm
+          text-red-600 dark:text-red-300">
           <AlertCircle size={16} className="flex-shrink-0" />
           {error}
         </div>
       )}
 
-      {/* Loading inicial */}
+      {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center py-20">
           <Loader2 size={24} className="animate-spin text-[#88b04b]" />
@@ -276,23 +312,38 @@ export default function CourierSessionsValidation() {
       )}
 
       {/* Estado vacío */}
-      {!loading && !error && sessions.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-20 text-[var(--theme-text)]/30 select-none">
+      {!loading && !error && closures.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20
+          text-[var(--theme-text)]/30 select-none">
           <ClipboardList size={40} strokeWidth={1.2} />
           <p className="mt-3 text-sm">No hay jornadas pendientes de validación</p>
         </div>
       )}
 
       {/* Lista */}
-      {!loading && sessions.length > 0 && (
-        <div className="space-y-3">
-          {sessions.map((session) => (
-            <SessionRow
-              key={session.sessionId}
-              session={session}
-              isValidating={validating === session.sessionId}
-              onApprove={() => handleApprove(session.sessionId)}
-              onReject={() => setRejectTarget(session)}
+      {!loading && closures.length > 0 && (
+        <div className="space-y-2">
+
+          {/* Cabecera */}
+          <div className="flex items-center gap-4 px-5 py-2.5 rounded-xl
+            bg-[var(--theme-secondary-bg)] text-[10px] font-semibold uppercase
+            tracking-wider text-[var(--theme-text)]/50">
+            <span className="w-[220px] flex-shrink-0">Mensajero</span>
+            <span className="w-[80px] flex-shrink-0">Entregas</span>
+            <span className="w-[110px] flex-shrink-0">Esperado</span>
+            <span className="w-[110px] flex-shrink-0">Registrado</span>
+            <span className="w-[120px] flex-shrink-0">Diferencia</span>
+            <span className="w-[70px] flex-shrink-0">Incidentes</span>
+            <span className="ml-auto">Acciones</span>
+          </div>
+
+          {closures.map((closure) => (
+            <ClosureRow
+              key={closure.id}
+              closure={closure}
+              isValidating={validating === closure.id}
+              onApprove={() => handleApprove(closure.id)}
+              onReject={() => setRejectTarget(closure)}
             />
           ))}
 
@@ -305,6 +356,7 @@ export default function CourierSessionsValidation() {
                   text-[#88b04b] hover:text-[#7aa043] disabled:opacity-50 transition-colors"
               >
                 {loadingMore && <Loader2 size={14} className="animate-spin" />}
+                <ChevronDown size={14} />
                 Cargar más
               </button>
             </div>
@@ -315,7 +367,7 @@ export default function CourierSessionsValidation() {
       {/* Modal de rechazo */}
       {rejectTarget && (
         <RejectModal
-          session={rejectTarget}
+          closure={rejectTarget}
           submitting={rejecting}
           onConfirm={handleConfirmReject}
           onCancel={() => setRejectTarget(null)}

--- a/src/features/admin/messengers/sessions/sessionsService.ts
+++ b/src/features/admin/messengers/sessions/sessionsService.ts
@@ -3,9 +3,9 @@
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from '../../../../lib/firebase';
 import type {
-  CourierSessionsListResponse,
-  ValidateCourierSessionPayload,
-  ValidateCourierSessionResponse,
+  ShiftClosuresListResponse,
+  ValidateShiftClosurePayload,
+  ValidateShiftClosureResponse,
 } from './types';
 
 async function getAuthorizationHeader(): Promise<Record<string, string>> {
@@ -22,14 +22,14 @@ async function getAuthorizationHeader(): Promise<Record<string, string>> {
   });
 }
 
-interface GetSessionsParams {
+interface GetClosuresParams {
   limit?: number;
   cursor?: string | null;
 }
 
-export async function getPendingSessions(
-  params: GetSessionsParams = {}
-): Promise<CourierSessionsListResponse> {
+export async function getPendingClosures(
+  params: GetClosuresParams = {}
+): Promise<ShiftClosuresListResponse> {
   const headers = await getAuthorizationHeader();
   const query = new URLSearchParams({
     status: 'closed',
@@ -44,12 +44,12 @@ export async function getPendingSessions(
     throw new Error(err.message ?? `Error ${response.status}`);
   }
 
-  return response.json() as Promise<CourierSessionsListResponse>;
+  return response.json() as Promise<ShiftClosuresListResponse>;
 }
 
-export async function validateCourierSession(
-  payload: ValidateCourierSessionPayload
-): Promise<ValidateCourierSessionResponse> {
+export async function validateShiftClosure(
+  payload: ValidateShiftClosurePayload
+): Promise<ValidateShiftClosureResponse> {
   const headers = await getAuthorizationHeader();
 
   const response = await fetch('/api/admin/courier_sessions', {
@@ -66,5 +66,5 @@ export async function validateCourierSession(
     throw new Error(err.message ?? `Error ${response.status}`);
   }
 
-  return response.json() as Promise<ValidateCourierSessionResponse>;
+  return response.json() as Promise<ValidateShiftClosureResponse>;
 }

--- a/src/features/admin/messengers/sessions/sessionsService.ts
+++ b/src/features/admin/messengers/sessions/sessionsService.ts
@@ -1,0 +1,70 @@
+// src/features/admin/messengers/sessions/sessionsService.ts
+
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../../../../lib/firebase';
+import type {
+  CourierSessionsListResponse,
+  ValidateCourierSessionPayload,
+  ValidateCourierSessionResponse,
+} from './types';
+
+async function getAuthorizationHeader(): Promise<Record<string, string>> {
+  return new Promise((resolve) => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      unsub();
+      if (user) {
+        const token = await user.getIdToken();
+        resolve({ Authorization: `Bearer ${token}` });
+      } else {
+        resolve({});
+      }
+    });
+  });
+}
+
+interface GetSessionsParams {
+  limit?: number;
+  cursor?: string | null;
+}
+
+export async function getPendingSessions(
+  params: GetSessionsParams = {}
+): Promise<CourierSessionsListResponse> {
+  const headers = await getAuthorizationHeader();
+  const query = new URLSearchParams({
+    status: 'closed',
+    limit: String(params.limit ?? 20),
+  });
+  if (params.cursor) query.set('cursor', params.cursor);
+
+  const response = await fetch(`/api/admin/courier_sessions?${query}`, { headers });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.message ?? `Error ${response.status}`);
+  }
+
+  return response.json() as Promise<CourierSessionsListResponse>;
+}
+
+export async function validateCourierSession(
+  payload: ValidateCourierSessionPayload
+): Promise<ValidateCourierSessionResponse> {
+  const headers = await getAuthorizationHeader();
+
+  const response = await fetch('/api/admin/courier_sessions', {
+    method: 'PATCH',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.message ?? `Error ${response.status}`);
+  }
+
+  return response.json() as Promise<ValidateCourierSessionResponse>;
+}

--- a/src/features/admin/messengers/sessions/types.ts
+++ b/src/features/admin/messengers/sessions/types.ts
@@ -1,0 +1,40 @@
+// src/features/admin/messengers/sessions/types.ts
+
+export type CourierSessionStatus = 'open' | 'closed' | 'validated' | 'rejected';
+
+export interface CourierSession {
+  sessionId: string;
+  courierId: string;
+  courierName: string;
+  totalCollected: number;
+  deliveriesCount: number;
+  expectedAmount: number;
+  differenceAmount: number;
+  status: CourierSessionStatus;
+  openedAt: string;
+  closedAt: string | null;
+  validatedBy?: string | null;
+  validatedByName?: string | null;
+  validatedAt?: string | null;
+  rejectionReason?: string | null;
+  updatedAt: string;
+}
+
+export interface CourierSessionsListResponse {
+  sessions: CourierSession[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export type CourierSessionAction = 'approve' | 'reject';
+
+export interface ValidateCourierSessionPayload {
+  sessionId: string;
+  action: CourierSessionAction;
+  rejectionReason?: string;
+}
+
+export interface ValidateCourierSessionResponse {
+  message: string;
+  session: CourierSession;
+}

--- a/src/features/admin/messengers/sessions/types.ts
+++ b/src/features/admin/messengers/sessions/types.ts
@@ -1,40 +1,70 @@
 // src/features/admin/messengers/sessions/types.ts
 
-export type CourierSessionStatus = 'open' | 'closed' | 'validated' | 'rejected';
-
-export interface CourierSession {
-  sessionId: string;
-  courierId: string;
-  courierName: string;
-  totalCollected: number;
-  deliveriesCount: number;
-  expectedAmount: number;
-  differenceAmount: number;
-  status: CourierSessionStatus;
-  openedAt: string;
-  closedAt: string | null;
-  validatedBy?: string | null;
-  validatedByName?: string | null;
-  validatedAt?: string | null;
-  rejectionReason?: string | null;
-  updatedAt: string;
+export interface ShiftOrderSnapshot {
+  id: string;
+  deliveryId: string;
+  customerName: string;
+  buyerName: string;
+  phone: string;
+  address: string;
+  city: string;
+  deliveryStatus: string;
+  paymentStatus: string;
+  paymentStatusLabel: string;
+  cashToCollect: number;
+  paymentCollectedAt: string | null;
+  assignedAt: string | null;
+  updatedAt: string | null;
 }
 
-export interface CourierSessionsListResponse {
-  sessions: CourierSession[];
+export interface ShiftSummary {
+  completedCount: number;
+  pendingCount: number;
+  notDeliveredCount: number;
+  cancelledCount: number;
+  totalCollected: number;
+}
+
+// Status del cierre — "closed" viene del mensajero,
+// "validated" y "rejected" los agrega esta HU al validar
+export type ShiftClosureStatus = 'closed' | 'validated' | 'rejected';
+
+export interface ShiftClosure {
+  // ID del documento: "{courierId}_{dateKey}" ej: "user-luis_2026-05-15"
+  id: string;
+  courierId: string;
+  courierName: string;
+  dateKey: string;            // "YYYY-MM-DD"
+  status: ShiftClosureStatus;
+  startedAt: string | null;
+  closedAt: string | null;
+  createdAt: string | null;
+  summary: ShiftSummary;
+  completedOrders: ShiftOrderSnapshot[];
+  pendingOrders: ShiftOrderSnapshot[];
+  incidentOrders: ShiftOrderSnapshot[];
+  // Campos que agrega el admin al validar (no existen en el doc original)
+  validatedBy: string | null;
+  validatedByName: string | null;
+  validatedAt: string | null;
+  rejectionReason: string | null;
+}
+
+export interface ShiftClosuresListResponse {
+  closures: ShiftClosure[];
   hasMore: boolean;
   nextCursor: string | null;
 }
 
-export type CourierSessionAction = 'approve' | 'reject';
+export type ShiftClosureAction = 'approve' | 'reject';
 
-export interface ValidateCourierSessionPayload {
-  sessionId: string;
-  action: CourierSessionAction;
+export interface ValidateShiftClosurePayload {
+  closureId: string;
+  action: ShiftClosureAction;
   rejectionReason?: string;
 }
 
-export interface ValidateCourierSessionResponse {
+export interface ValidateShiftClosureResponse {
   message: string;
-  session: CourierSession;
+  closure: ShiftClosure;
 }

--- a/src/features/admin/messengers/sessions/useSessions.ts
+++ b/src/features/admin/messengers/sessions/useSessions.ts
@@ -1,0 +1,103 @@
+// src/features/admin/messengers/sessions/useSessions.ts
+
+import { useState, useEffect, useCallback } from 'react';
+import { getPendingSessions, validateCourierSession } from './sessionsService';
+import type { CourierSession, CourierSessionAction } from './types';
+
+interface UseSessionsResult {
+  sessions: CourierSession[];
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+  validating: string | null; // sessionId que se está procesando actualmente
+  validateError: string | null;
+  approve: (sessionId: string) => Promise<boolean>;
+  reject: (sessionId: string, rejectionReason: string) => Promise<boolean>;
+}
+
+export function useSessions(): UseSessionsResult {
+  const [sessions, setSessions]       = useState<CourierSession[]>([]);
+  const [loading, setLoading]         = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError]             = useState<string | null>(null);
+  const [hasMore, setHasMore]         = useState(false);
+  const [cursor, setCursor]           = useState<string | null>(null);
+
+  const [validating, setValidating]       = useState<string | null>(null);
+  const [validateError, setValidateError] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async (cursorId: string | null, append: boolean) => {
+    try {
+      const data = await getPendingSessions({ limit: 20, cursor: cursorId });
+      setSessions((prev) => (append ? [...prev, ...data.sessions] : data.sessions));
+      setHasMore(data.hasMore);
+      setCursor(data.nextCursor);
+    } catch (err: any) {
+      setError(err.message ?? 'Error al cargar cierres de jornada');
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchSessions(null, false).finally(() => setLoading(false));
+  }, [fetchSessions]);
+
+  function loadMore() {
+    if (!hasMore || loadingMore || !cursor) return;
+    setLoadingMore(true);
+    fetchSessions(cursor, true).finally(() => setLoadingMore(false));
+  }
+
+  function refresh() {
+    setLoading(true);
+    setError(null);
+    setCursor(null);
+    fetchSessions(null, false).finally(() => setLoading(false));
+  }
+
+  async function runValidation(
+    sessionId: string,
+    action: CourierSessionAction,
+    rejectionReason?: string
+  ): Promise<boolean> {
+    setValidating(sessionId);
+    setValidateError(null);
+    try {
+      await validateCourierSession({ sessionId, action, rejectionReason });
+      // Quitar de la lista local ya que deja de estar "pendiente"
+      setSessions((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      return true;
+    } catch (err: any) {
+      setValidateError(err.message ?? 'Error al procesar el cierre');
+      return false;
+    } finally {
+      setValidating(null);
+    }
+  }
+
+  function approve(sessionId: string) {
+    return runValidation(sessionId, 'approve');
+  }
+
+  function reject(sessionId: string, rejectionReason: string) {
+    return runValidation(sessionId, 'reject', rejectionReason);
+  }
+
+  return {
+    sessions,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+    validating,
+    validateError,
+    approve,
+    reject,
+  };
+}

--- a/src/features/admin/messengers/sessions/useSessions.ts
+++ b/src/features/admin/messengers/sessions/useSessions.ts
@@ -1,25 +1,25 @@
 // src/features/admin/messengers/sessions/useSessions.ts
 
 import { useState, useEffect, useCallback } from 'react';
-import { getPendingSessions, validateCourierSession } from './sessionsService';
-import type { CourierSession, CourierSessionAction } from './types';
+import { getPendingClosures, validateShiftClosure } from './sessionsService';
+import type { ShiftClosure, ShiftClosureAction } from './types';
 
 interface UseSessionsResult {
-  sessions: CourierSession[];
+  closures: ShiftClosure[];
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
   hasMore: boolean;
   loadMore: () => void;
   refresh: () => void;
-  validating: string | null; // sessionId que se está procesando actualmente
+  validating: string | null; // closureId que se está procesando
   validateError: string | null;
-  approve: (sessionId: string) => Promise<boolean>;
-  reject: (sessionId: string, rejectionReason: string) => Promise<boolean>;
+  approve: (closureId: string) => Promise<boolean>;
+  reject: (closureId: string, rejectionReason: string) => Promise<boolean>;
 }
 
 export function useSessions(): UseSessionsResult {
-  const [sessions, setSessions]       = useState<CourierSession[]>([]);
+  const [closures, setClosures]       = useState<ShiftClosure[]>([]);
   const [loading, setLoading]         = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError]             = useState<string | null>(null);
@@ -29,10 +29,13 @@ export function useSessions(): UseSessionsResult {
   const [validating, setValidating]       = useState<string | null>(null);
   const [validateError, setValidateError] = useState<string | null>(null);
 
-  const fetchSessions = useCallback(async (cursorId: string | null, append: boolean) => {
+  const fetchClosures = useCallback(async (
+    cursorId: string | null,
+    append: boolean
+  ) => {
     try {
-      const data = await getPendingSessions({ limit: 20, cursor: cursorId });
-      setSessions((prev) => (append ? [...prev, ...data.sessions] : data.sessions));
+      const data = await getPendingClosures({ limit: 20, cursor: cursorId });
+      setClosures((prev) => append ? [...prev, ...data.closures] : data.closures);
       setHasMore(data.hasMore);
       setCursor(data.nextCursor);
     } catch (err: any) {
@@ -43,33 +46,33 @@ export function useSessions(): UseSessionsResult {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetchSessions(null, false).finally(() => setLoading(false));
-  }, [fetchSessions]);
+    fetchClosures(null, false).finally(() => setLoading(false));
+  }, [fetchClosures]);
 
   function loadMore() {
     if (!hasMore || loadingMore || !cursor) return;
     setLoadingMore(true);
-    fetchSessions(cursor, true).finally(() => setLoadingMore(false));
+    fetchClosures(cursor, true).finally(() => setLoadingMore(false));
   }
 
   function refresh() {
     setLoading(true);
     setError(null);
     setCursor(null);
-    fetchSessions(null, false).finally(() => setLoading(false));
+    fetchClosures(null, false).finally(() => setLoading(false));
   }
 
   async function runValidation(
-    sessionId: string,
-    action: CourierSessionAction,
+    closureId: string,
+    action: ShiftClosureAction,
     rejectionReason?: string
   ): Promise<boolean> {
-    setValidating(sessionId);
+    setValidating(closureId);
     setValidateError(null);
     try {
-      await validateCourierSession({ sessionId, action, rejectionReason });
-      // Quitar de la lista local ya que deja de estar "pendiente"
-      setSessions((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      await validateShiftClosure({ closureId, action, rejectionReason });
+      // Quitar de la lista local — ya no está "pendiente"
+      setClosures((prev) => prev.filter((c) => c.id !== closureId));
       return true;
     } catch (err: any) {
       setValidateError(err.message ?? 'Error al procesar el cierre');
@@ -79,16 +82,16 @@ export function useSessions(): UseSessionsResult {
     }
   }
 
-  function approve(sessionId: string) {
-    return runValidation(sessionId, 'approve');
+  function approve(closureId: string) {
+    return runValidation(closureId, 'approve');
   }
 
-  function reject(sessionId: string, rejectionReason: string) {
-    return runValidation(sessionId, 'reject', rejectionReason);
+  function reject(closureId: string, rejectionReason: string) {
+    return runValidation(closureId, 'reject', rejectionReason);
   }
 
   return {
-    sessions,
+    closures,
     loading,
     loadingMore,
     error,

--- a/src/pages/api/admin/courier_sessions.ts
+++ b/src/pages/api/admin/courier_sessions.ts
@@ -9,8 +9,7 @@ const devBypassEnabled =
   import.meta.env.PUBLIC_APP_ENV !== 'production';
 const devAdminUid = import.meta.env.DEV_ADMIN_UID || 'dev-admin';
 
-const VALID_STATUSES = ['open', 'closed', 'validated', 'rejected'] as const;
-type SessionStatus = (typeof VALID_STATUSES)[number];
+const COLLECTION = 'messenger_shift_closures';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -31,7 +30,9 @@ function toISO(ts: unknown): string | null {
   return String(ts);
 }
 
-async function requireAdmin(request: Request): Promise<{ uid: string } | { error: Response }> {
+async function requireAdmin(
+  request: Request
+): Promise<{ uid: string } | { error: Response }> {
   const authHeader = request.headers.get('authorization');
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null;
 
@@ -44,10 +45,8 @@ async function requireAdmin(request: Request): Promise<{ uid: string } | { error
     const decoded = await adminAuth.verifyIdToken(token);
     const userDoc = await adminDb.collection('users').doc(decoded.uid).get();
     const roles: string[] = userDoc.data()?.roles ?? [];
-
     if (roles.includes('admin')) return { uid: decoded.uid };
     if (devBypassEnabled) return { uid: devAdminUid };
-
     return { error: jsonResponse({ message: 'No tiene permisos de administrador.' }, 403) };
   } catch {
     if (devBypassEnabled) return { uid: devAdminUid };
@@ -55,69 +54,84 @@ async function requireAdmin(request: Request): Promise<{ uid: string } | { error
   }
 }
 
-async function resolveCourierName(courierId: string): Promise<string> {
-  const snap = await adminDb.collection('users').doc(courierId).get();
-  return snap.data()?.displayName ?? courierId;
+function serializeSummary(data: Record<string, unknown>) {
+  const s = (data.summary ?? {}) as Record<string, unknown>;
+  return {
+    completedCount:    Number(s.completedCount    ?? 0),
+    pendingCount:      Number(s.pendingCount      ?? 0),
+    notDeliveredCount: Number(s.notDeliveredCount ?? 0),
+    cancelledCount:    Number(s.cancelledCount    ?? 0),
+    totalCollected:    Number(s.totalCollected    ?? 0),
+  };
 }
 
-function serializeSession(
+function serializeOrderSnapshot(item: unknown) {
+  const d = (item ?? {}) as Record<string, unknown>;
+  return {
+    id:                   String(d.id              ?? ''),
+    deliveryId:           String(d.deliveryId      ?? ''),
+    customerName:         String(d.customerName    ?? 'Cliente no registrado'),
+    buyerName:            String(d.buyerName       ?? 'Comprador invitado'),
+    phone:                String(d.phone           ?? 'Sin teléfono'),
+    address:              String(d.address         ?? 'Dirección no registrada'),
+    city:                 String(d.city            ?? 'Cochabamba'),
+    deliveryStatus:       String(d.deliveryStatus  ?? ''),
+    paymentStatus:        String(d.paymentStatus   ?? ''),
+    paymentStatusLabel:   String(d.paymentStatusLabel ?? ''),
+    cashToCollect:        Number(d.cashToCollect   ?? 0),
+    paymentCollectedAt:   toISO(d.paymentCollectedAt),
+    assignedAt:           toISO(d.assignedAt),
+    updatedAt:            toISO(d.updatedAt),
+  };
+}
+
+function serializeClosure(
   id: string,
   data: FirebaseFirestore.DocumentData,
   courierName: string,
   validatedByName?: string | null
 ) {
-  const totalCollected = data.totalCollected ?? 0;
-  const expectedAmount = data.expectedAmount ?? 0;
-  // Fallback defensivo: si no viene calculada, se calcula aquí
-  const differenceAmount =
-    typeof data.differenceAmount === 'number'
-      ? data.differenceAmount
-      : Number((totalCollected - expectedAmount).toFixed(2));
-
   return {
-    sessionId: id,
-    courierId: data.courierId,
+    id,
+    courierId:        String(data.courierId  ?? ''),
     courierName,
-    totalCollected,
-    deliveriesCount: data.deliveriesCount ?? 0,
-    expectedAmount,
-    differenceAmount,
-    status: data.status,
-    openedAt: toISO(data.openedAt),
-    closedAt: toISO(data.closedAt),
-    validatedBy: data.validatedBy ?? null,
-    validatedByName: validatedByName ?? null,
-    validatedAt: toISO(data.validatedAt),
-    rejectionReason: data.rejectionReason ?? null,
-    updatedAt: toISO(data.updatedAt),
+    dateKey:          String(data.dateKey    ?? ''),
+    status:           String(data.status     ?? 'closed'),
+    startedAt:        toISO(data.startedAt),
+    closedAt:         toISO(data.closedAt),
+    createdAt:        toISO(data.createdAt),
+    summary:          serializeSummary(data),
+    completedOrders:  Array.isArray(data.completedOrders)  ? data.completedOrders.map(serializeOrderSnapshot)  : [],
+    pendingOrders:    Array.isArray(data.pendingOrders)    ? data.pendingOrders.map(serializeOrderSnapshot)    : [],
+    incidentOrders:   Array.isArray(data.incidentOrders)   ? data.incidentOrders.map(serializeOrderSnapshot)   : [],
+    validatedBy:      data.validatedBy     ?? null,
+    validatedByName:  validatedByName      ?? null,
+    validatedAt:      toISO(data.validatedAt),
+    rejectionReason:  data.rejectionReason ?? null,
   };
 }
 
-// ── GET: listar cierres (por defecto status=closed) ─────────────────────────────
+// ── GET: listar cierres ───────────────────────────────────────────────────────
 
 export const GET: APIRoute = async ({ request }) => {
   const admin = await requireAdmin(request);
   if ('error' in admin) return admin.error;
 
   try {
-    const url = new URL(request.url);
-    const status = (url.searchParams.get('status') ?? 'closed') as SessionStatus;
+    const url    = new URL(request.url);
+    const status = url.searchParams.get('status') ?? 'closed';
     const limitParam = parseInt(url.searchParams.get('limit') ?? '20');
-    const limit = isNaN(limitParam) ? 20 : Math.min(Math.max(limitParam, 1), 50);
+    const limit  = isNaN(limitParam) ? 20 : Math.min(Math.max(limitParam, 1), 50);
     const cursor = url.searchParams.get('cursor');
 
-    if (!VALID_STATUSES.includes(status)) {
-      return jsonResponse({ message: 'El estado solicitado no es válido.' }, 400);
-    }
-
     let query: FirebaseFirestore.Query = adminDb
-      .collection('courierSessions')
+      .collection(COLLECTION)
       .where('status', '==', status)
       .orderBy('closedAt', 'desc')
       .limit(limit + 1);
 
     if (cursor) {
-      const cursorSnap = await adminDb.collection('courierSessions').doc(cursor).get();
+      const cursorSnap = await adminDb.collection(COLLECTION).doc(cursor).get();
       if (cursorSnap.exists) query = query.startAfter(cursorSnap);
     }
 
@@ -125,7 +139,7 @@ export const GET: APIRoute = async ({ request }) => {
     const hasMore = snap.docs.length > limit;
     const docs = hasMore ? snap.docs.slice(0, limit) : snap.docs;
 
-    // Resolver nombres de mensajeros en paralelo, sin duplicar consultas
+    // Resolver nombres de mensajeros en paralelo sin duplicar consultas
     const courierIds = [...new Set(docs.map((d) => d.data().courierId).filter(Boolean))];
     const courierSnaps = await Promise.all(
       courierIds.map((id) => adminDb.collection('users').doc(id).get())
@@ -135,24 +149,24 @@ export const GET: APIRoute = async ({ request }) => {
       if (s.exists) courierMap[s.id] = s.data()?.displayName ?? s.id;
     });
 
-    const sessions = docs.map((d) => {
+    const closures = docs.map((d) => {
       const data = d.data();
-      return serializeSession(d.id, data, courierMap[data.courierId] ?? data.courierId);
+      return serializeClosure(d.id, data, courierMap[data.courierId] ?? data.courierId);
     });
 
     const nextCursor = hasMore ? docs[docs.length - 1].id : null;
 
-    return jsonResponse({ sessions, hasMore, nextCursor });
+    return jsonResponse({ closures, hasMore, nextCursor });
   } catch (err) {
     console.error('[courier_sessions GET]', err);
     return jsonResponse({ message: 'Error interno del servidor.' }, 500);
   }
 };
 
-// ── PATCH: aprobar o rechazar un cierre ──────────────────────────────────────────
+// ── PATCH: aprobar o rechazar un cierre ───────────────────────────────────────
 
 interface PatchBody {
-  sessionId?: string;
+  closureId?: string;
   action?: 'approve' | 'reject';
   rejectionReason?: string;
 }
@@ -169,12 +183,12 @@ export const PATCH: APIRoute = async ({ request }) => {
       return jsonResponse({ message: 'El cuerpo de la solicitud no es válido.' }, 400);
     }
 
-    const sessionId = body.sessionId?.trim();
-    const action = body.action;
+    const closureId      = body.closureId?.trim();
+    const action         = body.action;
     const rejectionReason = body.rejectionReason?.trim();
 
-    if (!sessionId) {
-      return jsonResponse({ message: 'sessionId es obligatorio.' }, 400);
+    if (!closureId) {
+      return jsonResponse({ message: 'closureId es obligatorio.' }, 400);
     }
     if (action !== 'approve' && action !== 'reject') {
       return jsonResponse({ message: 'action debe ser "approve" o "reject".' }, 400);
@@ -183,46 +197,50 @@ export const PATCH: APIRoute = async ({ request }) => {
       return jsonResponse({ message: 'El motivo de rechazo es obligatorio.' }, 400);
     }
 
-    const sessionRef = adminDb.collection('courierSessions').doc(sessionId);
-    const sessionSnap = await sessionRef.get();
+    const closureRef  = adminDb.collection(COLLECTION).doc(closureId);
+    const closureSnap = await closureRef.get();
 
-    if (!sessionSnap.exists) {
+    if (!closureSnap.exists) {
       return jsonResponse({ message: 'Cierre de jornada no encontrado.' }, 404);
     }
 
-    const sessionData = sessionSnap.data()!;
+    const closureData = closureSnap.data()!;
 
-    // Bloquear si ya fue validado o rechazado anteriormente
-    if (sessionData.status === 'validated' || sessionData.status === 'rejected') {
+    // Bloquear si ya fue validado o rechazado
+    if (closureData.status === 'validated' || closureData.status === 'rejected') {
       return jsonResponse(
         { message: 'Este cierre ya fue procesado y no puede modificarse nuevamente.' },
         409
       );
     }
 
-    const newStatus: SessionStatus = action === 'approve' ? 'validated' : 'rejected';
+    const newStatus = action === 'approve' ? 'validated' : 'rejected';
 
     const updatePayload: Record<string, unknown> = {
-      status: newStatus,
+      status:      newStatus,
       validatedBy: admin.uid,
       validatedAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
     };
-
     if (action === 'reject') {
       updatePayload.rejectionReason = rejectionReason;
     }
 
-    await sessionRef.update(updatePayload);
+    await closureRef.update(updatePayload);
 
-    const updatedSnap = await sessionRef.get();
+    // Leer el doc actualizado para devolver el estado real
+    const updatedSnap = await closureRef.get();
     const updatedData = updatedSnap.data()!;
-    const courierName = await resolveCourierName(updatedData.courierId);
-    const validatedByName = await resolveCourierName(admin.uid);
+
+    // Resolver nombres
+    const courierName      = (await adminDb.collection('users').doc(updatedData.courierId).get()).data()?.displayName ?? updatedData.courierId;
+    const validatedBySnap  = await adminDb.collection('users').doc(admin.uid).get();
+    const validatedByName  = validatedBySnap.data()?.displayName ?? admin.uid;
 
     return jsonResponse({
-      message: action === 'approve' ? 'Cierre aprobado correctamente.' : 'Cierre rechazado correctamente.',
-      session: serializeSession(sessionId, updatedData, courierName, validatedByName),
+      message: action === 'approve'
+        ? 'Cierre aprobado correctamente.'
+        : 'Cierre rechazado correctamente.',
+      closure: serializeClosure(closureId, updatedData, courierName, validatedByName),
     });
   } catch (err) {
     console.error('[courier_sessions PATCH]', err);

--- a/src/pages/api/admin/courier_sessions.ts
+++ b/src/pages/api/admin/courier_sessions.ts
@@ -1,0 +1,231 @@
+// src/pages/api/admin/courier_sessions.ts
+
+import type { APIRoute } from 'astro';
+import { adminDb, adminAuth } from '../../../lib/firebase-admin';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+
+const devBypassEnabled =
+  import.meta.env.ENABLE_DEV_ADMIN_BYPASS === 'true' &&
+  import.meta.env.PUBLIC_APP_ENV !== 'production';
+const devAdminUid = import.meta.env.DEV_ADMIN_UID || 'dev-admin';
+
+const VALID_STATUSES = ['open', 'closed', 'validated', 'rejected'] as const;
+type SessionStatus = (typeof VALID_STATUSES)[number];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function toISO(ts: unknown): string | null {
+  if (!ts) return null;
+  if (ts instanceof Timestamp) return ts.toDate().toISOString();
+  if (typeof ts === 'object' && ts !== null && 'toDate' in (ts as any)) {
+    return (ts as any).toDate().toISOString();
+  }
+  if (ts instanceof Date) return ts.toISOString();
+  return String(ts);
+}
+
+async function requireAdmin(request: Request): Promise<{ uid: string } | { error: Response }> {
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null;
+
+  if (!token) {
+    if (devBypassEnabled) return { uid: devAdminUid };
+    return { error: jsonResponse({ message: 'No autenticado.' }, 401) };
+  }
+
+  try {
+    const decoded = await adminAuth.verifyIdToken(token);
+    const userDoc = await adminDb.collection('users').doc(decoded.uid).get();
+    const roles: string[] = userDoc.data()?.roles ?? [];
+
+    if (roles.includes('admin')) return { uid: decoded.uid };
+    if (devBypassEnabled) return { uid: devAdminUid };
+
+    return { error: jsonResponse({ message: 'No tiene permisos de administrador.' }, 403) };
+  } catch {
+    if (devBypassEnabled) return { uid: devAdminUid };
+    return { error: jsonResponse({ message: 'Token de autenticación inválido.' }, 401) };
+  }
+}
+
+async function resolveCourierName(courierId: string): Promise<string> {
+  const snap = await adminDb.collection('users').doc(courierId).get();
+  return snap.data()?.displayName ?? courierId;
+}
+
+function serializeSession(
+  id: string,
+  data: FirebaseFirestore.DocumentData,
+  courierName: string,
+  validatedByName?: string | null
+) {
+  const totalCollected = data.totalCollected ?? 0;
+  const expectedAmount = data.expectedAmount ?? 0;
+  // Fallback defensivo: si no viene calculada, se calcula aquí
+  const differenceAmount =
+    typeof data.differenceAmount === 'number'
+      ? data.differenceAmount
+      : Number((totalCollected - expectedAmount).toFixed(2));
+
+  return {
+    sessionId: id,
+    courierId: data.courierId,
+    courierName,
+    totalCollected,
+    deliveriesCount: data.deliveriesCount ?? 0,
+    expectedAmount,
+    differenceAmount,
+    status: data.status,
+    openedAt: toISO(data.openedAt),
+    closedAt: toISO(data.closedAt),
+    validatedBy: data.validatedBy ?? null,
+    validatedByName: validatedByName ?? null,
+    validatedAt: toISO(data.validatedAt),
+    rejectionReason: data.rejectionReason ?? null,
+    updatedAt: toISO(data.updatedAt),
+  };
+}
+
+// ── GET: listar cierres (por defecto status=closed) ─────────────────────────────
+
+export const GET: APIRoute = async ({ request }) => {
+  const admin = await requireAdmin(request);
+  if ('error' in admin) return admin.error;
+
+  try {
+    const url = new URL(request.url);
+    const status = (url.searchParams.get('status') ?? 'closed') as SessionStatus;
+    const limitParam = parseInt(url.searchParams.get('limit') ?? '20');
+    const limit = isNaN(limitParam) ? 20 : Math.min(Math.max(limitParam, 1), 50);
+    const cursor = url.searchParams.get('cursor');
+
+    if (!VALID_STATUSES.includes(status)) {
+      return jsonResponse({ message: 'El estado solicitado no es válido.' }, 400);
+    }
+
+    let query: FirebaseFirestore.Query = adminDb
+      .collection('courierSessions')
+      .where('status', '==', status)
+      .orderBy('closedAt', 'desc')
+      .limit(limit + 1);
+
+    if (cursor) {
+      const cursorSnap = await adminDb.collection('courierSessions').doc(cursor).get();
+      if (cursorSnap.exists) query = query.startAfter(cursorSnap);
+    }
+
+    const snap = await query.get();
+    const hasMore = snap.docs.length > limit;
+    const docs = hasMore ? snap.docs.slice(0, limit) : snap.docs;
+
+    // Resolver nombres de mensajeros en paralelo, sin duplicar consultas
+    const courierIds = [...new Set(docs.map((d) => d.data().courierId).filter(Boolean))];
+    const courierSnaps = await Promise.all(
+      courierIds.map((id) => adminDb.collection('users').doc(id).get())
+    );
+    const courierMap: Record<string, string> = {};
+    courierSnaps.forEach((s) => {
+      if (s.exists) courierMap[s.id] = s.data()?.displayName ?? s.id;
+    });
+
+    const sessions = docs.map((d) => {
+      const data = d.data();
+      return serializeSession(d.id, data, courierMap[data.courierId] ?? data.courierId);
+    });
+
+    const nextCursor = hasMore ? docs[docs.length - 1].id : null;
+
+    return jsonResponse({ sessions, hasMore, nextCursor });
+  } catch (err) {
+    console.error('[courier_sessions GET]', err);
+    return jsonResponse({ message: 'Error interno del servidor.' }, 500);
+  }
+};
+
+// ── PATCH: aprobar o rechazar un cierre ──────────────────────────────────────────
+
+interface PatchBody {
+  sessionId?: string;
+  action?: 'approve' | 'reject';
+  rejectionReason?: string;
+}
+
+export const PATCH: APIRoute = async ({ request }) => {
+  const admin = await requireAdmin(request);
+  if ('error' in admin) return admin.error;
+
+  try {
+    let body: PatchBody;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ message: 'El cuerpo de la solicitud no es válido.' }, 400);
+    }
+
+    const sessionId = body.sessionId?.trim();
+    const action = body.action;
+    const rejectionReason = body.rejectionReason?.trim();
+
+    if (!sessionId) {
+      return jsonResponse({ message: 'sessionId es obligatorio.' }, 400);
+    }
+    if (action !== 'approve' && action !== 'reject') {
+      return jsonResponse({ message: 'action debe ser "approve" o "reject".' }, 400);
+    }
+    if (action === 'reject' && !rejectionReason) {
+      return jsonResponse({ message: 'El motivo de rechazo es obligatorio.' }, 400);
+    }
+
+    const sessionRef = adminDb.collection('courierSessions').doc(sessionId);
+    const sessionSnap = await sessionRef.get();
+
+    if (!sessionSnap.exists) {
+      return jsonResponse({ message: 'Cierre de jornada no encontrado.' }, 404);
+    }
+
+    const sessionData = sessionSnap.data()!;
+
+    // Bloquear si ya fue validado o rechazado anteriormente
+    if (sessionData.status === 'validated' || sessionData.status === 'rejected') {
+      return jsonResponse(
+        { message: 'Este cierre ya fue procesado y no puede modificarse nuevamente.' },
+        409
+      );
+    }
+
+    const newStatus: SessionStatus = action === 'approve' ? 'validated' : 'rejected';
+
+    const updatePayload: Record<string, unknown> = {
+      status: newStatus,
+      validatedBy: admin.uid,
+      validatedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    if (action === 'reject') {
+      updatePayload.rejectionReason = rejectionReason;
+    }
+
+    await sessionRef.update(updatePayload);
+
+    const updatedSnap = await sessionRef.get();
+    const updatedData = updatedSnap.data()!;
+    const courierName = await resolveCourierName(updatedData.courierId);
+    const validatedByName = await resolveCourierName(admin.uid);
+
+    return jsonResponse({
+      message: action === 'approve' ? 'Cierre aprobado correctamente.' : 'Cierre rechazado correctamente.',
+      session: serializeSession(sessionId, updatedData, courierName, validatedByName),
+    });
+  } catch (err) {
+    console.error('[courier_sessions PATCH]', err);
+    return jsonResponse({ message: 'Error interno del servidor.' }, 500);
+  }
+};


### PR DESCRIPTION
## Resumen
Implementa la pantalla de validación de cierres de jornada de mensajeros (HU #142). Permite al administrador revisar, aprobar o rechazar los cierres enviados por los mensajeros, mostrando el monto esperado vs. el registrado y destacando diferencias.

## URL de los cambios
- URL: `http://localhost:4321/admin`
- Ruta o pantalla afectada: Admin → Mensajeros → Validar cierres

## Cómo probar
1. Correr el emulador de Firestore y ejecutar el seed (`node seed/index.mjs`)
2. Ingresar al panel de admin y navegar a **Mensajeros → Validar cierres**
3. Verificar que aparecen 3 jornadas pendientes: una cuadrada, una con faltante (−Bs. 45) y una con sobrante (+Bs. 15)
4. Aprobar la jornada cuadrada y confirmar que desaparece de la lista
5. Rechazar una jornada, completar el motivo y confirmar que desaparece de la lista
6. Intentar aprobar una jornada ya procesada directamente en Firestore y verificar que el API devuelve 409

## Resultado esperado
- Las 3 jornadas con `status: "closed"` aparecen en la lista
- El badge de diferencia muestra verde (0), rojo (−) o naranja (+) según corresponda
- Al aprobar o rechazar, el documento en Firestore cambia a `validated` o `rejected` y la fila desaparece de la lista sin recargar la página
- El botón de rechazar no se habilita si el motivo está vacío
- Las jornadas con `status: "validated"` o `"rejected"` no aparecen en el panel

## Evidencia visual
| Antes | Después |
| --- | --- |
| No aplica | <img width="1563" height="613" alt="image" src="https://github.com/user-attachments/assets/542ce7fb-7498-47b8-b2ad-e5afad4bd8ff" /> |

## Tipo de cambio
- [x] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados
Closes #142

## Checklist del autor
- [x] Probé el cambio localmente
- [ ] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [ ] No hay errores ni warnings nuevos conocidos
- [ ] Revisé mi propio código antes de pedir review

## Notas para quien revisa
- El monto **esperado** se calcula en el frontend sumando `cashToCollect` de `completedOrders`, no viene del backend. Si en el futuro se necesita auditoría más estricta ese cálculo debería moverse al API.
- El seed de cierres (`seed/data/messenger_shift_closures.mjs`) está pendiente de integrar a `seed/index.mjs` y se subirá en un PR separado.
- El endpoint PATCH bloquea con 409 si el cierre ya fue procesado, para evitar doble validación.