### PR TITLE
fix(admin): show summarized order id in reconciliation

### DIFF
--- a/src/features/admin/reconciliation/components/PaymentReconciliationPanel.tsx
+++ b/src/features/admin/reconciliation/components/PaymentReconciliationPanel.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, CheckCircle2, RefreshCw, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { parseOrderId } from "../../../cart/services/orderService";
 import { listenPaymentReconciliation } from "../services/paymentReconciliationService";
 import type {
 	PaymentReconciliationItem,
@@ -72,6 +73,26 @@ function SummaryCard({
 				{value}
 			</p>
 		</div>
+	);
+}
+
+function OrderIdSummary({ orderId }: { orderId: string }) {
+	const { uuid, friendlyName } = parseOrderId(orderId);
+
+	return (
+		<>
+			<p
+				className="max-w-[180px] truncate font-mono text-[12px] font-black uppercase text-(--theme-text)"
+				title={orderId}
+			>
+				#{friendlyName}
+			</p>
+			{uuid !== friendlyName && (
+				<p className="mt-1 max-w-[180px] truncate font-mono text-[10px] text-(--theme-text) opacity-45">
+					{uuid}
+				</p>
+			)}
+		</>
 	);
 }
 
@@ -302,9 +323,7 @@ export default function PaymentReconciliationPanel() {
 											}
 										>
 											<td className="px-4 py-3 align-top">
-												<p className="max-w-[220px] truncate font-mono text-[11px] font-bold text-(--theme-text)">
-													{item.orderId}
-												</p>
+												<OrderIdSummary orderId={item.orderId} />
 												<p className="mt-1 text-[10px] text-(--theme-text) opacity-45">
 													{formatDateTime(item.deliveredAt ?? item.updatedAt)}
 												</p>


### PR DESCRIPTION
## Resumen

Se agrega una sección de conciliación de pagos para administradores, permitiendo detectar pedidos entregados con pagos faltantes, no cobrados o con montos diferentes. La vista es de solo lectura y muestra el ID resumido del pedido para facilitar la revisión.

## URL de los cambios

- URL: http://127.0.0.1:4321/admin
- Ruta o pantalla afectada: Admin > Pedidos > Conciliacion

## Cómo probar

1. Iniciar sesión con una cuenta administradora, por ejemplo `admin@umss.edu` / `12345678`.
2. Ingresar a `/admin` y abrir el menú lateral `Pedidos`.
3. Seleccionar la opción `Conciliacion`.
4. Revisar el resumen de inconsistencias y la tabla de resultados.
5. Verificar que el pedido muestre el ID resumido, por ejemplo `#wab-4ok`, y el UUID como referencia secundaria.
6. Probar los filtros por tipo de diferencia: `Todas`, `Sin pago`, `No cobrado`, `Monto diferente`.
7. Probar la búsqueda por ID de pedido, cliente o teléfono.

## Resultado esperado

El administrador puede ver un panel de conciliación con pedidos entregados que tienen diferencias frente a los pagos registrados. El sistema clasifica las inconsistencias como pagos faltantes, pagos no cobrados o montos diferentes, permite filtrar/buscar resultados y muestra un ID de pedido resumido para facilitar la lectura.

## Evidencia visual
| No existía la sección de conciliación de pagos en Admin. | Se muestra `Admin > Pedidos > Conciliacion` con resumen, filtros, tabla de inconsistencias e ID resumido del pedido. |

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

La sección es de solo lectura: no modifica pedidos, pagos ni entregas.  
Se agregó dentro del dashboard de Admin para evitar nuevas rutas y reducir conflictos con otros módulos.  
Se reutiliza `parseOrderId` para mostrar el ID resumido del pedido de forma consistente con otras pantallas del sistema.

