### PR TITLE
Fix/courier responsive modals

### DIFF
--- a/src/features/mensajero/components/CourierBuyerMap.tsx
+++ b/src/features/mensajero/components/CourierBuyerMap.tsx
@@ -1,371 +1,401 @@
-import { ArrowLeft, Banknote, Info, MapPin, Moon, Package, Phone, Sun, X } from 'lucide-react';
-import L from 'leaflet';
-import { useEffect, useMemo, useState } from 'react';
-import { collection, doc, getDoc, getDocs } from 'firebase/firestore';
-import { MapContainer, Marker, Polygon, TileLayer, ZoomControl } from 'react-leaflet';
-import { db } from '../../../lib/firebase';
-import { ALLOWED_ZONES } from '../../location/utils/zoneLimits';
-import { formatBolivianos } from '../utils/money';
-import 'leaflet/dist/leaflet.css';
+import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+import L from "leaflet";
+import {
+	ArrowLeft,
+	Banknote,
+	Info,
+	MapPin,
+	Moon,
+	Package,
+	Phone,
+	Sun,
+	X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	MapContainer,
+	Marker,
+	Polygon,
+	TileLayer,
+	ZoomControl,
+} from "react-leaflet";
+import { db } from "../../../lib/firebase";
+import { ALLOWED_ZONES } from "../../location/utils/zoneLimits";
+import { formatBolivianos } from "../utils/money";
+import "leaflet/dist/leaflet.css";
 
 const defaultIcon = L.icon({
-    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41],
+	iconUrl:
+		"https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png",
+	shadowUrl:
+		"https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png",
+	iconSize: [25, 41],
+	iconAnchor: [12, 41],
+	popupAnchor: [1, -34],
+	shadowSize: [41, 41],
 });
 
 L.Marker.prototype.options.icon = defaultIcon;
 
 type BuyerMapItem = {
-    name: string;
-    quantity: number;
+	name: string;
+	quantity: number;
 };
 
 type BuyerMapOrder = {
-    customerName: string;
-    phone: string;
-    address: string;
-    reference?: string;
-    items: BuyerMapItem[];
-    cashToCollect: number;
+	customerName: string;
+	phone: string;
+	address: string;
+	reference?: string;
+	items: BuyerMapItem[];
+	cashToCollect: number;
 };
 
 const FALLBACK_POSITION: [number, number] = [-17.394, -66.1473];
-const THEME_STORAGE_KEY = 'sansistore-theme';
+const THEME_STORAGE_KEY = "sansistore-theme";
 
-type ThemeMode = 'light' | 'dark';
+type ThemeMode = "light" | "dark";
 
 const applyTheme = (theme: ThemeMode) => {
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.style.colorScheme = theme;
+	document.documentElement.dataset.theme = theme;
+	document.documentElement.style.colorScheme = theme;
 
-    try {
-        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-    } catch {
-        // Keep visual theme even if local storage is unavailable.
-    }
+	try {
+		window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+	} catch {
+		// Keep visual theme even if local storage is unavailable.
+	}
 };
 
 function readOrderFromStorage(): BuyerMapOrder | null {
-    if (typeof window === 'undefined') return null;
-    try {
-        const raw = window.localStorage.getItem('courier_panel_order');
-        return raw ? (JSON.parse(raw) as BuyerMapOrder) : null;
-    } catch {
-        return null;
-    }
+	if (typeof window === "undefined") return null;
+	try {
+		const raw = window.localStorage.getItem("courier_panel_order");
+		return raw ? (JSON.parse(raw) as BuyerMapOrder) : null;
+	} catch {
+		return null;
+	}
 }
 
 function readInitialOrder(): BuyerMapOrder | null {
-    if (typeof window === 'undefined') return null;
+	if (typeof window === "undefined") return null;
 
-    const params = new URLSearchParams(window.location.search);
-    const mode = params.get('mode');
+	const params = new URLSearchParams(window.location.search);
+	const mode = params.get("mode");
 
-    if (mode === 'seller') {
-        try {
-            const raw = window.localStorage.getItem('courier_panel_seller');
-            return raw ? (JSON.parse(raw) as BuyerMapOrder) : null;
-        } catch {
-            return null;
-        }
-    }
+	if (mode === "seller") {
+		try {
+			const raw = window.localStorage.getItem("courier_panel_seller");
+			return raw ? (JSON.parse(raw) as BuyerMapOrder) : null;
+		} catch {
+			return null;
+		}
+	}
 
-    if (params.get('order')) return null;
+	if (params.get("order")) return null;
 
-    return readOrderFromStorage();
+	return readOrderFromStorage();
 }
 
 const asString = (value: unknown): string | null =>
-    typeof value === 'string' && value.trim() ? value.trim() : null;
+	typeof value === "string" && value.trim() ? value.trim() : null;
 
-async function readOrderFromFirestore(orderId: string): Promise<BuyerMapOrder | null> {
-    const orderSnap = await getDoc(doc(db, 'orders', orderId));
-    if (!orderSnap.exists()) return null;
+async function readOrderFromFirestore(
+	orderId: string,
+): Promise<BuyerMapOrder | null> {
+	const orderSnap = await getDoc(doc(db, "orders", orderId));
+	if (!orderSnap.exists()) return null;
 
-    const order = orderSnap.data();
-    const itemsSnapshot = await getDocs(collection(db, 'orders', orderId, 'orderItems'));
-    const locationId = asString(order.locationId);
-    const locationSnap = locationId ? await getDoc(doc(db, 'locations', locationId)) : null;
-    const location = locationSnap?.exists() ? locationSnap.data() : {};
+	const order = orderSnap.data();
+	const itemsSnapshot = await getDocs(
+		collection(db, "orders", orderId, "orderItems"),
+	);
+	const locationId = asString(order.locationId);
+	const locationSnap = locationId
+		? await getDoc(doc(db, "locations", locationId))
+		: null;
+	const location = locationSnap?.exists() ? locationSnap.data() : {};
 
-    const items = itemsSnapshot.docs.map((itemDoc) => {
-        const item = itemDoc.data();
-        return {
-            name: String(item.productName || 'Producto sin nombre'),
-            quantity: Number(item.quantity || 0),
-        };
-    });
+	const items = itemsSnapshot.docs.map((itemDoc) => {
+		const item = itemDoc.data();
+		return {
+			name: String(item.productName || "Producto sin nombre"),
+			quantity: Number(item.quantity || 0),
+		};
+	});
 
-    return {
-        customerName: String(order.customerName || 'Cliente no registrado'),
-        phone: String(order.customerPhone || 'Sin telefono'),
-        address: String(order.address || asString(location.label) || 'Direccion no registrada'),
-        reference:
-            asString(order.reference) ||
-            asString(order.locationLabel) ||
-            asString(location.label) ||
-            undefined,
-        items,
-        cashToCollect: Number(order.total || 0),
-    };
+	return {
+		customerName: String(order.customerName || "Cliente no registrado"),
+		phone: String(order.customerPhone || "Sin telefono"),
+		address: String(
+			order.address || asString(location.label) || "Direccion no registrada",
+		),
+		reference:
+			asString(order.reference) ||
+			asString(order.locationLabel) ||
+			asString(location.label) ||
+			undefined,
+		items,
+		cashToCollect: Number(order.total || 0),
+	};
 }
 
 export default function CourierBuyerMap() {
-    const [order, setOrder] = useState<BuyerMapOrder | null>(() => readInitialOrder());
-    const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-    const [theme, setTheme] = useState<ThemeMode>('light');
+	const [order, setOrder] = useState<BuyerMapOrder | null>(() =>
+		readInitialOrder(),
+	);
+	const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+	const [theme, setTheme] = useState<ThemeMode>("light");
 
-    useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        const orderId = params.get('order');
-        const mode = params.get('mode');
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		const orderId = params.get("order");
+		const mode = params.get("mode");
 
-        if (!orderId || mode === 'seller') return;
+		if (!orderId || mode === "seller") return;
 
-        let isMounted = true;
+		let isMounted = true;
 
-        readOrderFromFirestore(orderId)
-            .then((freshOrder) => {
-                if (!isMounted || !freshOrder) return;
-                setOrder(freshOrder);
-                localStorage.setItem('courier_panel_order', JSON.stringify(freshOrder));
-            })
-            .catch(() => { });
+		readOrderFromFirestore(orderId)
+			.then((freshOrder) => {
+				if (!isMounted || !freshOrder) return;
+				setOrder(freshOrder);
+				localStorage.setItem("courier_panel_order", JSON.stringify(freshOrder));
+			})
+			.catch(() => {});
 
-        return () => {
-            isMounted = false;
-        };
-    }, []);
+		return () => {
+			isMounted = false;
+		};
+	}, []);
 
-    useEffect(() => {
-        const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
-        const currentTheme =
-            savedTheme ||
-            (document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light');
+	useEffect(() => {
+		const savedTheme = window.localStorage.getItem(
+			THEME_STORAGE_KEY,
+		) as ThemeMode | null;
+		const currentTheme =
+			savedTheme ||
+			(document.documentElement.dataset.theme === "dark" ? "dark" : "light");
 
-        applyTheme(currentTheme);
-        setTheme(currentTheme);
-    }, []);
+		applyTheme(currentTheme);
+		setTheme(currentTheme);
+	}, []);
 
-    const position = useMemo<[number, number]>(() => {
-        const params = new URLSearchParams(window.location.search);
-        const lat = Number(params.get('lat'));
-        const lng = Number(params.get('lng'));
-        if (Number.isFinite(lat) && Number.isFinite(lng)) {
-            return [lat, lng];
-        }
-        return FALLBACK_POSITION;
-    }, []);
+	const position = useMemo<[number, number]>(() => {
+		const params = new URLSearchParams(window.location.search);
+		const lat = Number(params.get("lat"));
+		const lng = Number(params.get("lng"));
+		if (Number.isFinite(lat) && Number.isFinite(lng)) {
+			return [lat, lng];
+		}
+		return FALLBACK_POSITION;
+	}, []);
 
-    const isSeller = useMemo(() => {
-        return new URLSearchParams(window.location.search).get('mode') === 'seller';
-    }, []);
+	const isSeller = useMemo(() => {
+		return new URLSearchParams(window.location.search).get("mode") === "seller";
+	}, []);
 
-    const toggleTheme = () => {
-        const nextTheme = theme === 'dark' ? 'light' : 'dark';
-        applyTheme(nextTheme);
-        setTheme(nextTheme);
-    };
+	const toggleTheme = () => {
+		const nextTheme = theme === "dark" ? "light" : "dark";
+		applyTheme(nextTheme);
+		setTheme(nextTheme);
+	};
 
-    const detailsContent = (
-        <>
-            <p className="mb-1 text-xs font-bold uppercase text-primary">
-                {isSeller ? 'Ubicacion del vendedor' : 'Pedido del comprador'}
-            </p>
-            <h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
-                {order?.customerName ?? 'Cliente no registrado'}
-            </h1>
+	const detailsContent = (
+		<>
+			<p className="mb-1 text-xs font-bold uppercase text-primary">
+				{isSeller ? "Ubicacion del vendedor" : "Pedido del comprador"}
+			</p>
+			<h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
+				{order?.customerName ?? "Cliente no registrado"}
+			</h1>
 
-            <div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
-                <p className="flex items-start gap-3">
-                    <MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
-                    <span>
-                        <span className="block font-bold">
-                            {order?.address ?? 'Direccion no registrada'}
-                        </span>
-                        {order?.reference && (
-                            <span className="mt-1 block text-xs opacity-70">
-                                {order.reference}
-                            </span>
-                        )}
-                    </span>
-                </p>
+			<div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
+				<p className="flex items-start gap-3">
+					<MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
+					<span>
+						<span className="block font-bold">
+							{order?.address ?? "Direccion no registrada"}
+						</span>
+						{order?.reference && (
+							<span className="mt-1 block text-xs opacity-70">
+								{order.reference}
+							</span>
+						)}
+					</span>
+				</p>
 
-                <p className="flex items-center gap-3">
-                    <Phone className="shrink-0 text-primary" size={18} />
-                    <span className="font-bold">{order?.phone ?? 'Sin telefono'}</span>
-                </p>
+				<p className="flex items-center gap-3">
+					<Phone className="shrink-0 text-primary" size={18} />
+					<span className="font-bold">{order?.phone ?? "Sin telefono"}</span>
+				</p>
 
-                {!isSeller && (
-                    <>
-                        <div className="flex items-start gap-3">
-                            <Package className="mt-0.5 shrink-0 text-primary" size={18} />
-                            <div className="min-w-0 space-y-2">
-                                {(order?.items?.length ?? 0) > 0 ? (
-                                    order?.items.map((item) => (
-                                        <p key={`${item.name}-${item.quantity}`}>
-                                            {item.quantity}x {item.name}
-                                        </p>
-                                    ))
-                                ) : (
-                                    <p>Productos no registrados</p>
-                                )}
-                            </div>
-                        </div>
+				{!isSeller && (
+					<>
+						<div className="flex items-start gap-3">
+							<Package className="mt-0.5 shrink-0 text-primary" size={18} />
+							<div className="min-w-0 space-y-2">
+								{(order?.items?.length ?? 0) > 0 ? (
+									order?.items.map((item) => (
+										<p key={`${item.name}-${item.quantity}`}>
+											{item.quantity}x {item.name}
+										</p>
+									))
+								) : (
+									<p>Productos no registrados</p>
+								)}
+							</div>
+						</div>
 
-                        <div className="rounded-2xl border border-primary/50 bg-primary/10 p-4">
-                            <p className="flex items-center gap-2 text-xs font-bold uppercase text-primary">
-                                <Banknote size={16} />
-                                Cobro
-                            </p>
-                            <p className="mt-2 text-3xl font-black">
-                                {formatBolivianos(order?.cashToCollect ?? 0)}
-                            </p>
-                        </div>
-                    </>
-                )}
-            </div>
-        </>
-    );
+						<div className="rounded-2xl border border-primary/50 bg-primary/10 p-4">
+							<p className="flex items-center gap-2 text-xs font-bold uppercase text-primary">
+								<Banknote size={16} />
+								Cobro
+							</p>
+							<p className="mt-2 text-3xl font-black">
+								{formatBolivianos(order?.cashToCollect ?? 0)}
+							</p>
+						</div>
+					</>
+				)}
+			</div>
+		</>
+	);
 
-    return (
-        <main className="relative h-dvh overflow-hidden bg-bg-light text-text-light">
-            <MapContainer
-                center={position}
-                zoom={17}
-                className="h-full w-full"
-                zoomControl={false}
-            >
-                <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-                <ZoomControl position="bottomleft" />
+	return (
+		<main className="relative h-dvh overflow-hidden bg-bg-light text-text-light">
+			<MapContainer
+				center={position}
+				zoom={17}
+				className="h-full w-full"
+				zoomControl={false}
+			>
+				<TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+				<ZoomControl position="bottomleft" />
 
-                {ALLOWED_ZONES.map((zone, index) => (
-                    <Polygon
-                        key={zone.name}
-                        positions={zone.points}
-                        pathOptions={{
-                            color: index === 0 ? '#88b04b' : '#3b82f6',
-                            fillColor: index === 0 ? '#88b04b' : '#3b82f6',
-                            fillOpacity: 0.16,
-                            weight: 2,
-                        }}
-                    />
-                ))}
+				{ALLOWED_ZONES.map((zone, index) => (
+					<Polygon
+						key={zone.name}
+						positions={zone.points}
+						pathOptions={{
+							color: index === 0 ? "#88b04b" : "#3b82f6",
+							fillColor: index === 0 ? "#88b04b" : "#3b82f6",
+							fillOpacity: 0.16,
+							weight: 2,
+						}}
+					/>
+				))}
 
-                <Marker position={position} />
-            </MapContainer>
+				<Marker position={position} />
+			</MapContainer>
 
-            <a
-                href="/courier"
-                className="absolute left-4 top-4 z-[500] inline-flex h-11 w-11 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-text-light shadow-lg transition hover:border-primary hover:text-primary"
-                aria-label="Volver a entregas"
-            >
-                <ArrowLeft size={20} />
-            </a>
+			<a
+				href="/courier"
+				className="absolute left-4 top-4 z-[500] inline-flex h-11 w-11 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-text-light shadow-lg transition hover:border-primary hover:text-primary"
+				aria-label="Volver a entregas"
+			>
+				<ArrowLeft size={20} />
+			</a>
 
-            <button
-                aria-label="Cambiar tema"
-                className="absolute right-4 top-16 z-[500] inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary/40 bg-card-bg-light text-primary shadow-lg transition hover:border-primary md:top-4"
-                onClick={toggleTheme}
-                type="button"
-            >
-                {theme === 'dark' ? <Moon size={18} /> : <Sun size={18} />}
-            </button>
+			<button
+				aria-label="Cambiar tema"
+				className="absolute right-4 top-16 z-[500] inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary/40 bg-card-bg-light text-primary shadow-lg transition hover:border-primary md:top-4"
+				onClick={toggleTheme}
+				type="button"
+			>
+				{theme === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+			</button>
 
-            <button
-                className="absolute right-4 top-4 z-[500] inline-flex h-11 items-center justify-center gap-2 rounded-full border border-border-light bg-card-bg-light px-4 text-sm font-bold text-text-light shadow-lg transition hover:border-primary hover:text-primary md:hidden"
-                onClick={() => setIsDetailsOpen(true)}
-                type="button"
-            >
-                <Info size={18} />
-                Detalles
-            </button>
+			<button
+				className="absolute right-4 top-4 z-[500] inline-flex h-11 items-center justify-center gap-2 rounded-full border border-border-light bg-card-bg-light px-4 text-sm font-bold text-text-light shadow-lg transition hover:border-primary hover:text-primary md:hidden"
+				onClick={() => setIsDetailsOpen(true)}
+				type="button"
+			>
+				<Info size={18} />
+				Detalles
+			</button>
 
-            {isDetailsOpen && (
-                <div
-                    className="absolute inset-0 z-[650] bg-black/20 backdrop-blur-[1px] md:hidden"
-                    onClick={() => setIsDetailsOpen(false)}
-                >
-                    <aside
-                        className="absolute inset-x-3 top-16 max-h-[calc(100dvh-5rem)] overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-4 text-text-light shadow-2xl backdrop-blur"
-                        onClick={(event) => event.stopPropagation()}
-                    >
-                        <button
-                            aria-label="Cerrar detalles"
-                            className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-                            onClick={() => setIsDetailsOpen(false)}
-                            type="button"
-                        >
-                            <X size={16} />
-                        </button>
+			{isDetailsOpen && (
+				<>
+					<button
+						type="button"
+						aria-label="Cerrar detalles"
+						className="absolute inset-0 z-[650] bg-black/20 backdrop-blur-[1px] md:hidden"
+						onClick={() => setIsDetailsOpen(false)}
+					/>
+					<aside className="absolute inset-x-3 top-16 max-h-[calc(100dvh-5rem)] overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-4 text-text-light shadow-2xl backdrop-blur">
+						<button
+							aria-label="Cerrar detalles"
+							className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+							onClick={() => setIsDetailsOpen(false)}
+							type="button"
+						>
+							<X size={16} />
+						</button>
 
-                        <div className="pr-8">{detailsContent}</div>
-                    </aside>
-                </div>
-            )}
+						<div className="pr-8">{detailsContent}</div>
+					</aside>
+				</>
+			)}
 
-            <aside className="absolute bottom-auto left-auto right-6 top-1/2 z-[500] hidden max-h-[calc(100dvh-2rem)] w-[360px] max-w-[calc(100vw-3rem)] -translate-y-1/2 overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-5 text-text-light shadow-2xl backdrop-blur md:block">
-                <p className="mb-1 text-xs font-bold uppercase text-primary">
-                    {isSeller ? 'Ubicación del vendedor' : 'Pedido del comprador'}
-                </p>
-                <h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
-                    {order?.customerName ?? 'Cliente no registrado'}
-                </h1>
+			<aside className="absolute bottom-auto left-auto right-6 top-1/2 z-[500] hidden max-h-[calc(100dvh-2rem)] w-[360px] max-w-[calc(100vw-3rem)] -translate-y-1/2 overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-5 text-text-light shadow-2xl backdrop-blur md:block">
+				<p className="mb-1 text-xs font-bold uppercase text-primary">
+					{isSeller ? "Ubicación del vendedor" : "Pedido del comprador"}
+				</p>
+				<h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
+					{order?.customerName ?? "Cliente no registrado"}
+				</h1>
 
-                <div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
-                    <p className="flex items-start gap-3">
-                        <MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
-                        <span>
-                            <span className="block font-bold">
-                                {order?.address ?? 'Direccion no registrada'}
-                            </span>
-                            {order?.reference && (
-                                <span className="mt-1 block text-xs opacity-70">
-                                    {order.reference}
-                                </span>
-                            )}
-                        </span>
-                    </p>
+				<div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
+					<p className="flex items-start gap-3">
+						<MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
+						<span>
+							<span className="block font-bold">
+								{order?.address ?? "Direccion no registrada"}
+							</span>
+							{order?.reference && (
+								<span className="mt-1 block text-xs opacity-70">
+									{order.reference}
+								</span>
+							)}
+						</span>
+					</p>
 
-                    <p className="flex items-center gap-3">
-                        <Phone className="shrink-0 text-primary" size={18} />
-                        <span className="font-bold">{order?.phone ?? 'Sin telefono'}</span>
-                    </p>
+					<p className="flex items-center gap-3">
+						<Phone className="shrink-0 text-primary" size={18} />
+						<span className="font-bold">{order?.phone ?? "Sin telefono"}</span>
+					</p>
 
-                    {!isSeller && (
-                        <>
-                            <div className="flex items-start gap-3">
-                                <Package className="mt-0.5 shrink-0 text-primary" size={18} />
-                                <div className="min-w-0 space-y-2">
-                                    {(order?.items?.length ?? 0) > 0 ? (
-                                        order?.items.map((item) => (
-                                            <p key={`${item.name}-${item.quantity}`}>
-                                                {item.quantity}x {item.name}
-                                            </p>
-                                        ))
-                                    ) : (
-                                        <p>Productos no registrados</p>
-                                    )}
-                                </div>
-                            </div>
+					{!isSeller && (
+						<>
+							<div className="flex items-start gap-3">
+								<Package className="mt-0.5 shrink-0 text-primary" size={18} />
+								<div className="min-w-0 space-y-2">
+									{(order?.items?.length ?? 0) > 0 ? (
+										order?.items.map((item) => (
+											<p key={`${item.name}-${item.quantity}`}>
+												{item.quantity}x {item.name}
+											</p>
+										))
+									) : (
+										<p>Productos no registrados</p>
+									)}
+								</div>
+							</div>
 
-                            <div className="rounded-2xl border border-primary/50 bg-primary/10 p-4">
-                                <p className="flex items-center gap-2 text-xs font-bold uppercase text-primary">
-                                    <Banknote size={16} />
-                                    Cobro
-                                </p>
-                                <p className="mt-2 text-3xl font-black">
-                                    {formatBolivianos(order?.cashToCollect ?? 0)}
-                                </p>
-                            </div>
-                        </>
-                    )}
-                </div>
-            </aside>
-        </main>
-    );
+							<div className="rounded-2xl border border-primary/50 bg-primary/10 p-4">
+								<p className="flex items-center gap-2 text-xs font-bold uppercase text-primary">
+									<Banknote size={16} />
+									Cobro
+								</p>
+								<p className="mt-2 text-3xl font-black">
+									{formatBolivianos(order?.cashToCollect ?? 0)}
+								</p>
+							</div>
+						</>
+					)}
+				</div>
+			</aside>
+		</main>
+	);
 }

--- a/src/features/mensajero/components/CourierBuyerMap.tsx
+++ b/src/features/mensajero/components/CourierBuyerMap.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Banknote, MapPin, Package, Phone } from 'lucide-react';
+import { ArrowLeft, Banknote, Info, MapPin, Moon, Package, Phone, Sun, X } from 'lucide-react';
 import L from 'leaflet';
 import { useEffect, useMemo, useState } from 'react';
 import { collection, doc, getDoc, getDocs } from 'firebase/firestore';
@@ -34,6 +34,20 @@ type BuyerMapOrder = {
 };
 
 const FALLBACK_POSITION: [number, number] = [-17.394, -66.1473];
+const THEME_STORAGE_KEY = 'sansistore-theme';
+
+type ThemeMode = 'light' | 'dark';
+
+const applyTheme = (theme: ThemeMode) => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+
+    try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+        // Keep visual theme even if local storage is unavailable.
+    }
+};
 
 function readOrderFromStorage(): BuyerMapOrder | null {
     if (typeof window === 'undefined') return null;
@@ -102,6 +116,8 @@ async function readOrderFromFirestore(orderId: string): Promise<BuyerMapOrder | 
 
 export default function CourierBuyerMap() {
     const [order, setOrder] = useState<BuyerMapOrder | null>(() => readInitialOrder());
+    const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+    const [theme, setTheme] = useState<ThemeMode>('light');
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
@@ -125,6 +141,16 @@ export default function CourierBuyerMap() {
         };
     }, []);
 
+    useEffect(() => {
+        const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
+        const currentTheme =
+            savedTheme ||
+            (document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light');
+
+        applyTheme(currentTheme);
+        setTheme(currentTheme);
+    }, []);
+
     const position = useMemo<[number, number]>(() => {
         const params = new URLSearchParams(window.location.search);
         const lat = Number(params.get('lat'));
@@ -139,8 +165,75 @@ export default function CourierBuyerMap() {
         return new URLSearchParams(window.location.search).get('mode') === 'seller';
     }, []);
 
+    const toggleTheme = () => {
+        const nextTheme = theme === 'dark' ? 'light' : 'dark';
+        applyTheme(nextTheme);
+        setTheme(nextTheme);
+    };
+
+    const detailsContent = (
+        <>
+            <p className="mb-1 text-xs font-bold uppercase text-primary">
+                {isSeller ? 'Ubicacion del vendedor' : 'Pedido del comprador'}
+            </p>
+            <h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
+                {order?.customerName ?? 'Cliente no registrado'}
+            </h1>
+
+            <div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
+                <p className="flex items-start gap-3">
+                    <MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
+                    <span>
+                        <span className="block font-bold">
+                            {order?.address ?? 'Direccion no registrada'}
+                        </span>
+                        {order?.reference && (
+                            <span className="mt-1 block text-xs opacity-70">
+                                {order.reference}
+                            </span>
+                        )}
+                    </span>
+                </p>
+
+                <p className="flex items-center gap-3">
+                    <Phone className="shrink-0 text-primary" size={18} />
+                    <span className="font-bold">{order?.phone ?? 'Sin telefono'}</span>
+                </p>
+
+                {!isSeller && (
+                    <>
+                        <div className="flex items-start gap-3">
+                            <Package className="mt-0.5 shrink-0 text-primary" size={18} />
+                            <div className="min-w-0 space-y-2">
+                                {(order?.items?.length ?? 0) > 0 ? (
+                                    order?.items.map((item) => (
+                                        <p key={`${item.name}-${item.quantity}`}>
+                                            {item.quantity}x {item.name}
+                                        </p>
+                                    ))
+                                ) : (
+                                    <p>Productos no registrados</p>
+                                )}
+                            </div>
+                        </div>
+
+                        <div className="rounded-2xl border border-primary/50 bg-primary/10 p-4">
+                            <p className="flex items-center gap-2 text-xs font-bold uppercase text-primary">
+                                <Banknote size={16} />
+                                Cobro
+                            </p>
+                            <p className="mt-2 text-3xl font-black">
+                                {formatBolivianos(order?.cashToCollect ?? 0)}
+                            </p>
+                        </div>
+                    </>
+                )}
+            </div>
+        </>
+    );
+
     return (
-        <main className="relative h-screen overflow-hidden bg-bg-light text-text-light">
+        <main className="relative h-dvh overflow-hidden bg-bg-light text-text-light">
             <MapContainer
                 center={position}
                 zoom={17}
@@ -174,15 +267,56 @@ export default function CourierBuyerMap() {
                 <ArrowLeft size={20} />
             </a>
 
-            <aside className="absolute inset-x-4 bottom-4 z-[500] rounded-[28px] border border-border-light bg-card-bg-light/95 p-5 text-text-light shadow-2xl backdrop-blur md:bottom-auto md:left-auto md:right-6 md:top-1/2 md:w-[360px] md:-translate-y-1/2">
+            <button
+                aria-label="Cambiar tema"
+                className="absolute right-4 top-16 z-[500] inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary/40 bg-card-bg-light text-primary shadow-lg transition hover:border-primary md:top-4"
+                onClick={toggleTheme}
+                type="button"
+            >
+                {theme === 'dark' ? <Moon size={18} /> : <Sun size={18} />}
+            </button>
+
+            <button
+                className="absolute right-4 top-4 z-[500] inline-flex h-11 items-center justify-center gap-2 rounded-full border border-border-light bg-card-bg-light px-4 text-sm font-bold text-text-light shadow-lg transition hover:border-primary hover:text-primary md:hidden"
+                onClick={() => setIsDetailsOpen(true)}
+                type="button"
+            >
+                <Info size={18} />
+                Detalles
+            </button>
+
+            {isDetailsOpen && (
+                <div
+                    className="absolute inset-0 z-[650] bg-black/20 backdrop-blur-[1px] md:hidden"
+                    onClick={() => setIsDetailsOpen(false)}
+                >
+                    <aside
+                        className="absolute inset-x-3 top-16 max-h-[calc(100dvh-5rem)] overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-4 text-text-light shadow-2xl backdrop-blur"
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <button
+                            aria-label="Cerrar detalles"
+                            className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+                            onClick={() => setIsDetailsOpen(false)}
+                            type="button"
+                        >
+                            <X size={16} />
+                        </button>
+
+                        <div className="pr-8">{detailsContent}</div>
+                    </aside>
+                </div>
+            )}
+
+            <aside className="absolute bottom-auto left-auto right-6 top-1/2 z-[500] hidden max-h-[calc(100dvh-2rem)] w-[360px] max-w-[calc(100vw-3rem)] -translate-y-1/2 overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light/95 p-5 text-text-light shadow-2xl backdrop-blur md:block">
                 <p className="mb-1 text-xs font-bold uppercase text-primary">
                     {isSeller ? 'Ubicación del vendedor' : 'Pedido del comprador'}
                 </p>
-                <h1 className="text-2xl font-black tracking-normal">
+                <h1 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
                     {order?.customerName ?? 'Cliente no registrado'}
                 </h1>
 
-                <div className="mt-5 space-y-4 text-sm">
+                <div className="mt-4 space-y-3 text-sm sm:mt-5 sm:space-y-4">
                     <p className="flex items-start gap-3">
                         <MapPin className="mt-0.5 shrink-0 text-primary" size={18} />
                         <span>

--- a/src/features/mensajero/components/CourierDashboard.tsx
+++ b/src/features/mensajero/components/CourierDashboard.tsx
@@ -41,7 +41,7 @@ const INVALID_AMOUNT_MESSAGE =
 const getPageClass = (embedded = false) =>
   embedded
     ? 'bg-transparent py-2 text-text-light'
-    : 'min-h-screen bg-bg-light pt-24 pb-12 text-text-light';
+    : 'min-h-[100dvh] bg-bg-light pt-24 pb-12 text-text-light';
 const cardBaseClass =
   'rounded-[28px] border border-border-light bg-card-bg-light px-7 py-8 shadow-[0_14px_30px_rgba(38,33,22,0.10)]';
 const sectionCardClass =

--- a/src/features/mensajero/components/CourierDashboard.tsx
+++ b/src/features/mensajero/components/CourierDashboard.tsx
@@ -1,711 +1,745 @@
-import { useEffect, useMemo, useState } from 'react';
 import {
-  ArrowLeft,
-  BadgeCheck,
-  Box,
-  ClipboardList,
-  Eye,
-  LoaderCircle,
-  MapPin,
-  NotebookText,
-  PackageCheck,
-  ReceiptText,
-  Wallet,
-} from 'lucide-react';
+	ArrowLeft,
+	BadgeCheck,
+	Box,
+	ClipboardList,
+	Eye,
+	LoaderCircle,
+	MapPin,
+	NotebookText,
+	PackageCheck,
+	ReceiptText,
+	Wallet,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  markOrderAsDelivered,
-  registerPayment,
-  subscribeToCourierOrders,
-} from '../services/courierOrdersService';
-import type { CourierDashboardStats, CourierOrder } from '../types';
+	markOrderAsDelivered,
+	registerPayment,
+	subscribeToCourierOrders,
+} from "../services/courierOrdersService";
+import type { CourierDashboardStats, CourierOrder } from "../types";
 
-const moneyFormatter = new Intl.NumberFormat('es-BO', {
-  style: 'currency',
-  currency: 'BOB',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
+const moneyFormatter = new Intl.NumberFormat("es-BO", {
+	style: "currency",
+	currency: "BOB",
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 0,
 });
 
 const emptyStats: CourierDashboardStats = {
-  pendingCount: 0,
-  deliveredTodayCount: 0,
-  pendingCashTotal: 0,
+	pendingCount: 0,
+	deliveredTodayCount: 0,
+	pendingCashTotal: 0,
 };
 
 const formatMoney = (value: number) =>
-  moneyFormatter.format(value).replace('BOB', 'Bs').trim();
+	moneyFormatter.format(value).replace("BOB", "Bs").trim();
 
 const INVALID_AMOUNT_MESSAGE =
-  'No se puede mostrar el monto a cobrar. Verifique el detalle del pedido.';
+	"No se puede mostrar el monto a cobrar. Verifique el detalle del pedido.";
 
 const getPageClass = (embedded = false) =>
-  embedded
-    ? 'bg-transparent py-2 text-text-light'
-    : 'min-h-[100dvh] bg-bg-light pt-24 pb-12 text-text-light';
+	embedded
+		? "bg-transparent py-2 text-text-light"
+		: "min-h-[100dvh] bg-bg-light pt-24 pb-12 text-text-light";
 const cardBaseClass =
-  'rounded-[28px] border border-border-light bg-card-bg-light px-7 py-8 shadow-[0_14px_30px_rgba(38,33,22,0.10)]';
+	"rounded-[28px] border border-border-light bg-card-bg-light px-7 py-8 shadow-[0_14px_30px_rgba(38,33,22,0.10)]";
 const sectionCardClass =
-  'rounded-[28px] border border-border-light bg-card-bg-light px-5 py-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:px-7';
+	"rounded-[28px] border border-border-light bg-card-bg-light px-5 py-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:px-7";
 const badgeClass =
-  'inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold';
-const mutedTextClass = 'text-text-light opacity-60';
-const iconClass = 'text-text-light opacity-55';
+	"inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold";
+const mutedTextClass = "text-text-light opacity-60";
+const iconClass = "text-text-light opacity-55";
 const ghostButtonClass =
-  'rounded-2xl border border-border-light bg-card-bg-light px-5 py-3 text-sm font-bold text-text-light transition hover:border-primary hover:text-primary';
+	"rounded-2xl border border-border-light bg-card-bg-light px-5 py-3 text-sm font-bold text-text-light transition hover:border-primary hover:text-primary";
 const primaryButtonClass =
-  'inline-flex items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 text-sm font-bold text-bg-dark transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60';
+	"inline-flex items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 text-sm font-bold text-bg-dark transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60";
 
 function OrderDetailView({
-  selectedOrder,
-  selectedItemsCount,
-  selectedOrderHasValidAmount,
-  updatingOrderId,
-  updatingPaymentId,
-  pageClassName,
-  onBack,
-  onOpenMaps,
-  onMarkDelivered,
-  onRegisterPayment,
+	selectedOrder,
+	selectedItemsCount,
+	selectedOrderHasValidAmount,
+	updatingOrderId,
+	updatingPaymentId,
+	pageClassName,
+	onBack,
+	onOpenMaps,
+	onMarkDelivered,
+	onRegisterPayment,
 }: {
-  selectedOrder: CourierOrder;
-  selectedItemsCount: number;
-  selectedOrderHasValidAmount: boolean;
-  updatingOrderId: string;
-  updatingPaymentId: string;
-  pageClassName: string;
-  onBack: () => void;
-  onOpenMaps: (order: CourierOrder) => void;
-  onMarkDelivered: (order: CourierOrder) => Promise<void>;
-  onRegisterPayment: (order: CourierOrder) => Promise<void>;
+	selectedOrder: CourierOrder;
+	selectedItemsCount: number;
+	selectedOrderHasValidAmount: boolean;
+	updatingOrderId: string;
+	updatingPaymentId: string;
+	pageClassName: string;
+	onBack: () => void;
+	onOpenMaps: (order: CourierOrder) => void;
+	onMarkDelivered: (order: CourierOrder) => Promise<void>;
+	onRegisterPayment: (order: CourierOrder) => Promise<void>;
 }) {
-  return (
-    <section className={pageClassName}>
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <button
-          type="button"
-          onClick={onBack}
-          className="mb-6 inline-flex items-center gap-2 text-sm font-bold text-text-light opacity-75 transition hover:text-primary hover:opacity-100"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Volver a pedidos
-        </button>
+	return (
+		<section className={pageClassName}>
+			<div className="mx-auto max-w-6xl px-4 sm:px-6">
+				<button
+					type="button"
+					onClick={onBack}
+					className="mb-6 inline-flex items-center gap-2 text-sm font-bold text-text-light opacity-75 transition hover:text-primary hover:opacity-100"
+				>
+					<ArrowLeft className="h-4 w-4" />
+					Volver a pedidos
+				</button>
 
-        <div className="mb-8">
-          <h1 className="text-4xl font-black tracking-[-0.04em]">
-            Detalle de cobro del pedido
-          </h1>
-          <p className={`mt-2 text-sm font-semibold ${mutedTextClass}`}>
-            Verifica el pedido antes de marcarlo como entregado.
-          </p>
-        </div>
+				<div className="mb-8">
+					<h1 className="text-4xl font-black tracking-[-0.04em]">
+						Detalle de cobro del pedido
+					</h1>
+					<p className={`mt-2 text-sm font-semibold ${mutedTextClass}`}>
+						Verifica el pedido antes de marcarlo como entregado.
+					</p>
+				</div>
 
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_370px]">
-          <div className="space-y-4">
-            <div className={sectionCardClass}>
-              <div className="flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-black tracking-[-0.04em]">
-                  {selectedOrder.displayId}
-                </h2>
-                <span className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}>
-                  Cobrar
-                </span>
-                <span className={`${badgeClass} bg-primary/10 py-1 text-primary`}>
-                  {selectedOrder.paymentStatusLabel}
-                </span>
-              </div>
+				<div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_370px]">
+					<div className="space-y-4">
+						<div className={sectionCardClass}>
+							<div className="flex flex-wrap items-center gap-3">
+								<h2 className="text-2xl font-black tracking-[-0.04em]">
+									{selectedOrder.displayId}
+								</h2>
+								<span
+									className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}
+								>
+									Cobrar
+								</span>
+								<span
+									className={`${badgeClass} bg-primary/10 py-1 text-primary`}
+								>
+									{selectedOrder.paymentStatusLabel}
+								</span>
+							</div>
 
-              <div className="mt-6">
-                <p className={`text-sm font-medium ${mutedTextClass}`}>Cliente</p>
-                <p className="mt-1 text-3xl font-medium tracking-[-0.03em]">
-                  {selectedOrder.buyerName}
-                </p>
-              </div>
+							<div className="mt-6">
+								<p className={`text-sm font-medium ${mutedTextClass}`}>
+									Cliente
+								</p>
+								<p className="mt-1 text-3xl font-medium tracking-[-0.03em]">
+									{selectedOrder.buyerName}
+								</p>
+							</div>
 
-              {!selectedOrderHasValidAmount ? (
-                <div className="mt-5 rounded-2xl border border-(--theme-warning-border) bg-(--theme-warning-bg) px-4 py-3 text-sm font-semibold text-(--theme-warning)">
-                  {INVALID_AMOUNT_MESSAGE}
-                </div>
-              ) : null}
-            </div>
+							{!selectedOrderHasValidAmount ? (
+								<div className="mt-5 rounded-2xl border border-(--theme-warning-border) bg-(--theme-warning-bg) px-4 py-3 text-sm font-semibold text-(--theme-warning)">
+									{INVALID_AMOUNT_MESSAGE}
+								</div>
+							) : null}
+						</div>
 
-            <div className={sectionCardClass}>
-              <h3 className="text-lg font-black">Productos</h3>
-              <div className="mt-4 rounded-2xl border border-primary/30 bg-primary/10 px-5 py-3">
-                {selectedOrder.items.length === 0 ? (
-                  <p className={`py-4 text-sm font-semibold ${mutedTextClass}`}>
-                    Este pedido no tiene items visibles en el documento.
-                  </p>
-                ) : (
-                  selectedOrder.items.map((item, index) => (
-                    <div
-                      key={`${selectedOrder.id}-${item.productId}`}
-                      className={index === 0 ? '' : 'border-t border-primary/20 pt-4'}
-                    >
-                      <p className="text-lg font-medium">{item.name}</p>
-                      <p className="mt-1 text-sm font-medium text-text-light opacity-70">
-                        Cantidad: {item.quantity} | Precio: {formatMoney(item.subtotal)}
-                      </p>
-                      {index < selectedOrder.items.length - 1 ? (
-                        <div className="mt-4 border-b border-primary/20" />
-                      ) : null}
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
+						<div className={sectionCardClass}>
+							<h3 className="text-lg font-black">Productos</h3>
+							<div className="mt-4 rounded-2xl border border-primary/30 bg-primary/10 px-5 py-3">
+								{selectedOrder.items.length === 0 ? (
+									<p className={`py-4 text-sm font-semibold ${mutedTextClass}`}>
+										Este pedido no tiene items visibles en el documento.
+									</p>
+								) : (
+									selectedOrder.items.map((item, index) => (
+										<div
+											key={`${selectedOrder.id}-${item.productId}`}
+											className={
+												index === 0 ? "" : "border-t border-primary/20 pt-4"
+											}
+										>
+											<p className="text-lg font-medium">{item.name}</p>
+											<p className="mt-1 text-sm font-medium text-text-light opacity-70">
+												Cantidad: {item.quantity} | Precio:{" "}
+												{formatMoney(item.subtotal)}
+											</p>
+											{index < selectedOrder.items.length - 1 ? (
+												<div className="mt-4 border-b border-primary/20" />
+											) : null}
+										</div>
+									))
+								)}
+							</div>
+						</div>
 
-            <div className="grid gap-4 rounded-[28px] border border-border-light bg-card-bg-light px-5 py-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:grid-cols-3 sm:px-7">
-              <div className="flex items-start gap-3">
-                <Wallet className={`mt-1 h-5 w-5 ${iconClass}`} />
-                <div>
-                  <p className={`text-sm font-medium ${mutedTextClass}`}>
-                    Metodo de pago
-                  </p>
-                  <p className="text-lg font-medium">{selectedOrder.paymentMethod}</p>
-                </div>
-              </div>
+						<div className="grid gap-4 rounded-[28px] border border-border-light bg-card-bg-light px-5 py-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:grid-cols-3 sm:px-7">
+							<div className="flex items-start gap-3">
+								<Wallet className={`mt-1 h-5 w-5 ${iconClass}`} />
+								<div>
+									<p className={`text-sm font-medium ${mutedTextClass}`}>
+										Metodo de pago
+									</p>
+									<p className="text-lg font-medium">
+										{selectedOrder.paymentMethod}
+									</p>
+								</div>
+							</div>
 
-              <div className="flex items-start gap-3">
-                <MapPin className={`mt-1 h-5 w-5 ${iconClass}`} />
-                <div>
-                  <p className={`text-sm font-medium ${mutedTextClass}`}>
-                    Metodo de envio
-                  </p>
-                  <p className="text-lg font-medium">{selectedOrder.deliveryMethod}</p>
-                </div>
-              </div>
+							<div className="flex items-start gap-3">
+								<MapPin className={`mt-1 h-5 w-5 ${iconClass}`} />
+								<div>
+									<p className={`text-sm font-medium ${mutedTextClass}`}>
+										Metodo de envio
+									</p>
+									<p className="text-lg font-medium">
+										{selectedOrder.deliveryMethod}
+									</p>
+								</div>
+							</div>
 
-              <div className="flex items-start gap-3">
-                <ClipboardList className={`mt-1 h-5 w-5 ${iconClass}`} />
-                <div>
-                  <p className={`text-sm font-medium ${mutedTextClass}`}>
-                    Condiciones especiales
-                  </p>
-                  <p className="text-lg font-medium">
-                    {selectedOrder.specialInstructions}
-                  </p>
-                </div>
-              </div>
-            </div>
+							<div className="flex items-start gap-3">
+								<ClipboardList className={`mt-1 h-5 w-5 ${iconClass}`} />
+								<div>
+									<p className={`text-sm font-medium ${mutedTextClass}`}>
+										Condiciones especiales
+									</p>
+									<p className="text-lg font-medium">
+										{selectedOrder.specialInstructions}
+									</p>
+								</div>
+							</div>
+						</div>
 
-            <div className="flex flex-wrap gap-3">
-              <button type="button" className={ghostButtonClass}>
-                Solicitar producto
-              </button>
-              <button
-                type="button"
-                onClick={() => onOpenMaps(selectedOrder)}
-                className={`inline-flex items-center gap-2 ${ghostButtonClass}`}
-              >
-                <MapPin className="h-4 w-4" />
-                Abrir en Maps
-              </button>
-            </div>
+						<div className="flex flex-wrap gap-3">
+							<button type="button" className={ghostButtonClass}>
+								Solicitar producto
+							</button>
+							<button
+								type="button"
+								onClick={() => onOpenMaps(selectedOrder)}
+								className={`inline-flex items-center gap-2 ${ghostButtonClass}`}
+							>
+								<MapPin className="h-4 w-4" />
+								Abrir en Maps
+							</button>
+						</div>
 
-            <div className={sectionCardClass}>
-              <h3 className="text-2xl font-black tracking-[-0.04em]">
-                Resumen del cobro
-              </h3>
-              <div className="mt-6 grid gap-6 sm:grid-cols-2">
-                <div className="flex items-start gap-3">
-                  <ReceiptText className={`mt-1 h-5 w-5 ${iconClass}`} />
-                  <div>
-                    <p className="text-xl font-medium">
-                      {selectedOrderHasValidAmount
-                        ? formatMoney(selectedOrder.total)
-                        : INVALID_AMOUNT_MESSAGE}
-                    </p>
-                    <p className={`text-sm font-medium ${mutedTextClass}`}>
-                      Recibimiento
-                    </p>
-                  </div>
-                </div>
+						<div className={sectionCardClass}>
+							<h3 className="text-2xl font-black tracking-[-0.04em]">
+								Resumen del cobro
+							</h3>
+							<div className="mt-6 grid gap-6 sm:grid-cols-2">
+								<div className="flex items-start gap-3">
+									<ReceiptText className={`mt-1 h-5 w-5 ${iconClass}`} />
+									<div>
+										<p className="text-xl font-medium">
+											{selectedOrderHasValidAmount
+												? formatMoney(selectedOrder.total)
+												: INVALID_AMOUNT_MESSAGE}
+										</p>
+										<p className={`text-sm font-medium ${mutedTextClass}`}>
+											Recibimiento
+										</p>
+									</div>
+								</div>
 
-                <div className="flex items-start gap-3">
-                  <NotebookText className={`mt-1 h-5 w-5 ${iconClass}`} />
-                  <div>
-                    <p className="text-xl font-medium">Sin observaciones</p>
-                    <p className={`text-sm font-medium ${mutedTextClass}`}>
-                      Observaciones
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+								<div className="flex items-start gap-3">
+									<NotebookText className={`mt-1 h-5 w-5 ${iconClass}`} />
+									<div>
+										<p className="text-xl font-medium">Sin observaciones</p>
+										<p className={`text-sm font-medium ${mutedTextClass}`}>
+											Observaciones
+										</p>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
 
-          <aside className="self-start rounded-[28px] border border-border-light bg-card-bg-light p-5 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:p-6">
-            <div className="rounded-3xl border border-primary/25 bg-primary/10 p-5">
-              <p className="text-sm font-medium text-text-light opacity-70">
-                Te llevas a cobrar
-              </p>
-              <p className="mt-1 text-3xl font-medium tracking-[-0.03em]">
-                {selectedOrderHasValidAmount
-                  ? formatMoney(selectedOrder.total)
-                  : 'Monto no disponible'}
-              </p>
-              <p className="mt-2 text-sm font-medium text-text-light opacity-70">
-                {selectedItemsCount} items en este pedido
-              </p>
+					<aside className="self-start rounded-[28px] border border-border-light bg-card-bg-light p-5 shadow-[0_14px_30px_rgba(38,33,22,0.10)] sm:p-6">
+						<div className="rounded-3xl border border-primary/25 bg-primary/10 p-5">
+							<p className="text-sm font-medium text-text-light opacity-70">
+								Te llevas a cobrar
+							</p>
+							<p className="mt-1 text-3xl font-medium tracking-[-0.03em]">
+								{selectedOrderHasValidAmount
+									? formatMoney(selectedOrder.total)
+									: "Monto no disponible"}
+							</p>
+							<p className="mt-2 text-sm font-medium text-text-light opacity-70">
+								{selectedItemsCount} items en este pedido
+							</p>
 
-              <div className="my-5 border-t border-primary/20" />
+							<div className="my-5 border-t border-primary/20" />
 
-              <p className="text-sm font-medium text-text-light opacity-70">
-                Monto a cobrar
-              </p>
-              {selectedOrderHasValidAmount ? (
-                <p className="mt-2 text-5xl font-medium tracking-[-0.05em] text-primary">
-                  {formatMoney(selectedOrder.total)}
-                </p>
-              ) : (
-                <p className="mt-2 text-base font-semibold leading-6 text-(--theme-warning)">
-                  {INVALID_AMOUNT_MESSAGE}
-                </p>
-              )}
+							<p className="text-sm font-medium text-text-light opacity-70">
+								Monto a cobrar
+							</p>
+							{selectedOrderHasValidAmount ? (
+								<p className="mt-2 text-5xl font-medium tracking-[-0.05em] text-primary">
+									{formatMoney(selectedOrder.total)}
+								</p>
+							) : (
+								<p className="mt-2 text-base font-semibold leading-6 text-(--theme-warning)">
+									{INVALID_AMOUNT_MESSAGE}
+								</p>
+							)}
 
-              <div className="mt-6 space-y-3 text-base">
-                <div className="flex items-center justify-between gap-4">
-                  <span className="font-medium text-text-light opacity-80">
-                    Subtotal
-                  </span>
-                  <span className="font-medium">
-                    {formatMoney(selectedOrder.productsTotal)}
-                  </span>
-                </div>
+							<div className="mt-6 space-y-3 text-base">
+								<div className="flex items-center justify-between gap-4">
+									<span className="font-medium text-text-light opacity-80">
+										Subtotal
+									</span>
+									<span className="font-medium">
+										{formatMoney(selectedOrder.productsTotal)}
+									</span>
+								</div>
 
-                <div className="flex items-center justify-between gap-4">
-                  <span className="font-medium text-text-light opacity-80">
-                    Costo de entrega
-                  </span>
-                  <span className="font-medium">
-                    {formatMoney(selectedOrder.additionalCharges)}
-                  </span>
-                </div>
+								<div className="flex items-center justify-between gap-4">
+									<span className="font-medium text-text-light opacity-80">
+										Costo de entrega
+									</span>
+									<span className="font-medium">
+										{formatMoney(selectedOrder.additionalCharges)}
+									</span>
+								</div>
 
-                <div className="flex items-center justify-between gap-4">
-                  <span className="font-medium text-text-light opacity-80">
-                    Descuento
-                  </span>
-                  <span className="font-medium">Bs 0</span>
-                </div>
-              </div>
+								<div className="flex items-center justify-between gap-4">
+									<span className="font-medium text-text-light opacity-80">
+										Descuento
+									</span>
+									<span className="font-medium">Bs 0</span>
+								</div>
+							</div>
 
-              <div className="mt-4 border-t border-primary/20 pt-4">
-                <div className="flex items-center justify-between gap-4 text-lg">
-                  <span className="font-medium text-primary">Total final</span>
-                  <span className="font-medium text-primary">
-                    {selectedOrderHasValidAmount
-                      ? formatMoney(selectedOrder.total)
-                      : 'Monto no disponible'}
-                  </span>
-                </div>
-              </div>
-            </div>
+							<div className="mt-4 border-t border-primary/20 pt-4">
+								<div className="flex items-center justify-between gap-4 text-lg">
+									<span className="font-medium text-primary">Total final</span>
+									<span className="font-medium text-primary">
+										{selectedOrderHasValidAmount
+											? formatMoney(selectedOrder.total)
+											: "Monto no disponible"}
+									</span>
+								</div>
+							</div>
+						</div>
 
-            <div className="mt-4 space-y-3">
-              <button
-                type="button"
-                onClick={() => onRegisterPayment(selectedOrder)}
-                disabled={
-                  selectedOrder.paymentStatus === 'Cobrado' ||
-                  updatingPaymentId === selectedOrder.id
-                }
-                className={`w-full ${ghostButtonClass}`}
-              >
-                {updatingPaymentId === selectedOrder.id ? (
-                  <LoaderCircle className="h-4 w-4 animate-spin" />
-                ) : (
-                  'Registrar pago'
-                )}
-              </button>
-              <p className="text-xs font-semibold text-text-light opacity-55">
-                El monto a cobrar es de solo lectura en esta vista.
-              </p>
-              <button
-                type="button"
-                onClick={() => onMarkDelivered(selectedOrder)}
-                disabled={
-                  updatingOrderId === selectedOrder.id || 
-                  !selectedOrderHasValidAmount ||
-                  selectedOrder.paymentStatus !== 'Cobrado'
-                }
-                className={`w-full ${primaryButtonClass}`}
-              >
-                {updatingOrderId === selectedOrder.id ? (
-                  <LoaderCircle className="h-4 w-4 animate-spin" />
-                ) : (
-                  <BadgeCheck className="h-4 w-4" />
-                )}
-                Marcar como entregado
-              </button>
-            </div>
-          </aside>
-        </div>
-      </div>
-    </section>
-  );
+						<div className="mt-4 space-y-3">
+							<button
+								type="button"
+								onClick={() => onRegisterPayment(selectedOrder)}
+								disabled={
+									selectedOrder.paymentStatus === "Cobrado" ||
+									updatingPaymentId === selectedOrder.id
+								}
+								className={`w-full ${ghostButtonClass}`}
+							>
+								{updatingPaymentId === selectedOrder.id ? (
+									<LoaderCircle className="h-4 w-4 animate-spin" />
+								) : (
+									"Registrar pago"
+								)}
+							</button>
+							<p className="text-xs font-semibold text-text-light opacity-55">
+								El monto a cobrar es de solo lectura en esta vista.
+							</p>
+							<button
+								type="button"
+								onClick={() => onMarkDelivered(selectedOrder)}
+								disabled={
+									updatingOrderId === selectedOrder.id ||
+									!selectedOrderHasValidAmount ||
+									selectedOrder.paymentStatus !== "Cobrado"
+								}
+								className={`w-full ${primaryButtonClass}`}
+							>
+								{updatingOrderId === selectedOrder.id ? (
+									<LoaderCircle className="h-4 w-4 animate-spin" />
+								) : (
+									<BadgeCheck className="h-4 w-4" />
+								)}
+								Marcar como entregado
+							</button>
+						</div>
+					</aside>
+				</div>
+			</div>
+		</section>
+	);
 }
 
-export default function CourierDashboard({ embedded = false }: { embedded?: boolean }) {
-  const [orders, setOrders] = useState<CourierOrder[]>([]);
-  const [pendingOrders, setPendingOrders] = useState<CourierOrder[]>([]);
-  const [stats, setStats] = useState<CourierDashboardStats>(emptyStats);
-  const [selectedOrder, setSelectedOrder] = useState<CourierOrder | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [updatingOrderId, setUpdatingOrderId] = useState('');
-  const [updatingPaymentId, setUpdatingPaymentId] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [successMessage, setSuccessMessage] = useState('');
+export default function CourierDashboard({
+	embedded = false,
+}: {
+	embedded?: boolean;
+}) {
+	const [orders, setOrders] = useState<CourierOrder[]>([]);
+	const [pendingOrders, setPendingOrders] = useState<CourierOrder[]>([]);
+	const [stats, setStats] = useState<CourierDashboardStats>(emptyStats);
+	const [selectedOrder, setSelectedOrder] = useState<CourierOrder | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [updatingOrderId, setUpdatingOrderId] = useState("");
+	const [updatingPaymentId, setUpdatingPaymentId] = useState("");
+	const [errorMessage, setErrorMessage] = useState("");
+	const [successMessage, setSuccessMessage] = useState("");
 
-  useEffect(() => {
-    const unsubscribe = subscribeToCourierOrders((payload) => {
-      setOrders(payload.orders);
-      setPendingOrders(payload.pendingOrders);
-      setStats(payload.stats);
-      setLoading(false);
-    });
+	useEffect(() => {
+		const unsubscribe = subscribeToCourierOrders((payload) => {
+			setOrders(payload.orders);
+			setPendingOrders(payload.pendingOrders);
+			setStats(payload.stats);
+			setLoading(false);
+		});
 
-    return unsubscribe;
-  }, []);
+		return unsubscribe;
+	}, []);
 
-  const deliveredOrders = useMemo(
-    () => orders.filter((order) => order.status === 'Entregado'),
-    [orders]
-  );
+	const deliveredOrders = useMemo(
+		() => orders.filter((order) => order.status === "Entregado"),
+		[orders],
+	);
 
-  const handleRegisterPayment = async (order: CourierOrder) => {
-    if (order.paymentStatus === 'Cobrado') {
-      setErrorMessage('Este pedido ya fue cobrado');
-      return;
-    }
+	const handleRegisterPayment = async (order: CourierOrder) => {
+		if (order.paymentStatus === "Cobrado") {
+			setErrorMessage("Este pedido ya fue cobrado");
+			return;
+		}
 
-    const confirmed = window.confirm(
-      `Confirmar cobro de ${formatMoney(order.total)} del pedido ${order.displayId}`
-    );
+		const confirmed = window.confirm(
+			`Confirmar cobro de ${formatMoney(order.total)} del pedido ${order.displayId}`,
+		);
 
-    if (!confirmed) return;
+		if (!confirmed) return;
 
-    try {
-      setErrorMessage('');
-      setSuccessMessage('');
-      setUpdatingPaymentId(order.id);
-      await registerPayment(order);
-      setSuccessMessage('Pago registrado correctamente');
-      
-      if (selectedOrder?.id === order.id) {
-        setSelectedOrder({
-          ...selectedOrder,
-          paymentStatus: 'Cobrado',
-          paymentStatusLabel: 'Cobrado',
-        });
-      }
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'No se pudo registrar el pago');
-    } finally {
-      setUpdatingPaymentId('');
-    }
-  };
+		try {
+			setErrorMessage("");
+			setSuccessMessage("");
+			setUpdatingPaymentId(order.id);
+			await registerPayment(order);
+			setSuccessMessage("Pago registrado correctamente");
 
-  const handleMarkDelivered = async (order: CourierOrder) => {
-    const blockedStatuses = ['Entregado', 'Cancelado', 'No entregado'];
+			if (selectedOrder?.id === order.id) {
+				setSelectedOrder({
+					...selectedOrder,
+					paymentStatus: "Cobrado",
+					paymentStatusLabel: "Cobrado",
+				});
+			}
+		} catch (error) {
+			setErrorMessage(
+				error instanceof Error ? error.message : "No se pudo registrar el pago",
+			);
+		} finally {
+			setUpdatingPaymentId("");
+		}
+	};
 
-    if (blockedStatuses.includes(order.status)) {
-      setSuccessMessage('');
-      setErrorMessage('No se puede marcar como entregado un pedido con ese estado.');
-      return;
-    }
+	const handleMarkDelivered = async (order: CourierOrder) => {
+		const blockedStatuses = ["Entregado", "Cancelado", "No entregado"];
 
-    if (order.paymentStatus !== 'Cobrado') {
-      setErrorMessage('Debe registrar el pago antes de marcar como entregado.');
-      return;
-    }
+		if (blockedStatuses.includes(order.status)) {
+			setSuccessMessage("");
+			setErrorMessage(
+				"No se puede marcar como entregado un pedido con ese estado.",
+			);
+			return;
+		}
 
-    const confirmed = window.confirm(
-      `Confirmar entrega de ${order.displayId}. Monto a cobrar: ${formatMoney(order.total)}.`
-    );
+		if (order.paymentStatus !== "Cobrado") {
+			setErrorMessage("Debe registrar el pago antes de marcar como entregado.");
+			return;
+		}
 
-    if (!confirmed) return;
+		const confirmed = window.confirm(
+			`Confirmar entrega de ${order.displayId}. Monto a cobrar: ${formatMoney(order.total)}.`,
+		);
 
-    try {
-      setErrorMessage('');
-      setSuccessMessage('');
-      setUpdatingOrderId(order.id);
-      await markOrderAsDelivered(order);
-      setSuccessMessage('Pedido marcado como entregado correctamente.');
-      if (selectedOrder?.id === order.id) {
-        setSelectedOrder(null);
-      }
-    } catch {
-      setErrorMessage('No se pudo actualizar el pedido. Intente nuevamente.');
-    } finally {
-      setUpdatingOrderId('');
-    }
-  };
+		if (!confirmed) return;
 
-  const handleOpenMaps = (order: CourierOrder) => {
-    const query = encodeURIComponent(
-      `${order.deliveryZone}, Cochabamba, Bolivia`
-    );
-    window.open(
-      `https://www.google.com/maps/search/?api=1&query=${query}`,
-      '_blank',
-      'noopener,noreferrer'
-    );
-  };
+		try {
+			setErrorMessage("");
+			setSuccessMessage("");
+			setUpdatingOrderId(order.id);
+			await markOrderAsDelivered(order);
+			setSuccessMessage("Pedido marcado como entregado correctamente.");
+			if (selectedOrder?.id === order.id) {
+				setSelectedOrder(null);
+			}
+		} catch {
+			setErrorMessage("No se pudo actualizar el pedido. Intente nuevamente.");
+		} finally {
+			setUpdatingOrderId("");
+		}
+	};
 
-  const selectedItemsCount = selectedOrder
-    ? selectedOrder.items.reduce((count, item) => count + item.quantity, 0)
-    : 0;
+	const handleOpenMaps = (order: CourierOrder) => {
+		const query = encodeURIComponent(
+			`${order.deliveryZone}, Cochabamba, Bolivia`,
+		);
+		window.open(
+			`https://www.google.com/maps/search/?api=1&query=${query}`,
+			"_blank",
+			"noopener,noreferrer",
+		);
+	};
 
-  const selectedOrderExpectedTotal = selectedOrder
-    ? Number(
-        (selectedOrder.productsTotal + selectedOrder.additionalCharges).toFixed(2)
-      )
-    : 0;
+	const selectedItemsCount = selectedOrder
+		? selectedOrder.items.reduce((count, item) => count + item.quantity, 0)
+		: 0;
 
-  const selectedOrderHasValidAmount = selectedOrder
-    ? Number.isFinite(selectedOrder.total) &&
-      selectedOrder.total > 0 &&
-      Number.isFinite(selectedOrder.productsTotal) &&
-      Number.isFinite(selectedOrder.additionalCharges) &&
-      Number(selectedOrder.total.toFixed(2)) === selectedOrderExpectedTotal
-    : false;
+	const selectedOrderExpectedTotal = selectedOrder
+		? Number(
+				(selectedOrder.productsTotal + selectedOrder.additionalCharges).toFixed(
+					2,
+				),
+			)
+		: 0;
 
-  if (selectedOrder) {
-    return (
-      <OrderDetailView
-        selectedOrder={selectedOrder}
-        selectedItemsCount={selectedItemsCount}
-        selectedOrderHasValidAmount={selectedOrderHasValidAmount}
-        updatingOrderId={updatingOrderId}
-        updatingPaymentId={updatingPaymentId}
-        pageClassName={getPageClass(embedded)}
-        onBack={() => setSelectedOrder(null)}
-        onOpenMaps={handleOpenMaps}
-        onMarkDelivered={handleMarkDelivered}
-        onRegisterPayment={handleRegisterPayment}
-      />
-    );
-  }
+	const selectedOrderHasValidAmount = selectedOrder
+		? Number.isFinite(selectedOrder.total) &&
+			selectedOrder.total > 0 &&
+			Number.isFinite(selectedOrder.productsTotal) &&
+			Number.isFinite(selectedOrder.additionalCharges) &&
+			Number(selectedOrder.total.toFixed(2)) === selectedOrderExpectedTotal
+		: false;
 
-  return (
-    <section className={getPageClass(embedded)}>
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="mb-10 flex flex-col gap-3">
-          <p className="text-sm font-bold uppercase tracking-[0.28em] text-primary">
-            Operacion de entregas
-          </p>
+	if (selectedOrder) {
+		return (
+			<OrderDetailView
+				selectedOrder={selectedOrder}
+				selectedItemsCount={selectedItemsCount}
+				selectedOrderHasValidAmount={selectedOrderHasValidAmount}
+				updatingOrderId={updatingOrderId}
+				updatingPaymentId={updatingPaymentId}
+				pageClassName={getPageClass(embedded)}
+				onBack={() => setSelectedOrder(null)}
+				onOpenMaps={handleOpenMaps}
+				onMarkDelivered={handleMarkDelivered}
+				onRegisterPayment={handleRegisterPayment}
+			/>
+		);
+	}
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-4xl font-black tracking-[-0.04em] sm:text-5xl">
-                Gestion de entregas
-              </h1>
-              <p className={`mt-2 max-w-2xl text-sm font-semibold ${mutedTextClass}`}>
-                Gestiona pedidos pendientes, revisa lo cobrado y registra las
-                entregas del dia.
-              </p>
-            </div>
+	return (
+		<section className={getPageClass(embedded)}>
+			<div className="mx-auto max-w-6xl px-4 sm:px-6">
+				<div className="mb-10 flex flex-col gap-3">
+					<p className="text-sm font-bold uppercase tracking-[0.28em] text-primary">
+						Operacion de entregas
+					</p>
 
-            <div className="inline-flex items-center gap-2 self-start rounded-full border border-primary/20 bg-card-bg-light px-4 py-2 text-sm font-semibold text-text-light opacity-80 shadow-[0_10px_24px_rgba(18,32,56,0.08)]">
-              <PackageCheck className="h-4 w-4 text-primary" />
-              Datos de pedidos actualizados
-            </div>
-          </div>
-        </div>
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+						<div>
+							<h1 className="text-4xl font-black tracking-[-0.04em] sm:text-5xl">
+								Gestion de entregas
+							</h1>
+							<p
+								className={`mt-2 max-w-2xl text-sm font-semibold ${mutedTextClass}`}
+							>
+								Gestiona pedidos pendientes, revisa lo cobrado y registra las
+								entregas del dia.
+							</p>
+						</div>
 
-        <div className="mb-8 grid gap-5 lg:grid-cols-3">
-          <article className={cardBaseClass}>
-            <div className="flex items-center gap-5">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-(--theme-warning-bg) text-(--theme-warning)">
-                <Box className="h-8 w-8" />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-text-light opacity-70">
-                  Pendientes
-                </p>
-                <strong className="text-[3rem] leading-none font-black tracking-[-0.05em]">
-                  {stats.pendingCount}
-                </strong>
-              </div>
-            </div>
-          </article>
+						<div className="inline-flex items-center gap-2 self-start rounded-full border border-primary/20 bg-card-bg-light px-4 py-2 text-sm font-semibold text-text-light opacity-80 shadow-[0_10px_24px_rgba(18,32,56,0.08)]">
+							<PackageCheck className="h-4 w-4 text-primary" />
+							Datos de pedidos actualizados
+						</div>
+					</div>
+				</div>
 
-          <article className={cardBaseClass}>
-            <div className="flex items-center gap-5">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-                <BadgeCheck className="h-8 w-8" />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-text-light opacity-70">
-                  Entregados hoy
-                </p>
-                <strong className="text-[3rem] leading-none font-black tracking-[-0.05em]">
-                  {stats.deliveredTodayCount}
-                </strong>
-              </div>
-            </div>
-          </article>
+				<div className="mb-8 grid gap-5 lg:grid-cols-3">
+					<article className={cardBaseClass}>
+						<div className="flex items-center gap-5">
+							<div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-(--theme-warning-bg) text-(--theme-warning)">
+								<Box className="h-8 w-8" />
+							</div>
+							<div>
+								<p className="text-sm font-medium text-text-light opacity-70">
+									Pendientes
+								</p>
+								<strong className="text-[3rem] leading-none font-black tracking-[-0.05em]">
+									{stats.pendingCount}
+								</strong>
+							</div>
+						</div>
+					</article>
 
-          <article className={cardBaseClass}>
-            <div className="flex items-center gap-5">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-                <Wallet className="h-8 w-8" />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-text-light opacity-70">
-                  Total a cobrar
-                </p>
-                <strong className="text-[2.7rem] leading-none font-black tracking-[-0.05em]">
-                  {formatMoney(stats.pendingCashTotal)}
-                </strong>
-              </div>
-            </div>
-          </article>
-        </div>
+					<article className={cardBaseClass}>
+						<div className="flex items-center gap-5">
+							<div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+								<BadgeCheck className="h-8 w-8" />
+							</div>
+							<div>
+								<p className="text-sm font-medium text-text-light opacity-70">
+									Entregados hoy
+								</p>
+								<strong className="text-[3rem] leading-none font-black tracking-[-0.05em]">
+									{stats.deliveredTodayCount}
+								</strong>
+							</div>
+						</div>
+					</article>
 
-        <div className="overflow-hidden rounded-[30px] border border-border-light bg-card-bg-light shadow-[0_16px_36px_rgba(32,28,20,0.12)]">
-          <div className="border-b border-border-light px-8 py-6">
-            <h2 className="text-2xl font-black tracking-[-0.04em]">
-              Pedidos pendientes
-            </h2>
-            <p className="mt-1 text-sm font-semibold text-text-light opacity-55">
-              Pedidos pendientes de entrega y cobro contra entrega.
-            </p>
-          </div>
+					<article className={cardBaseClass}>
+						<div className="flex items-center gap-5">
+							<div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+								<Wallet className="h-8 w-8" />
+							</div>
+							<div>
+								<p className="text-sm font-medium text-text-light opacity-70">
+									Total a cobrar
+								</p>
+								<strong className="text-[2.7rem] leading-none font-black tracking-[-0.05em]">
+									{formatMoney(stats.pendingCashTotal)}
+								</strong>
+							</div>
+						</div>
+					</article>
+				</div>
 
-          {errorMessage ? (
-            <div className="border-b border-(--theme-warning-border) bg-(--theme-warning-bg) px-8 py-4 text-sm font-semibold text-(--theme-warning)">
-              {errorMessage}
-            </div>
-          ) : null}
+				<div className="overflow-hidden rounded-[30px] border border-border-light bg-card-bg-light shadow-[0_16px_36px_rgba(32,28,20,0.12)]">
+					<div className="border-b border-border-light px-8 py-6">
+						<h2 className="text-2xl font-black tracking-[-0.04em]">
+							Pedidos pendientes
+						</h2>
+						<p className="mt-1 text-sm font-semibold text-text-light opacity-55">
+							Pedidos pendientes de entrega y cobro contra entrega.
+						</p>
+					</div>
 
-          {successMessage ? (
-            <div className="border-b border-primary/20 bg-primary/10 px-8 py-4 text-sm font-semibold text-primary">
-              {successMessage}
-            </div>
-          ) : null}
+					{errorMessage ? (
+						<div className="border-b border-(--theme-warning-border) bg-(--theme-warning-bg) px-8 py-4 text-sm font-semibold text-(--theme-warning)">
+							{errorMessage}
+						</div>
+					) : null}
 
-          {loading ? (
-            <div className="flex min-h-72 items-center justify-center px-8 py-12 text-text-light opacity-55">
-              <LoaderCircle className="h-6 w-6 animate-spin" />
-            </div>
-          ) : pendingOrders.length === 0 ? (
-            <div className="px-8 py-16 text-center">
-              <p className="text-lg font-bold">No hay pedidos pendientes.</p>
-              <p className="mt-2 text-sm font-semibold text-text-light opacity-55">
-                Los pedidos entregados hoy aparecen reflejados en las metricas
-                superiores.
-              </p>
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-left">
-                <thead className="bg-secondary-bg-light/50 text-sm font-black uppercase tracking-[0.08em] text-text-light">
-                  <tr>
-                    <th className="px-8 py-5">Codigo</th>
-                    <th className="px-8 py-5">Cliente</th>
-                    <th className="px-8 py-5">Zona</th>
-                    <th className="px-8 py-5">Monto</th>
-                    <th className="px-8 py-5">Estado</th>
-                    <th className="px-8 py-5">Acciones</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pendingOrders.map((order) => {
-                    const expectedTotal = Number(
-                      (order.productsTotal + order.additionalCharges).toFixed(2)
-                    );
-                    const hasValidAmount =
-                      Number.isFinite(order.total) &&
-                      order.total > 0 &&
-                      Number(order.total.toFixed(2)) === expectedTotal;
+					{successMessage ? (
+						<div className="border-b border-primary/20 bg-primary/10 px-8 py-4 text-sm font-semibold text-primary">
+							{successMessage}
+						</div>
+					) : null}
 
-                    return (
-                      <tr
-                        key={order.id}
-                        className="border-t border-border-light text-[1.05rem] text-text-light"
-                      >
-                        <td className="px-8 py-5 font-medium">{order.displayId}</td>
-                        <td className="px-8 py-5 font-medium">{order.buyerName}</td>
-                        <td className="px-8 py-5">
-                          <span className="inline-flex items-center gap-2 font-medium text-text-light opacity-75">
-                            <MapPin className="h-4 w-4" />
-                            {order.deliveryZone}
-                          </span>
-                        </td>
-                        <td className="px-8 py-5 font-medium">
-                          {hasValidAmount
-                            ? formatMoney(order.total)
-                            : 'Monto no disponible'}
-                        </td>
-                        <td className="px-8 py-5">
-                          <span
-                            className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}
-                          >
-                            {order.paymentStatusLabel}
-                          </span>
-                        </td>
-                        <td className="px-8 py-5">
-                          <div className="flex flex-wrap gap-3">
-                            <button
-                              type="button"
-                              onClick={() => setSelectedOrder(order)}
-                              className="inline-flex items-center gap-2 rounded-2xl bg-(--theme-text) px-5 py-3 text-sm font-bold text-(--theme-bg) transition hover:opacity-90"
-                            >
-                              <Eye className="h-4 w-4" />
-                              Ver detalle
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => handleRegisterPayment(order)}
-                              disabled={order.paymentStatus === 'Cobrado' || updatingPaymentId === order.id}
-                              className={ghostButtonClass}
-                            >
-                              {updatingPaymentId === order.id ? (
-                                <LoaderCircle className="h-4 w-4 animate-spin" />
-                              ) : (
-                                'Registrar pago'
-                              )}
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => handleMarkDelivered(order)}
-                              disabled={
-                                updatingOrderId === order.id || 
-                                !hasValidAmount ||
-                                order.paymentStatus !== 'Cobrado'
-                              }
-                              className={primaryButtonClass}
-                            >
-                              {updatingOrderId === order.id ? (
-                                <LoaderCircle className="h-4 w-4 animate-spin" />
-                              ) : (
-                                <BadgeCheck className="h-4 w-4" />
-                              )}
-                              Marcar entregado
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+					{loading ? (
+						<div className="flex min-h-72 items-center justify-center px-8 py-12 text-text-light opacity-55">
+							<LoaderCircle className="h-6 w-6 animate-spin" />
+						</div>
+					) : pendingOrders.length === 0 ? (
+						<div className="px-8 py-16 text-center">
+							<p className="text-lg font-bold">No hay pedidos pendientes.</p>
+							<p className="mt-2 text-sm font-semibold text-text-light opacity-55">
+								Los pedidos entregados hoy aparecen reflejados en las metricas
+								superiores.
+							</p>
+						</div>
+					) : (
+						<div className="overflow-x-auto">
+							<table className="min-w-full text-left">
+								<thead className="bg-secondary-bg-light/50 text-sm font-black uppercase tracking-[0.08em] text-text-light">
+									<tr>
+										<th className="px-8 py-5">Codigo</th>
+										<th className="px-8 py-5">Cliente</th>
+										<th className="px-8 py-5">Zona</th>
+										<th className="px-8 py-5">Monto</th>
+										<th className="px-8 py-5">Estado</th>
+										<th className="px-8 py-5">Acciones</th>
+									</tr>
+								</thead>
+								<tbody>
+									{pendingOrders.map((order) => {
+										const expectedTotal = Number(
+											(order.productsTotal + order.additionalCharges).toFixed(
+												2,
+											),
+										);
+										const hasValidAmount =
+											Number.isFinite(order.total) &&
+											order.total > 0 &&
+											Number(order.total.toFixed(2)) === expectedTotal;
 
-        <div className="mt-6 rounded-[26px] border border-border-light bg-card-bg-light/80 px-6 py-5 shadow-[0_10px_24px_rgba(18,32,56,0.06)] backdrop-blur">
-          <p className="text-sm font-semibold text-text-light opacity-65">
-            Historial entregado:{' '}
-            <span className="font-black text-text-light">
-              {deliveredOrders.length}
-            </span>{' '}
-            pedidos registrados como entregados.
-          </p>
-        </div>
-      </div>
-    </section>
-  );
+										return (
+											<tr
+												key={order.id}
+												className="border-t border-border-light text-[1.05rem] text-text-light"
+											>
+												<td className="px-8 py-5 font-medium">
+													{order.displayId}
+												</td>
+												<td className="px-8 py-5 font-medium">
+													{order.buyerName}
+												</td>
+												<td className="px-8 py-5">
+													<span className="inline-flex items-center gap-2 font-medium text-text-light opacity-75">
+														<MapPin className="h-4 w-4" />
+														{order.deliveryZone}
+													</span>
+												</td>
+												<td className="px-8 py-5 font-medium">
+													{hasValidAmount
+														? formatMoney(order.total)
+														: "Monto no disponible"}
+												</td>
+												<td className="px-8 py-5">
+													<span
+														className={`${badgeClass} bg-(--theme-warning-bg) py-1 text-(--theme-warning)`}
+													>
+														{order.paymentStatusLabel}
+													</span>
+												</td>
+												<td className="px-8 py-5">
+													<div className="flex flex-wrap gap-3">
+														<button
+															type="button"
+															onClick={() => setSelectedOrder(order)}
+															className="inline-flex items-center gap-2 rounded-2xl bg-(--theme-text) px-5 py-3 text-sm font-bold text-(--theme-bg) transition hover:opacity-90"
+														>
+															<Eye className="h-4 w-4" />
+															Ver detalle
+														</button>
+														<button
+															type="button"
+															onClick={() => handleRegisterPayment(order)}
+															disabled={
+																order.paymentStatus === "Cobrado" ||
+																updatingPaymentId === order.id
+															}
+															className={ghostButtonClass}
+														>
+															{updatingPaymentId === order.id ? (
+																<LoaderCircle className="h-4 w-4 animate-spin" />
+															) : (
+																"Registrar pago"
+															)}
+														</button>
+														<button
+															type="button"
+															onClick={() => handleMarkDelivered(order)}
+															disabled={
+																updatingOrderId === order.id ||
+																!hasValidAmount ||
+																order.paymentStatus !== "Cobrado"
+															}
+															className={primaryButtonClass}
+														>
+															{updatingOrderId === order.id ? (
+																<LoaderCircle className="h-4 w-4 animate-spin" />
+															) : (
+																<BadgeCheck className="h-4 w-4" />
+															)}
+															Marcar entregado
+														</button>
+													</div>
+												</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</table>
+						</div>
+					)}
+				</div>
+
+				<div className="mt-6 rounded-[26px] border border-border-light bg-card-bg-light/80 px-6 py-5 shadow-[0_10px_24px_rgba(18,32,56,0.06)] backdrop-blur">
+					<p className="text-sm font-semibold text-text-light opacity-65">
+						Historial entregado:{" "}
+						<span className="font-black text-text-light">
+							{deliveredOrders.length}
+						</span>{" "}
+						pedidos registrados como entregados.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
 }

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -600,15 +600,15 @@ function OrderDetailModal({
 
     return (
         <div
-            className="fixed inset-0 z-[998] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+            className="fixed inset-0 z-[998] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
             onClick={(event) => {
                 if (event.target === event.currentTarget) onClose();
             }}
         >
-            <section className="max-h-[92vh] w-full max-w-6xl overflow-y-auto rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-                <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
                     <div>
-                        <h2 className="text-2xl font-black tracking-normal">
+                        <h2 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
                             Detalle de cobro del pedido
                         </h2>
                         <p className="text-sm font-semibold opacity-70">
@@ -625,7 +625,7 @@ function OrderDetailModal({
                     </button>
                 </header>
 
-                <div className="grid gap-5 p-6 lg:grid-cols-[1fr_280px]">
+                <div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[minmax(0,1fr)_280px]">
                     <div className="space-y-5">
                         <article className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
                             <div className="flex flex-wrap items-center gap-3">
@@ -826,12 +826,12 @@ function CloseShiftModal({
 }) {
     return (
         <div
-            className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
             onClick={(event) => {
                 if (event.target === event.currentTarget && !isSaving) onClose();
             }}
         >
-            <section className="w-full max-w-xl rounded-[28px] border border-border-light bg-card-bg-light p-6 text-text-light shadow-2xl">
+            <section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-xl overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light p-4 text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
                 <header className="flex items-start justify-between gap-4">
                     <div>
                         <span className="messenger-icon mb-4 inline-flex h-14 w-14 items-center justify-center rounded-full">
@@ -925,18 +925,18 @@ function ShiftReportDetailModal({
 
     return (
         <div
-            className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
             onClick={(event) => {
                 if (event.target === event.currentTarget) onClose();
             }}
         >
-            <section className="max-h-[92vh] w-full max-w-6xl overflow-y-auto rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-                <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
                     <div>
                         <p className="text-sm font-bold uppercase tracking-[0.24em] text-primary">
                             Reporte de jornada
                         </p>
-                        <h2 className="mt-2 text-2xl font-black tracking-[-0.04em]">
+                        <h2 className="mt-2 text-xl font-black leading-tight tracking-[-0.04em] sm:text-2xl">
                             Detalle de jornada - {formatDateKey(report.dateKey)}
                         </h2>
                         <p className="messenger-copy mt-1 text-sm font-semibold">
@@ -954,7 +954,7 @@ function ShiftReportDetailModal({
                     </button>
                 </header>
 
-                <div className="grid gap-5 p-6 lg:grid-cols-[280px_1fr]">
+                <div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[280px_minmax(0,1fr)]">
                     <aside className="h-fit rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
                         <h3 className="text-lg font-black">Resumen</h3>
 
@@ -1655,7 +1655,7 @@ export default function MessengerDashboard({
 
     return (
         <main
-            className={`messenger-dashboard ${embedded ? 'messenger-dashboard--embedded' : 'min-h-screen'}`}
+            className={`messenger-dashboard ${embedded ? 'messenger-dashboard--embedded' : 'min-h-[100dvh]'}`}
         >
             {newOrderCount > 0 && clientSection === 'assigned' && (
                 <NewOrderToast
@@ -1911,7 +1911,7 @@ export default function MessengerDashboard({
                                                 </p>
                                             </div>
 
-                                            <div className="grid gap-3 text-sm font-bold sm:grid-cols-4 lg:min-w-[520px]">
+                                            <div className="grid min-w-0 gap-3 text-sm font-bold sm:grid-cols-4 lg:w-[520px] lg:max-w-full">
                                                 <p>
                                                     <span className="messenger-muted block text-xs">Completadas</span>
                                                     {report.summary.completedCount}

--- a/src/features/mensajero/components/MessengerDashboard.tsx
+++ b/src/features/mensajero/components/MessengerDashboard.tsx
@@ -1,2032 +1,2095 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
-import PaymentSuccessModal from '../modals/PaymentSuccessModal';
+import { onAuthStateChanged } from "firebase/auth";
 import {
-    AlertTriangle,
-    CheckCircle2,
-    Clock3,
-    DollarSign,
-    Eye,
-    MapPin,
-    Package,
-    Phone,
-    Send,
-    Truck,
-    X,
-    XCircle,
-} from 'lucide-react';
-import { onAuthStateChanged } from 'firebase/auth';
-import { getSellerData } from '../../location/services/locationService';
-import { auth } from '../../../lib/firebase';
+	AlertTriangle,
+	CheckCircle2,
+	Clock3,
+	DollarSign,
+	Eye,
+	MapPin,
+	Package,
+	Phone,
+	Send,
+	Truck,
+	X,
+	XCircle,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
-    countActiveDeliveriesByCourier,
-    isCourierAvailableFromActiveCount,
-} from '../../../lib/deliveryAvailability';
-import { parseOrderId } from '../../cart/services/orderService';
+	countActiveDeliveriesByCourier,
+	isCourierAvailableFromActiveCount,
+} from "../../../lib/deliveryAvailability";
+import { auth } from "../../../lib/firebase";
+import { parseOrderId } from "../../cart/services/orderService";
+import { getSellerData } from "../../location/services/locationService";
+import AcceptBlockedModal from "../modals/AcceptBlockedModal";
+import PaymentSuccessModal from "../modals/PaymentSuccessModal";
+import UndeliveredModal from "../modals/UndeliveredModal";
 import {
-    acceptMessengerOrder,
-    closeMessengerShift,
-    markMessengerOrderAsNotDelivered,
-    registerMessengerCashPayment,
-    setMessengerOrderStatus,
-    subscribeToMessengerOrders,
-    subscribeToMessengerShiftClosures,
-} from '../services/messengerOrdersService';
-import type { MessengerOrder, MessengerShiftClosure } from '../types';
-import { hasActiveMessengerDelivery } from '../utils/acceptEligibility';
-import AcceptBlockedModal from '../modals/AcceptBlockedModal';
+	acceptMessengerOrder,
+	closeMessengerShift,
+	markMessengerOrderAsNotDelivered,
+	registerMessengerCashPayment,
+	setMessengerOrderStatus,
+	subscribeToMessengerOrders,
+	subscribeToMessengerShiftClosures,
+} from "../services/messengerOrdersService";
+import type { MessengerOrder, MessengerShiftClosure } from "../types";
+import { hasActiveMessengerDelivery } from "../utils/acceptEligibility";
 import {
-    sortAcceptedOrdersByAge,
-    type AcceptedOrderSort,
-} from '../utils/acceptedOrderSorting';
-import { getDeliveryStatusLabel } from '../utils/deliveryStatusFlow';
+	type AcceptedOrderSort,
+	sortAcceptedOrdersByAge,
+} from "../utils/acceptedOrderSorting";
 import {
-    getCollectedOrdersForDay,
-    getCollectedTotal,
-    getCollectedTotalForDay,
-    isMessengerOrderCollected,
-} from '../utils/collectionSummary';
-import { formatBolivianos } from '../utils/money';
-import UndeliveredModal from '../modals/UndeliveredModal';
+	getCollectedOrdersForDay,
+	getCollectedTotal,
+	getCollectedTotalForDay,
+	isMessengerOrderCollected,
+} from "../utils/collectionSummary";
+import { getDeliveryStatusLabel } from "../utils/deliveryStatusFlow";
+import { formatBolivianos } from "../utils/money";
 
-import './MessengerDashboard.css';
-import ConfirmPaymentModal from '../modals/Confirmpaymentmodal';
+import "./MessengerDashboard.css";
 import ConfirmAssignedOrderActionModal, {
-    type AssignedOrderAction,
-} from '../modals/ConfirmAssignedOrderActionModal';
+	type AssignedOrderAction,
+} from "../modals/ConfirmAssignedOrderActionModal";
+import ConfirmPaymentModal from "../modals/Confirmpaymentmodal";
 
-const DEV_COURIER_ID = 'user-nadia';
+const DEV_COURIER_ID = "user-nadia";
 
 const buildDeliveryOrderDetailUrl = (orderId: string) =>
-    `/delivery/order/${encodeURIComponent(orderId)}`;
+	`/delivery/order/${encodeURIComponent(orderId)}`;
 
 const navigateToDeliveryOrderDetail = (orderId: string) => {
-    window.location.href = buildDeliveryOrderDetailUrl(orderId);
+	window.location.href = buildDeliveryOrderDetailUrl(orderId);
 };
 
 const formatDate = (date: Date | null | undefined) => {
-    if (!date) return 'Fecha no disponible';
-    return new Intl.DateTimeFormat('es-BO', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(date);
+	if (!date) return "Fecha no disponible";
+	return new Intl.DateTimeFormat("es-BO", {
+		dateStyle: "medium",
+		timeStyle: "short",
+	}).format(date);
 };
 const getLocalDateKey = (date = new Date()) => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
 
-    return `${year}-${month}-${day}`;
+	return `${year}-${month}-${day}`;
 };
 
 const formatDateKey = (dateKey: string) => {
-    const [year, month, day] = dateKey.split('-').map(Number);
+	const [year, month, day] = dateKey.split("-").map(Number);
 
-    if (!year || !month || !day) return dateKey;
+	if (!year || !month || !day) return dateKey;
 
-    return new Intl.DateTimeFormat('es-BO', {
-        dateStyle: 'medium',
-    }).format(new Date(year, month - 1, day));
+	return new Intl.DateTimeFormat("es-BO", {
+		dateStyle: "medium",
+	}).format(new Date(year, month - 1, day));
 };
 
 const formatTimeOnly = (date: Date | null | undefined) => {
-    if (!date) return 'No registrado';
+	if (!date) return "No registrado";
 
-    return new Intl.DateTimeFormat('es-BO', {
-        hour: '2-digit',
-        minute: '2-digit',
-    }).format(date);
+	return new Intl.DateTimeFormat("es-BO", {
+		hour: "2-digit",
+		minute: "2-digit",
+	}).format(date);
 };
 
 const formatOrderAgeDate = (order: MessengerOrder) => {
-    const date = order.assignedAt ?? order.createdAt ?? order.updatedAt;
+	const date = order.assignedAt ?? order.createdAt ?? order.updatedAt;
 
-    if (!date) return 'Fecha no disponible';
+	if (!date) return "Fecha no disponible";
 
-    return new Intl.DateTimeFormat('es-BO', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(date);
+	return new Intl.DateTimeFormat("es-BO", {
+		dateStyle: "medium",
+		timeStyle: "short",
+	}).format(date);
 };
 
 function CopyableOrderId({
-    order,
-    codeClassName,
+	order,
+	codeClassName,
 }: {
-    order: MessengerOrder;
-    codeClassName: string;
+	order: MessengerOrder;
+	codeClassName: string;
 }) {
-    const { uuid, friendlyName } = parseOrderId(order.id);
-    const displayId = order.displayId ?? friendlyName;
-    const showTechnicalId = !order.displayId;
-    const copyOrderId = () => {
-        void navigator.clipboard?.writeText(order.id);
-    };
+	const { uuid, friendlyName } = parseOrderId(order.id);
+	const displayId = order.displayId ?? friendlyName;
+	const showTechnicalId = !order.displayId;
+	const copyOrderId = () => {
+		void navigator.clipboard?.writeText(order.id);
+	};
 
-    return (
-        <button
-            className="block text-left"
-            onClick={copyOrderId}
-            title="Copiar ID del pedido"
-            type="button"
-        >
-            {showTechnicalId && (
-                <p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
-            )}
-            <h3 className={codeClassName}>{displayId}</h3>
-        </button>
-    );
+	return (
+		<button
+			className="block text-left"
+			onClick={copyOrderId}
+			title="Copiar ID del pedido"
+			type="button"
+		>
+			{showTechnicalId && (
+				<p className="font-mono text-[10px] font-bold opacity-40">{uuid}</p>
+			)}
+			<h3 className={codeClassName}>{displayId}</h3>
+		</button>
+	);
 }
 
-const formatDeliveryStatus = (status: MessengerOrder['deliveryStatus']): string => {
-    return getDeliveryStatusLabel(status);
+const formatDeliveryStatus = (
+	status: MessengerOrder["deliveryStatus"],
+): string => {
+	return getDeliveryStatusLabel(status);
 };
 
-const getStatusUpdateMessage = (status: MessengerOrder['deliveryStatus']): string => {
-    if (status === 'accepted') return 'Pedido aceptado correctamente.';
-    if (status === 'in_transit') return 'Entrega iniciada correctamente.';
-    if (status === 'pending_reassignment') {
-        return 'Pedido rechazado y enviado a reasignacion.';
-    }
-    return `Estado actualizado a ${formatDeliveryStatus(status)}.`;
+const getStatusUpdateMessage = (
+	status: MessengerOrder["deliveryStatus"],
+): string => {
+	if (status === "accepted") return "Pedido aceptado correctamente.";
+	if (status === "in_transit") return "Entrega iniciada correctamente.";
+	if (status === "pending_reassignment") {
+		return "Pedido rechazado y enviado a reasignacion.";
+	}
+	return `Estado actualizado a ${formatDeliveryStatus(status)}.`;
 };
 
 const buildBuyerMapUrl = (order: MessengerOrder) => {
-    const url = new URL('/mapa', window.location.origin);
+	const url = new URL("/mapa", window.location.origin);
 
-    if (order.deliveryLat != null && order.deliveryLng != null) {
-        url.searchParams.set('lat', String(order.deliveryLat));
-        url.searchParams.set('lng', String(order.deliveryLng));
-    }
+	if (order.deliveryLat != null && order.deliveryLng != null) {
+		url.searchParams.set("lat", String(order.deliveryLat));
+		url.searchParams.set("lng", String(order.deliveryLng));
+	}
 
-    url.searchParams.set('order', order.id);
+	url.searchParams.set("order", order.id);
 
-    return url.toString();
+	return url.toString();
 };
 
 const storeBuyerMapOrder = (order: MessengerOrder) => {
-    localStorage.setItem(
-        'courier_panel_order',
-        JSON.stringify({
-            customerName: order.customerName,
-            phone: order.phone,
-            address: order.address,
-            reference: order.reference || order.locationLabel,
-            items: order.items.map((item) => ({
-                name: item.name,
-                quantity: item.quantity,
-            })),
-            cashToCollect: order.cashToCollect,
-        })
-    );
+	localStorage.setItem(
+		"courier_panel_order",
+		JSON.stringify({
+			customerName: order.customerName,
+			phone: order.phone,
+			address: order.address,
+			reference: order.reference || order.locationLabel,
+			items: order.items.map((item) => ({
+				name: item.name,
+				quantity: item.quantity,
+			})),
+			cashToCollect: order.cashToCollect,
+		}),
+	);
 };
-
-
-
-
 
 const openDeliveryMap = (order: MessengerOrder) => {
-    storeBuyerMapOrder(order);
-    window.location.href = buildBuyerMapUrl(order);
+	storeBuyerMapOrder(order);
+	window.location.href = buildBuyerMapUrl(order);
 };
 
-function MessageToast({ message, onDismiss }: { message: string; onDismiss: () => void }) {
-    useEffect(() => {
-        const timer = setTimeout(onDismiss, 3000);
-        return () => clearTimeout(timer);
-    }, [message, onDismiss]);
+function MessageToast({
+	message,
+	onDismiss,
+}: {
+	message: string;
+	onDismiss: () => void;
+}) {
+	useEffect(() => {
+		const timer = setTimeout(onDismiss, 3000);
+		return () => clearTimeout(timer);
+	}, [onDismiss]);
 
-    const isError =
-        message.toLowerCase().includes('error') ||
-        message.toLowerCase().includes('no se pudo');
+	const isError =
+		message.toLowerCase().includes("error") ||
+		message.toLowerCase().includes("no se pudo");
 
-    return (
-        <div
-            className={`messenger-toast mt-6 mb-6 flex items-center gap-4 rounded-[20px] border-2 px-5 py-4 text-sm font-bold shadow-lg ${isError ? 'messenger-toast--error' : 'messenger-toast--success'
-                }`}
-        >
-            <span className="messenger-toast-dot h-2.5 w-2.5 shrink-0 rounded-full" />
-            <span className="flex-1">{message}</span>
-            <button
-                className="messenger-toast-close ml-2 opacity-50 transition hover:opacity-100"
-                onClick={onDismiss}
-                type="button"
-            >
-                <X size={15} />
-            </button>
-        </div>
-    );
+	return (
+		<div
+			className={`messenger-toast mt-6 mb-6 flex items-center gap-4 rounded-[20px] border-2 px-5 py-4 text-sm font-bold shadow-lg ${
+				isError ? "messenger-toast--error" : "messenger-toast--success"
+			}`}
+		>
+			<span className="messenger-toast-dot h-2.5 w-2.5 shrink-0 rounded-full" />
+			<span className="flex-1">{message}</span>
+			<button
+				className="messenger-toast-close ml-2 opacity-50 transition hover:opacity-100"
+				onClick={onDismiss}
+				type="button"
+			>
+				<X size={15} />
+			</button>
+		</div>
+	);
 }
 
 function NewOrderToast({
-    count,
-    onDismiss,
+	count,
+	onDismiss,
 }: {
-    count: number;
-    onDismiss: () => void;
+	count: number;
+	onDismiss: () => void;
 }) {
-    useEffect(() => {
-        const timer = setTimeout(onDismiss, 5000);
-        return () => clearTimeout(timer);
-    }, [count, onDismiss]);
+	useEffect(() => {
+		const timer = setTimeout(onDismiss, 5000);
+		return () => clearTimeout(timer);
+	}, [onDismiss]);
 
-    const pedidoLabel = count === 1 ? 'pedido' : 'pedidos';
+	const pedidoLabel = count === 1 ? "pedido" : "pedidos";
 
-    return (
-        <aside
-            aria-live="polite"
-            className="messenger-new-order-toast"
-            role="status"
-        >
-            <div className="flex items-start gap-4">
-                <span className="messenger-new-order-icon inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full">
-                    <Package size={24} />
-                </span>
+	return (
+		<aside
+			aria-live="polite"
+			className="messenger-new-order-toast"
+			role="status"
+		>
+			<div className="flex items-start gap-4">
+				<span className="messenger-new-order-icon inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full">
+					<Package size={24} />
+				</span>
 
-                <div className="min-w-0 flex-1">
-                    <h3 className="text-base font-black">Nuevo pedido disponible</h3>
-                    <p className="messenger-copy mt-1 text-sm font-semibold">
-                        Tienes {count} {pedidoLabel} por revisar.
-                    </p>
-                </div>
+				<div className="min-w-0 flex-1">
+					<h3 className="text-base font-black">Nuevo pedido disponible</h3>
+					<p className="messenger-copy mt-1 text-sm font-semibold">
+						Tienes {count} {pedidoLabel} por revisar.
+					</p>
+				</div>
 
-                <button
-                    aria-label="Cerrar alerta de nuevo pedido"
-                    className="messenger-new-order-close inline-flex h-8 w-8 items-center justify-center rounded-full transition"
-                    onClick={onDismiss}
-                    type="button"
-                >
-                    <X size={17} />
-                </button>
-            </div>
+				<button
+					aria-label="Cerrar alerta de nuevo pedido"
+					className="messenger-new-order-close inline-flex h-8 w-8 items-center justify-center rounded-full transition"
+					onClick={onDismiss}
+					type="button"
+				>
+					<X size={17} />
+				</button>
+			</div>
 
-            <div className="messenger-new-order-progress mt-4" aria-hidden="true">
-                <span />
-            </div>
+			<div className="messenger-new-order-progress mt-4" aria-hidden="true">
+				<span />
+			</div>
 
-            <p className="messenger-copy mt-2 text-xs font-semibold">
-                Se cerrará automáticamente en unos segundos.
-            </p>
-        </aside>
-    );
+			<p className="messenger-copy mt-2 text-xs font-semibold">
+				Se cerrará automáticamente en unos segundos.
+			</p>
+		</aside>
+	);
 }
 
 function SummaryCard({
-    icon,
-    label,
-    value,
-    featured = false,
+	icon,
+	label,
+	value,
+	featured = false,
 }: {
-    icon: ReactNode;
-    label: string;
-    value: string | number;
-    featured?: boolean;
+	icon: ReactNode;
+	label: string;
+	value: string | number;
+	featured?: boolean;
 }) {
-    return (
-        <article
-            className={`messenger-summary-card rounded-[28px] border px-7 py-8 shadow-[0_14px_30px_rgba(38,33,22,0.10)] ${featured ? 'messenger-summary-card--featured' : ''
-                }`}
-        >
-            <div className="flex items-center gap-4">
-                <span
-                    className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${featured ? 'messenger-icon--featured' : 'messenger-icon'
-                        }`}
-                >
-                    {icon}
-                </span>
-                <span className="messenger-muted text-sm font-medium">{label}</span>
-            </div>
-            <p className="mt-4 text-3xl font-black tracking-normal">{value}</p>
-        </article>
-    );
+	return (
+		<article
+			className={`messenger-summary-card rounded-[28px] border px-7 py-8 shadow-[0_14px_30px_rgba(38,33,22,0.10)] ${
+				featured ? "messenger-summary-card--featured" : ""
+			}`}
+		>
+			<div className="flex items-center gap-4">
+				<span
+					className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
+						featured ? "messenger-icon--featured" : "messenger-icon"
+					}`}
+				>
+					{icon}
+				</span>
+				<span className="messenger-muted text-sm font-medium">{label}</span>
+			</div>
+			<p className="mt-4 text-3xl font-black tracking-normal">{value}</p>
+		</article>
+	);
 }
 
 function PendingOrderCard({
-    order,
-    onAccept,
-    onDelivered,
-    onDetail,
-    onInTransit,
-    onNotDelivered,
-    onReject,
-    acceptDisabled = false,
+	order,
+	onAccept,
+	onDelivered,
+	onDetail,
+	onInTransit,
+	onNotDelivered,
+	onReject,
+	acceptDisabled = false,
 }: {
-    order: MessengerOrder;
-    onAccept: (orderId: string) => void;
-    onDelivered: (order: MessengerOrder) => void;
-    onDetail: (order: MessengerOrder) => void;
-    onInTransit: (orderId: string) => void;
-    onNotDelivered: (order: MessengerOrder) => void;
-    onReject: (orderId: string) => void;
-    acceptDisabled?: boolean;
+	order: MessengerOrder;
+	onAccept: (orderId: string) => void;
+	onDelivered: (order: MessengerOrder) => void;
+	onDetail: (order: MessengerOrder) => void;
+	onInTransit: (orderId: string) => void;
+	onNotDelivered: (order: MessengerOrder) => void;
+	onReject: (orderId: string) => void;
+	acceptDisabled?: boolean;
 }) {
-    const [showAcceptBlockedModal, setShowAcceptBlockedModal] = useState(false);
-    const customerLocationUrl = useMemo(() => {
-        return buildBuyerMapUrl(order);
-    }, [order]);
+	const [showAcceptBlockedModal, setShowAcceptBlockedModal] = useState(false);
+	const customerLocationUrl = useMemo(() => {
+		return buildBuyerMapUrl(order);
+	}, [order]);
 
-    const [sellerData, setSellerData] = useState<Awaited<ReturnType<typeof getSellerData>> | null>(null);
+	const [sellerData, setSellerData] = useState<Awaited<
+		ReturnType<typeof getSellerData>
+	> | null>(null);
 
-    useEffect(() => {
-        getSellerData(order.id).then(setSellerData).catch(() => setSellerData(null));
-    }, [order.id]);
+	useEffect(() => {
+		getSellerData(order.id)
+			.then(setSellerData)
+			.catch(() => setSellerData(null));
+	}, [order.id]);
 
-    const openSellerMap = () => {
-        if (!sellerData) return;
+	const openSellerMap = () => {
+		if (!sellerData) return;
 
-        localStorage.setItem(
-            'courier_panel_seller',
-            JSON.stringify({
-                customerName: sellerData.sellerName ?? 'Vendedor',
-                phone: sellerData.sellerPhone ?? '',
-                address: sellerData.address,
-                reference: null,
-                items: [],
-                cashToCollect: 0,
-            })
-        );
+		localStorage.setItem(
+			"courier_panel_seller",
+			JSON.stringify({
+				customerName: sellerData.sellerName ?? "Vendedor",
+				phone: sellerData.sellerPhone ?? "",
+				address: sellerData.address,
+				reference: null,
+				items: [],
+				cashToCollect: 0,
+			}),
+		);
 
-        const url = new URL('/mapa', window.location.origin);
-        url.searchParams.set('lat', String(sellerData.lat));
-        url.searchParams.set('lng', String(sellerData.lng));
-        url.searchParams.set('order', order.id);
-        url.searchParams.set('mode', 'seller');
-        window.location.href = url.toString();
-    };
-    return (
-        <article className="messenger-order-card rounded-[28px] border p-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)]">
-            <div className="messenger-order-grid grid gap-8">
-                <div>
-                    <div className="mb-6 flex items-center gap-3">
-                        <CopyableOrderId order={order} codeClassName="text-base font-black" />
-                        <span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
-                            {formatDeliveryStatus(order.deliveryStatus)}
-                        </span>
-                        <span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
-                            {order.paymentStatusLabel.toUpperCase()}
-                        </span>
-                    </div>
+		const url = new URL("/mapa", window.location.origin);
+		url.searchParams.set("lat", String(sellerData.lat));
+		url.searchParams.set("lng", String(sellerData.lng));
+		url.searchParams.set("order", order.id);
+		url.searchParams.set("mode", "seller");
+		window.location.href = url.toString();
+	};
+	return (
+		<article className="messenger-order-card rounded-[28px] border p-6 shadow-[0_14px_30px_rgba(38,33,22,0.10)]">
+			<div className="messenger-order-grid grid gap-8">
+				<div>
+					<div className="mb-6 flex items-center gap-3">
+						<CopyableOrderId
+							order={order}
+							codeClassName="text-base font-black"
+						/>
+						<span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
+							{formatDeliveryStatus(order.deliveryStatus)}
+						</span>
+						<span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
+							{order.paymentStatusLabel.toUpperCase()}
+						</span>
+					</div>
 
-                    <div className="messenger-copy space-y-4 text-sm">
-                        {(order.deliveryStatus === 'accepted' ||
-                            order.deliveryStatus === 'in_transit') && (
-                                <div>
-                                    <p className="messenger-muted mb-1 text-xs">Asignado</p>
-                                    <p className="font-bold">{formatOrderAgeDate(order)}</p>
-                                </div>
-                            )}
+					<div className="messenger-copy space-y-4 text-sm">
+						{(order.deliveryStatus === "accepted" ||
+							order.deliveryStatus === "in_transit") && (
+							<div>
+								<p className="messenger-muted mb-1 text-xs">Asignado</p>
+								<p className="font-bold">{formatOrderAgeDate(order)}</p>
+							</div>
+						)}
 
-                        <div>
-                            <p className="messenger-muted mb-1 text-xs">Cliente</p>
-                            <p className="font-bold">{order.customerName}</p>
-                        </div>
+						<div>
+							<p className="messenger-muted mb-1 text-xs">Cliente</p>
+							<p className="font-bold">{order.customerName}</p>
+						</div>
 
-                        <p className="flex items-center gap-2">
-                            <Phone size={16} />
-                            <a className="hover:text-green-600" href={`tel:${order.phone}`}>
-                                {order.phone}
-                            </a>
-                        </p>
+						<p className="flex items-center gap-2">
+							<Phone size={16} />
+							<a className="hover:text-green-600" href={`tel:${order.phone}`}>
+								{order.phone}
+							</a>
+						</p>
 
-                        <p className="flex items-start gap-2">
-                            <MapPin className="mt-0.5 shrink-0" size={16} />
-                            <span>
-                                {order.address}
-                                <span className="messenger-muted block text-xs">
-                                    {order.city}
-                                </span>
-                            </span>
-                        </p>
+						<p className="flex items-start gap-2">
+							<MapPin className="mt-0.5 shrink-0" size={16} />
+							<span>
+								{order.address}
+								<span className="messenger-muted block text-xs">
+									{order.city}
+								</span>
+							</span>
+						</p>
 
-                        {order.reference && (
-                            <p className="messenger-reference border-l-4 px-3 py-3 text-xs font-medium">
-                                {order.reference}
-                            </p>
-                        )}
-                        {order.deliveryStatus === 'reprogrammed' && (
-                        <div className="messenger-reference border-l-4 px-4 py-4 text-sm font-semibold">
-                            <p className="messenger-muted mb-1 text-xs font-bold uppercase">
-                                Nueva fecha y hora de entrega
-                            </p>
-                            <p className="font-black text-primary">
-                                {formatDate(order.newDeliveryAt)}
-                            </p>
+						{order.reference && (
+							<p className="messenger-reference border-l-4 px-3 py-3 text-xs font-medium">
+								{order.reference}
+							</p>
+						)}
+						{order.deliveryStatus === "reprogrammed" && (
+							<div className="messenger-reference border-l-4 px-4 py-4 text-sm font-semibold">
+								<p className="messenger-muted mb-1 text-xs font-bold uppercase">
+									Nueva fecha y hora de entrega
+								</p>
+								<p className="font-black text-primary">
+									{formatDate(order.newDeliveryAt)}
+								</p>
 
-                            <p className="messenger-muted mb-1 mt-3 text-xs font-bold uppercase">
-                                Motivo de reprogramacion
-                            </p>
-                            <p>
-                                {order.reprogramReason || 'Sin motivo registrado'}
-                            </p>
+								<p className="messenger-muted mb-1 mt-3 text-xs font-bold uppercase">
+									Motivo de reprogramacion
+								</p>
+								<p>{order.reprogramReason || "Sin motivo registrado"}</p>
 
-                            <p className="messenger-muted mt-3 text-xs">
-                                Reprogramado el: {formatDate(order.reprogrammedAt)}
-                            </p>
-                        </div>
-                    )}
-                    </div>
-                </div>
+								<p className="messenger-muted mt-3 text-xs">
+									Reprogramado el: {formatDate(order.reprogrammedAt)}
+								</p>
+							</div>
+						)}
+					</div>
+				</div>
 
-                <div>
-                    <p className="messenger-muted mb-3 text-xs font-medium">Productos</p>
-                    <div className="space-y-3">
-                        {order.items.map((item) => (
-                            <p
-                                className="messenger-copy flex items-center gap-2 text-sm"
-                                key={item.id}
-                            >
-                                <Package size={16} />
-                                <span>
-                                    {item.quantity}x {item.name} — {formatBolivianos(item.price)}
-                                </span>
-                            </p>
-                        ))}
-                    </div>
+				<div>
+					<p className="messenger-muted mb-3 text-xs font-medium">Productos</p>
+					<div className="space-y-3">
+						{order.items.map((item) => (
+							<p
+								className="messenger-copy flex items-center gap-2 text-sm"
+								key={item.id}
+							>
+								<Package size={16} />
+								<span>
+									{item.quantity}x {item.name} — {formatBolivianos(item.price)}
+								</span>
+							</p>
+						))}
+					</div>
 
-                    <div className="messenger-cash-box mt-5 rounded-2xl border-2 p-5">
-                        <p className="text-xs font-medium uppercase">Monto a cobrar</p>
-                        <p className="mt-2 text-3xl font-black">
-                            {formatBolivianos(order.cashToCollect)}
-                        </p>
-                        <p className="messenger-copy mt-1 text-xs">en efectivo</p>
-                    </div>
-                </div>
-            </div>
+					<div className="messenger-cash-box mt-5 rounded-2xl border-2 p-5">
+						<p className="text-xs font-medium uppercase">Monto a cobrar</p>
+						<p className="mt-2 text-3xl font-black">
+							{formatBolivianos(order.cashToCollect)}
+						</p>
+						<p className="messenger-copy mt-1 text-xs">en efectivo</p>
+					</div>
+				</div>
+			</div>
 
-            <div className="mt-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-                    <a
-                        className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                        href={customerLocationUrl}
-                        onClick={() => storeBuyerMapOrder(order)}
-                    >
-                        <Send size={17} />
-                        Abrir Maps
-                    </a>
+			<div className="mt-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+				<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+					<a
+						className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+						href={customerLocationUrl}
+						onClick={() => storeBuyerMapOrder(order)}
+					>
+						<Send size={17} />
+						Abrir Maps
+					</a>
 
-                    <a
-                        className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                        href={buildDeliveryOrderDetailUrl(order.id)}
-                        onClick={(event) => {
-                            event.preventDefault();
-                            onDetail(order);
-                        }}
-                    >
-                        <Eye size={17} />
-                        Ver detalle
-                    </a>
+					<a
+						className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+						href={buildDeliveryOrderDetailUrl(order.id)}
+						onClick={(event) => {
+							event.preventDefault();
+							onDetail(order);
+						}}
+					>
+						<Eye size={17} />
+						Ver detalle
+					</a>
 
-                    {order.deliveryStatus === 'assigned' && (
-                        <>
-                            <button
-                                aria-disabled={acceptDisabled}
-                                className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
-                                onClick={() => {
-                                    if (acceptDisabled) {
-                                        setShowAcceptBlockedModal(true);
-                                    } else {
-                                        onAccept(order.id);
-                                    }
-                                }}
-                                type="button"
-                            >
-                                <CheckCircle2 size={17} />
-                                Aceptar pedido
-                            </button>
-                            {showAcceptBlockedModal && (
-                                <AcceptBlockedModal onClose={() => setShowAcceptBlockedModal(false)} />
-                            )}
-                            <button
-                                className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                onClick={() => onReject(order.id)}
-                                type="button"
-                            >
-                                <XCircle size={17} />
-                                Rechazar
-                            </button>
-                        </>
-                    )}
+					{order.deliveryStatus === "assigned" && (
+						<>
+							<button
+								aria-disabled={acceptDisabled}
+								className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+								onClick={() => {
+									if (acceptDisabled) {
+										setShowAcceptBlockedModal(true);
+									} else {
+										onAccept(order.id);
+									}
+								}}
+								type="button"
+							>
+								<CheckCircle2 size={17} />
+								Aceptar pedido
+							</button>
+							{showAcceptBlockedModal && (
+								<AcceptBlockedModal
+									onClose={() => setShowAcceptBlockedModal(false)}
+								/>
+							)}
+							<button
+								className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+								onClick={() => onReject(order.id)}
+								type="button"
+							>
+								<XCircle size={17} />
+								Rechazar
+							</button>
+						</>
+					)}
 
-                    {order.deliveryStatus === 'accepted' && (
-                        <button
-                            className="messenger-transit-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold shadow-lg transition hover:scale-[1.02]"
-                            onClick={() => onInTransit(order.id)}
-                            type="button"
-                        >
-                            <Truck size={17} />
-                            Iniciar entrega
-                        </button>
-                    )}
+					{order.deliveryStatus === "accepted" && (
+						<button
+							className="messenger-transit-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold shadow-lg transition hover:scale-[1.02]"
+							onClick={() => onInTransit(order.id)}
+							type="button"
+						>
+							<Truck size={17} />
+							Iniciar entrega
+						</button>
+					)}
 
-                    {order.deliveryStatus === 'in_transit' && (
-                        <>
-                            <button
-                                className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
-                                onClick={() => onDelivered(order)}
-                                type="button"
-                            >
-                                <CheckCircle2 size={17} />
-                                Registrar pago
-                            </button>
+					{order.deliveryStatus === "in_transit" && (
+						<>
+							<button
+								className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition"
+								onClick={() => onDelivered(order)}
+								type="button"
+							>
+								<CheckCircle2 size={17} />
+								Registrar pago
+							</button>
 
-                            <button
-                                className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                onClick={() => onNotDelivered(order)}
-                                type="button"
-                            >
-                                <AlertTriangle size={17} />
-                                No entregado
-                            </button>
-                        </>
-                    )}
-                </div>
-                <button
-                    className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                    disabled={!sellerData}
-                    onClick={openSellerMap}
-                    type="button"
-                >
-                    <Send size={17} />
-                    Ubi. Vendedor
-                </button>
-            </div>
-        </article>
-    );
+							<button
+								className="messenger-reject-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+								onClick={() => onNotDelivered(order)}
+								type="button"
+							>
+								<AlertTriangle size={17} />
+								No entregado
+							</button>
+						</>
+					)}
+				</div>
+				<button
+					className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+					disabled={!sellerData}
+					onClick={openSellerMap}
+					type="button"
+				>
+					<Send size={17} />
+					Ubi. Vendedor
+				</button>
+			</div>
+		</article>
+	);
 }
 
 // MODIFICADO: Se agregó la fecha de entrega
 function DeliveredOrderRow({ order }: { order: MessengerOrder }) {
-    const deliveryDate = order.paymentCollectedAt || order.updatedAt || order.createdAt;
-    return (
-        <article className="messenger-delivered-row flex items-center justify-between gap-4 rounded-[26px] border p-6 shadow-[0_10px_24px_rgba(18,32,56,0.06)]">
-            <div className="flex items-center gap-4">
-                <span className="messenger-icon inline-flex h-10 w-10 items-center justify-center rounded-full">
-                    <CheckCircle2 size={20} />
-                </span>
-                <div>
-                    <CopyableOrderId order={order} codeClassName="font-black" />
-                    <p className="messenger-copy text-sm">{order.customerName}</p>
-                    <p className="messenger-muted mt-1 text-xs">
-                        Entregado: {formatDate(deliveryDate)}
-                    </p>
-                </div>
-            </div>
-            <div className="flex shrink-0 items-center gap-4">
-                <span className="messenger-delivered-badge rounded-full px-3 py-1 text-xs font-bold">
-                    Entregado
-                </span>
-                <strong>{formatBolivianos(order.cashToCollect)}</strong>
-            </div>
-        </article>
-    );
+	const deliveryDate =
+		order.paymentCollectedAt || order.updatedAt || order.createdAt;
+	return (
+		<article className="messenger-delivered-row flex items-center justify-between gap-4 rounded-[26px] border p-6 shadow-[0_10px_24px_rgba(18,32,56,0.06)]">
+			<div className="flex items-center gap-4">
+				<span className="messenger-icon inline-flex h-10 w-10 items-center justify-center rounded-full">
+					<CheckCircle2 size={20} />
+				</span>
+				<div>
+					<CopyableOrderId order={order} codeClassName="font-black" />
+					<p className="messenger-copy text-sm">{order.customerName}</p>
+					<p className="messenger-muted mt-1 text-xs">
+						Entregado: {formatDate(deliveryDate)}
+					</p>
+				</div>
+			</div>
+			<div className="flex shrink-0 items-center gap-4">
+				<span className="messenger-delivered-badge rounded-full px-3 py-1 text-xs font-bold">
+					Entregado
+				</span>
+				<strong>{formatBolivianos(order.cashToCollect)}</strong>
+			</div>
+		</article>
+	);
 }
 
 function OrderDetailModal({
-    order,
-    onClose,
-    onDelivered,
-    onNotDelivered,
+	order,
+	onClose,
+	onDelivered,
+	onNotDelivered,
 }: {
-    order: MessengerOrder;
-    onClose: () => void;
-    onDelivered: (order: MessengerOrder) => void;
-    onNotDelivered: (order: MessengerOrder) => void;
+	order: MessengerOrder;
+	onClose: () => void;
+	onDelivered: (order: MessengerOrder) => void;
+	onNotDelivered: (order: MessengerOrder) => void;
 }) {
-    const subtotal = order.items.reduce(
-        (total, item) => total + item.price * item.quantity,
-        0
-    );
-    const deliveryCost = Math.max(order.cashToCollect - subtotal, 0);
+	const subtotal = order.items.reduce(
+		(total, item) => total + item.price * item.quantity,
+		0,
+	);
+	const deliveryCost = Math.max(order.cashToCollect - subtotal, 0);
 
-    return (
-        <div
-            className="fixed inset-0 z-[998] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-            onClick={(event) => {
-                if (event.target === event.currentTarget) onClose();
-            }}
-        >
-            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-                    <div>
-                        <h2 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
-                            Detalle de cobro del pedido
-                        </h2>
-                        <p className="text-sm font-semibold opacity-70">
-                            Verifica el pedido antes de marcarlo como entregado.
-                        </p>
-                    </div>
-                    <button
-                        aria-label="Cerrar detalle"
-                        className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-                        onClick={onClose}
-                        type="button"
-                    >
-                        <X size={16} />
-                    </button>
-                </header>
+	return (
+		<div
+			className="fixed inset-0 z-[998] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div>
+						<h2 className="text-xl font-black leading-tight tracking-normal sm:text-2xl">
+							Detalle de cobro del pedido
+						</h2>
+						<p className="text-sm font-semibold opacity-70">
+							Verifica el pedido antes de marcarlo como entregado.
+						</p>
+					</div>
+					<button
+						aria-label="Cerrar detalle"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-                <div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[minmax(0,1fr)_280px]">
-                    <div className="space-y-5">
-                        <article className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
-                            <div className="flex flex-wrap items-center gap-3">
-                                <CopyableOrderId order={order} codeClassName="text-lg font-black" />
-                                <span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
-                                    {formatDeliveryStatus(order.deliveryStatus)}
-                                </span>
-                                <span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
-                                    {order.paymentStatusLabel.toUpperCase()}
-                                </span>
-                            </div>
-                            <p className="messenger-muted mt-5 text-xs font-bold uppercase">
-                                Cliente
-                            </p>
-                            <p className="text-xl font-black">{order.customerName}</p>
-                        </article>
+				<div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+					<div className="space-y-5">
+						<article className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
+							<div className="flex flex-wrap items-center gap-3">
+								<CopyableOrderId
+									order={order}
+									codeClassName="text-lg font-black"
+								/>
+								<span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
+									{formatDeliveryStatus(order.deliveryStatus)}
+								</span>
+								<span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
+									{order.paymentStatusLabel.toUpperCase()}
+								</span>
+							</div>
+							<p className="messenger-muted mt-5 text-xs font-bold uppercase">
+								Cliente
+							</p>
+							<p className="text-xl font-black">{order.customerName}</p>
+						</article>
 
-                        {order.deliveryStatus === 'reprogrammed' && (
-                            <article className="rounded-[24px] border border-primary/40 bg-secondary-bg-light/40 p-5">
-                                <h3 className="mb-4 text-lg font-black text-primary">
-                                    Informacion de reprogramacion
-                                </h3>
+						{order.deliveryStatus === "reprogrammed" && (
+							<article className="rounded-[24px] border border-primary/40 bg-secondary-bg-light/40 p-5">
+								<h3 className="mb-4 text-lg font-black text-primary">
+									Informacion de reprogramacion
+								</h3>
 
-                                <div className="grid gap-4 sm:grid-cols-2">
-                                    <div>
-                                        <p className="messenger-muted text-xs font-bold uppercase">
-                                            Nueva fecha y hora
-                                        </p>
-                                        <p className="font-black">
-                                            {formatDate(order.newDeliveryAt)}
-                                        </p>
-                                    </div>
+								<div className="grid gap-4 sm:grid-cols-2">
+									<div>
+										<p className="messenger-muted text-xs font-bold uppercase">
+											Nueva fecha y hora
+										</p>
+										<p className="font-black">
+											{formatDate(order.newDeliveryAt)}
+										</p>
+									</div>
 
-                                    <div>
-                                        <p className="messenger-muted text-xs font-bold uppercase">
-                                            Reprogramado el
-                                        </p>
-                                        <p className="font-black">
-                                            {formatDate(order.reprogrammedAt)}
-                                        </p>
-                                    </div>
-                                </div>
+									<div>
+										<p className="messenger-muted text-xs font-bold uppercase">
+											Reprogramado el
+										</p>
+										<p className="font-black">
+											{formatDate(order.reprogrammedAt)}
+										</p>
+									</div>
+								</div>
 
-                                <div className="mt-4">
-                                    <p className="messenger-muted text-xs font-bold uppercase">
-                                        Motivo
-                                    </p>
-                                    <p className="font-semibold">
-                                        {order.reprogramReason || 'Sin motivo registrado'}
-                                    </p>
-                                </div>
-                            </article>
-                        )}
+								<div className="mt-4">
+									<p className="messenger-muted text-xs font-bold uppercase">
+										Motivo
+									</p>
+									<p className="font-semibold">
+										{order.reprogramReason || "Sin motivo registrado"}
+									</p>
+								</div>
+							</article>
+						)}
 
-                        <article className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
-                            <h3 className="mb-4 text-lg font-black">Productos</h3>
-                            {order.items.length > 0 ? (
-                                <div className="space-y-3">
-                                    {order.items.map((item) => (
-                                        <p
-                                            className="messenger-copy flex items-center gap-2 text-sm"
-                                            key={item.id}
-                                        >
-                                            <Package size={16} />
-                                            <span>
-                                                {item.quantity}x {item.name} -{' '}
-                                                {formatBolivianos(item.price)}
-                                            </span>
-                                        </p>
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-semibold">
-                                    Este pedido no tiene items visibles en el documento.
-                                </p>
-                            )}
-                        </article>
+						<article className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
+							<h3 className="mb-4 text-lg font-black">Productos</h3>
+							{order.items.length > 0 ? (
+								<div className="space-y-3">
+									{order.items.map((item) => (
+										<p
+											className="messenger-copy flex items-center gap-2 text-sm"
+											key={item.id}
+										>
+											<Package size={16} />
+											<span>
+												{item.quantity}x {item.name} -{" "}
+												{formatBolivianos(item.price)}
+											</span>
+										</p>
+									))}
+								</div>
+							) : (
+								<p className="rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-semibold">
+									Este pedido no tiene items visibles en el documento.
+								</p>
+							)}
+						</article>
 
-                        <article className="grid gap-4 rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5 sm:grid-cols-3">
-                            <div>
-                                <p className="messenger-muted text-xs font-bold uppercase">
-                                    Metodo de pago
-                                </p>
-                                <p className="font-black">Contra entrega</p>
-                            </div>
-                            <div>
-                                <p className="messenger-muted text-xs font-bold uppercase">
-                                    Metodo de envio
-                                </p>
-                                <p className="font-black">Delivery</p>
-                            </div>
-                            <div>
-                                <p className="messenger-muted text-xs font-bold uppercase">
-                                    Condiciones especiales
-                                </p>
-                                <p className="font-black">{order.reference || 'Ninguna'}</p>
-                            </div>
-                        </article>
+						<article className="grid gap-4 rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5 sm:grid-cols-3">
+							<div>
+								<p className="messenger-muted text-xs font-bold uppercase">
+									Metodo de pago
+								</p>
+								<p className="font-black">Contra entrega</p>
+							</div>
+							<div>
+								<p className="messenger-muted text-xs font-bold uppercase">
+									Metodo de envio
+								</p>
+								<p className="font-black">Delivery</p>
+							</div>
+							<div>
+								<p className="messenger-muted text-xs font-bold uppercase">
+									Condiciones especiales
+								</p>
+								<p className="font-black">{order.reference || "Ninguna"}</p>
+							</div>
+						</article>
 
-                        <div className="flex flex-col gap-3 sm:flex-row">
-                            <button
-                                className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                onClick={() => openDeliveryMap(order)}
-                                type="button"
-                            >
-                                <Send size={17} />
-                                Abrir en Maps
-                            </button>
-                        </div>
-                    </div>
+						<div className="flex flex-col gap-3 sm:flex-row">
+							<button
+								className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+								onClick={() => openDeliveryMap(order)}
+								type="button"
+							>
+								<Send size={17} />
+								Abrir en Maps
+							</button>
+						</div>
+					</div>
 
-                    <aside className="messenger-cash-box h-fit rounded-[24px] border-2 p-5">
-                        <p className="text-xs font-bold uppercase">Te llevas a cobrar</p>
-                        <p className="mt-2 text-3xl font-black">
-                            {formatBolivianos(order.cashToCollect)}
-                        </p>
-                        <p className="messenger-copy mt-1 text-xs">
-                            {order.items.length} items en este pedido
-                        </p>
-                        <div className="my-5 border-t border-border-light" />
-                        <div className="space-y-3 text-sm font-bold">
-                            <p className="flex justify-between gap-3">
-                                <span>Subtotal</span>
-                                <span>{formatBolivianos(subtotal)}</span>
-                            </p>
-                            <p className="flex justify-between gap-3">
-                                <span>Costo de entrega</span>
-                                <span>{formatBolivianos(deliveryCost)}</span>
-                            </p>
-                            <p className="flex justify-between gap-3">
-                                <span>Descuento</span>
-                                <span>{formatBolivianos(0)}</span>
-                            </p>
-                            <p className="flex justify-between gap-3 pt-4 text-primary">
-                                <span>Total final</span>
-                                <span>{formatBolivianos(order.cashToCollect)}</span>
-                            </p>
-                        </div>
+					<aside className="messenger-cash-box h-fit rounded-[24px] border-2 p-5">
+						<p className="text-xs font-bold uppercase">Te llevas a cobrar</p>
+						<p className="mt-2 text-3xl font-black">
+							{formatBolivianos(order.cashToCollect)}
+						</p>
+						<p className="messenger-copy mt-1 text-xs">
+							{order.items.length} items en este pedido
+						</p>
+						<div className="my-5 border-t border-border-light" />
+						<div className="space-y-3 text-sm font-bold">
+							<p className="flex justify-between gap-3">
+								<span>Subtotal</span>
+								<span>{formatBolivianos(subtotal)}</span>
+							</p>
+							<p className="flex justify-between gap-3">
+								<span>Costo de entrega</span>
+								<span>{formatBolivianos(deliveryCost)}</span>
+							</p>
+							<p className="flex justify-between gap-3">
+								<span>Descuento</span>
+								<span>{formatBolivianos(0)}</span>
+							</p>
+							<p className="flex justify-between gap-3 pt-4 text-primary">
+								<span>Total final</span>
+								<span>{formatBolivianos(order.cashToCollect)}</span>
+							</p>
+						</div>
 
-                        <div className="mt-6 flex flex-col gap-3">
-                            {order.deliveryStatus === 'in_transit' && (
-                                <button
-                                    className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition active:scale-95"
-                                    onClick={() => {
-                                        onDelivered(order);
-                                        onClose();
-                                    }}
-                                    type="button"
-                                >
-                                    <CheckCircle2 size={18} />
-                                    <span>Registrar pago</span>
-                                </button>
-                            )}
+						<div className="mt-6 flex flex-col gap-3">
+							{order.deliveryStatus === "in_transit" && (
+								<button
+									className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition active:scale-95"
+									onClick={() => {
+										onDelivered(order);
+										onClose();
+									}}
+									type="button"
+								>
+									<CheckCircle2 size={18} />
+									<span>Registrar pago</span>
+								</button>
+							)}
 
-                            {(order.deliveryStatus === 'accepted' ||
-                                order.deliveryStatus === 'in_transit') && (
-                                    <button
-                                        className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition active:scale-95"
-                                        onClick={() => {
-                                            onClose();
-                                            onNotDelivered(order);
-                                        }}
-                                        type="button"
-                                    >
-                                        <AlertTriangle size={18} />
-                                        <span>No entregado</span>
-                                    </button>
-                                )}
-                        </div>
-
-                    </aside>
-                </div>
-            </section>
-        </div>
-    );
+							{(order.deliveryStatus === "accepted" ||
+								order.deliveryStatus === "in_transit") && (
+								<button
+									className="messenger-reject-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition active:scale-95"
+									onClick={() => {
+										onClose();
+										onNotDelivered(order);
+									}}
+									type="button"
+								>
+									<AlertTriangle size={18} />
+									<span>No entregado</span>
+								</button>
+							)}
+						</div>
+					</aside>
+				</div>
+			</section>
+		</div>
+	);
 }
 
 function CloseShiftModal({
-    completedCount,
-    pendingCount,
-    notDeliveredCount,
-    cancelledCount,
-    totalCollected,
-    alreadyClosed,
-    isSaving,
-    onClose,
-    onConfirm,
+	completedCount,
+	pendingCount,
+	notDeliveredCount,
+	cancelledCount,
+	totalCollected,
+	alreadyClosed,
+	isSaving,
+	onClose,
+	onConfirm,
 }: {
-    completedCount: number;
-    pendingCount: number;
-    notDeliveredCount: number;
-    cancelledCount: number;
-    totalCollected: number;
-    alreadyClosed: boolean;
-    isSaving: boolean;
-    onClose: () => void;
-    onConfirm: () => void;
+	completedCount: number;
+	pendingCount: number;
+	notDeliveredCount: number;
+	cancelledCount: number;
+	totalCollected: number;
+	alreadyClosed: boolean;
+	isSaving: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
 }) {
-    return (
-        <div
-            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-            onClick={(event) => {
-                if (event.target === event.currentTarget && !isSaving) onClose();
-            }}
-        >
-            <section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-xl overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light p-4 text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
-                <header className="flex items-start justify-between gap-4">
-                    <div>
-                        <span className="messenger-icon mb-4 inline-flex h-14 w-14 items-center justify-center rounded-full">
-                            <CheckCircle2 size={28} />
-                        </span>
-                        <h2 className="text-2xl font-black tracking-[-0.04em]">
-                            ¿Cerrar jornada?
-                        </h2>
-                        <p className="messenger-copy mt-2 text-sm font-semibold">
-                            Se registrará el resumen de tus entregas realizadas durante la jornada actual.
-                        </p>
-                    </div>
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget && !isSaving) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape" && !isSaving) onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-xl overflow-y-auto rounded-[24px] border border-border-light bg-card-bg-light p-4 text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
+				<header className="flex items-start justify-between gap-4">
+					<div>
+						<span className="messenger-icon mb-4 inline-flex h-14 w-14 items-center justify-center rounded-full">
+							<CheckCircle2 size={28} />
+						</span>
+						<h2 className="text-2xl font-black tracking-[-0.04em]">
+							¿Cerrar jornada?
+						</h2>
+						<p className="messenger-copy mt-2 text-sm font-semibold">
+							Se registrará el resumen de tus entregas realizadas durante la
+							jornada actual.
+						</p>
+					</div>
 
-                    <button
-                        aria-label="Cerrar modal"
-                        className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-                        disabled={isSaving}
-                        onClick={onClose}
-                        type="button"
-                    >
-                        <X size={16} />
-                    </button>
-                </header>
+					<button
+						aria-label="Cerrar modal"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						disabled={isSaving}
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-                <div className="mt-6 space-y-3 rounded-[22px] border border-border-light bg-secondary-bg-light/40 p-5 text-sm font-bold">
-                    <p className="flex justify-between gap-4">
-                        <span>Entregas completadas</span>
-                        <span>{completedCount}</span>
-                    </p>
-                    <p className="flex justify-between gap-4">
-                        <span>Pedidos pendientes</span>
-                        <span>{pendingCount}</span>
-                    </p>
-                    <p className="flex justify-between gap-4">
-                        <span>No entregados</span>
-                        <span>{notDeliveredCount}</span>
-                    </p>
-                    <p className="flex justify-between gap-4">
-                        <span>Cancelados</span>
-                        <span>{cancelledCount}</span>
-                    </p>
-                    <div className="border-t border-border-light pt-3">
-                        <p className="flex justify-between gap-4 text-primary">
-                            <span>Total cobrado</span>
-                            <span>{formatBolivianos(totalCollected)}</span>
-                        </p>
-                    </div>
-                </div>
+				<div className="mt-6 space-y-3 rounded-[22px] border border-border-light bg-secondary-bg-light/40 p-5 text-sm font-bold">
+					<p className="flex justify-between gap-4">
+						<span>Entregas completadas</span>
+						<span>{completedCount}</span>
+					</p>
+					<p className="flex justify-between gap-4">
+						<span>Pedidos pendientes</span>
+						<span>{pendingCount}</span>
+					</p>
+					<p className="flex justify-between gap-4">
+						<span>No entregados</span>
+						<span>{notDeliveredCount}</span>
+					</p>
+					<p className="flex justify-between gap-4">
+						<span>Cancelados</span>
+						<span>{cancelledCount}</span>
+					</p>
+					<div className="border-t border-border-light pt-3">
+						<p className="flex justify-between gap-4 text-primary">
+							<span>Total cobrado</span>
+							<span>{formatBolivianos(totalCollected)}</span>
+						</p>
+					</div>
+				</div>
 
-                {alreadyClosed && (
-                    <p className="mt-5 rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-bold text-primary">
-                        La jornada de hoy ya fue cerrada. Puedes revisar el reporte en el historial.
-                    </p>
-                )}
+				{alreadyClosed && (
+					<p className="mt-5 rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-bold text-primary">
+						La jornada de hoy ya fue cerrada. Puedes revisar el reporte en el
+						historial.
+					</p>
+				)}
 
-                <footer className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-                    <button
-                        className="messenger-map-button inline-flex h-12 items-center justify-center rounded-2xl border-2 px-6 text-sm font-bold transition"
-                        disabled={isSaving}
-                        onClick={onClose}
-                        type="button"
-                    >
-                        Cancelar
-                    </button>
-                    <button
-                        className="messenger-deliver-button inline-flex h-12 items-center justify-center rounded-2xl px-6 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-60"
-                        disabled={isSaving || alreadyClosed}
-                        onClick={onConfirm}
-                        type="button"
-                    >
-                        {isSaving ? 'Cerrando jornada...' : 'Cerrar jornada'}
-                    </button>
-                </footer>
-            </section>
-        </div>
-    );
+				<footer className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+					<button
+						className="messenger-map-button inline-flex h-12 items-center justify-center rounded-2xl border-2 px-6 text-sm font-bold transition"
+						disabled={isSaving}
+						onClick={onClose}
+						type="button"
+					>
+						Cancelar
+					</button>
+					<button
+						className="messenger-deliver-button inline-flex h-12 items-center justify-center rounded-2xl px-6 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-60"
+						disabled={isSaving || alreadyClosed}
+						onClick={onConfirm}
+						type="button"
+					>
+						{isSaving ? "Cerrando jornada..." : "Cerrar jornada"}
+					</button>
+				</footer>
+			</section>
+		</div>
+	);
 }
 
 function ShiftReportDetailModal({
-    report,
-    onClose,
+	report,
+	onClose,
 }: {
-    report: MessengerShiftClosure;
-    onClose: () => void;
+	report: MessengerShiftClosure;
+	onClose: () => void;
 }) {
-    const allOrders = [
-        ...report.completedOrders,
-        ...report.pendingOrders,
-        ...report.incidentOrders,
-    ];
+	const allOrders = [
+		...report.completedOrders,
+		...report.pendingOrders,
+		...report.incidentOrders,
+	];
 
-    return (
-        <div
-            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-            onClick={(event) => {
-                if (event.target === event.currentTarget) onClose();
-            }}
-        >
-            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-                    <div>
-                        <p className="text-sm font-bold uppercase tracking-[0.24em] text-primary">
-                            Reporte de jornada
-                        </p>
-                        <h2 className="mt-2 text-xl font-black leading-tight tracking-[-0.04em] sm:text-2xl">
-                            Detalle de jornada - {formatDateKey(report.dateKey)}
-                        </h2>
-                        <p className="messenger-copy mt-1 text-sm font-semibold">
-                            Inicio: {formatTimeOnly(report.startedAt)} · Cierre: {formatTimeOnly(report.closedAt)}
-                        </p>
-                    </div>
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div>
+						<p className="text-sm font-bold uppercase tracking-[0.24em] text-primary">
+							Reporte de jornada
+						</p>
+						<h2 className="mt-2 text-xl font-black leading-tight tracking-[-0.04em] sm:text-2xl">
+							Detalle de jornada - {formatDateKey(report.dateKey)}
+						</h2>
+						<p className="messenger-copy mt-1 text-sm font-semibold">
+							Inicio: {formatTimeOnly(report.startedAt)} · Cierre:{" "}
+							{formatTimeOnly(report.closedAt)}
+						</p>
+					</div>
 
-                    <button
-                        aria-label="Cerrar detalle de jornada"
-                        className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-                        onClick={onClose}
-                        type="button"
-                    >
-                        <X size={16} />
-                    </button>
-                </header>
+					<button
+						aria-label="Cerrar detalle de jornada"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-                <div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-                    <aside className="h-fit rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
-                        <h3 className="text-lg font-black">Resumen</h3>
+				<div className="grid min-h-0 flex-1 gap-5 overflow-y-auto p-4 sm:p-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+					<aside className="h-fit rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5">
+						<h3 className="text-lg font-black">Resumen</h3>
 
-                        <div className="mt-5 space-y-3 text-sm font-bold">
-                            <p className="flex justify-between gap-3">
-                                <span>Completadas</span>
-                                <span>{report.summary.completedCount}</span>
-                            </p>
-                            <p className="flex justify-between gap-3">
-                                <span>Pendientes</span>
-                                <span>{report.summary.pendingCount}</span>
-                            </p>
-                            <p className="flex justify-between gap-3">
-                                <span>No entregadas</span>
-                                <span>{report.summary.notDeliveredCount}</span>
-                            </p>
-                            <p className="flex justify-between gap-3">
-                                <span>Canceladas</span>
-                                <span>{report.summary.cancelledCount}</span>
-                            </p>
-                            <div className="border-t border-border-light pt-3">
-                                <p className="flex justify-between gap-3 text-primary">
-                                    <span>Total cobrado</span>
-                                    <span>{formatBolivianos(report.summary.totalCollected)}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </aside>
+						<div className="mt-5 space-y-3 text-sm font-bold">
+							<p className="flex justify-between gap-3">
+								<span>Completadas</span>
+								<span>{report.summary.completedCount}</span>
+							</p>
+							<p className="flex justify-between gap-3">
+								<span>Pendientes</span>
+								<span>{report.summary.pendingCount}</span>
+							</p>
+							<p className="flex justify-between gap-3">
+								<span>No entregadas</span>
+								<span>{report.summary.notDeliveredCount}</span>
+							</p>
+							<p className="flex justify-between gap-3">
+								<span>Canceladas</span>
+								<span>{report.summary.cancelledCount}</span>
+							</p>
+							<div className="border-t border-border-light pt-3">
+								<p className="flex justify-between gap-3 text-primary">
+									<span>Total cobrado</span>
+									<span>{formatBolivianos(report.summary.totalCollected)}</span>
+								</p>
+							</div>
+						</div>
+					</aside>
 
-                    <div className="space-y-5">
-                        <h3 className="text-xl font-black">Pedidos registrados</h3>
+					<div className="space-y-5">
+						<h3 className="text-xl font-black">Pedidos registrados</h3>
 
-                        {allOrders.length > 0 ? (
-                            <div className="space-y-4">
-                                {allOrders.map((order) => (
-                                    <article
-                                        className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5"
-                                        key={`${report.id}-${order.deliveryId}`}
-                                    >
-                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                            <div>
-                                                <p className="font-mono text-xs font-bold opacity-50">
-                                                    {order.id}
-                                                </p>
-                                                <h4 className="text-lg font-black">
-                                                    {order.customerName}
-                                                </h4>
-                                                <p className="messenger-copy text-sm">
-                                                    {order.address}
-                                                </p>
-                                            </div>
+						{allOrders.length > 0 ? (
+							<div className="space-y-4">
+								{allOrders.map((order) => (
+									<article
+										className="rounded-[24px] border border-border-light bg-secondary-bg-light/40 p-5"
+										key={`${report.id}-${order.deliveryId}`}
+									>
+										<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+											<div>
+												<p className="font-mono text-xs font-bold opacity-50">
+													{order.id}
+												</p>
+												<h4 className="text-lg font-black">
+													{order.customerName}
+												</h4>
+												<p className="messenger-copy text-sm">
+													{order.address}
+												</p>
+											</div>
 
-                                            <div className="flex flex-wrap gap-2">
-                                                <span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
-                                                    {formatDeliveryStatus(order.deliveryStatus)}
-                                                </span>
-                                                <span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
-                                                    {order.paymentStatusLabel.toUpperCase()}
-                                                </span>
-                                            </div>
-                                        </div>
+											<div className="flex flex-wrap gap-2">
+												<span className="messenger-status-badge rounded-full px-3 py-1 text-xs font-bold">
+													{formatDeliveryStatus(order.deliveryStatus)}
+												</span>
+												<span className="messenger-charge-badge rounded-full px-3 py-1 text-xs font-bold">
+													{order.paymentStatusLabel.toUpperCase()}
+												</span>
+											</div>
+										</div>
 
-                                        <div className="mt-4 grid gap-4 md:grid-cols-[1fr_180px]">
-                                            <div>
-                                                <p className="messenger-muted mb-2 text-xs font-bold uppercase">
-                                                    Productos
-                                                </p>
-                                                {order.items.length > 0 ? (
-                                                    <div className="space-y-2">
-                                                        {order.items.map((item) => (
-                                                            <p
-                                                                className="messenger-copy flex items-center gap-2 text-sm"
-                                                                key={item.id}
-                                                            >
-                                                                <Package size={15} />
-                                                                <span>
-                                                                    {item.quantity}x {item.name} - {formatBolivianos(item.price)}
-                                                                </span>
-                                                            </p>
-                                                        ))}
-                                                    </div>
-                                                ) : (
-                                                    <p className="messenger-copy text-sm">
-                                                        Sin productos visibles.
-                                                    </p>
-                                                )}
-                                            </div>
+										<div className="mt-4 grid gap-4 md:grid-cols-[1fr_180px]">
+											<div>
+												<p className="messenger-muted mb-2 text-xs font-bold uppercase">
+													Productos
+												</p>
+												{order.items.length > 0 ? (
+													<div className="space-y-2">
+														{order.items.map((item) => (
+															<p
+																className="messenger-copy flex items-center gap-2 text-sm"
+																key={item.id}
+															>
+																<Package size={15} />
+																<span>
+																	{item.quantity}x {item.name} -{" "}
+																	{formatBolivianos(item.price)}
+																</span>
+															</p>
+														))}
+													</div>
+												) : (
+													<p className="messenger-copy text-sm">
+														Sin productos visibles.
+													</p>
+												)}
+											</div>
 
-                                            <div className="messenger-cash-box rounded-2xl border-2 p-4">
-                                                <p className="text-xs font-bold uppercase">
-                                                    Monto
-                                                </p>
-                                                <p className="mt-1 text-2xl font-black">
-                                                    {formatBolivianos(order.cashToCollect)}
-                                                </p>
-                                                <p className="messenger-copy mt-1 text-xs">
-                                                    Cobrado: {formatTimeOnly(order.paymentCollectedAt)}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </article>
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
-                                Esta jornada no tiene pedidos registrados.
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </section>
-        </div>
-    );
+											<div className="messenger-cash-box rounded-2xl border-2 p-4">
+												<p className="text-xs font-bold uppercase">Monto</p>
+												<p className="mt-1 text-2xl font-black">
+													{formatBolivianos(order.cashToCollect)}
+												</p>
+												<p className="messenger-copy mt-1 text-xs">
+													Cobrado: {formatTimeOnly(order.paymentCollectedAt)}
+												</p>
+											</div>
+										</div>
+									</article>
+								))}
+							</div>
+						) : (
+							<div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
+								Esta jornada no tiene pedidos registrados.
+							</div>
+						)}
+					</div>
+				</div>
+			</section>
+		</div>
+	);
 }
 interface MessengerDashboardProps {
-    embedded?: boolean;
-    clientSection?: 'assigned' | 'accepted' | 'reprogrammed' | 'delivered' | 'not_delivered';
+	embedded?: boolean;
+	clientSection?:
+		| "assigned"
+		| "accepted"
+		| "reprogrammed"
+		| "delivered"
+		| "not_delivered";
 }
 
 export default function MessengerDashboard({
-    embedded = false,
-    clientSection = 'assigned',
+	embedded = false,
+	clientSection = "assigned",
 }: MessengerDashboardProps) {
-    const [orders, setOrders] = useState<MessengerOrder[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [message, setMessage] = useState('');
-    const [detailOrder, setDetailOrder] = useState<MessengerOrder | null>(null);
-    const [undeliveredOrder, setUndeliveredOrder] =
-        useState<MessengerOrder | null>(null);
-    const [savingUndelivered, setSavingUndelivered] = useState(false);
-    const [confirmPaymentOrder, setConfirmPaymentOrder] = useState<MessengerOrder | null>(null);
-    const [paymentSuccessOrder, setPaymentSuccessOrder] = useState<MessengerOrder | null>(null);
-    const [pendingAssignedAction, setPendingAssignedAction] = useState<{
-        order: MessengerOrder;
-        action: AssignedOrderAction;
-    } | null>(null);
-    const [savingAssignedAction, setSavingAssignedAction] = useState(false);
-    const [currentCourierId, setCurrentCourierId] = useState<string | null>(null);
-    const [newOrderCount, setNewOrderCount] = useState(0);
-    const [acceptedSortOrder, setAcceptedSortOrder] =
-        useState<AcceptedOrderSort>('newest-first');
-    const [showCloseShiftModal, setShowCloseShiftModal] = useState(false);
-    const [savingShiftClose, setSavingShiftClose] = useState(false);
-    const [shiftReports, setShiftReports] = useState<MessengerShiftClosure[]>([]);
-    const [selectedShiftReport, setSelectedShiftReport] =
-    useState<MessengerShiftClosure | null>(null);
-    const notifiedOrderIdsRef = useRef<Set<string>>(new Set());
-    const isFirstLoadRef = useRef(true);
-
-    useEffect(() => {
-        let unsubscribeOrders: (() => void) | undefined;
-
-        const startOrdersSubscription = (
-            courierId: string,
-            allowDevFallback = false
-        ) => {
-            setLoading(true);
-            setMessage('');
-
-            unsubscribeOrders?.();
-
-            unsubscribeOrders = subscribeToMessengerOrders(
-                courierId,
-                (data) => {
-                    if (
-                        data.length === 0 &&
-                        allowDevFallback &&
-                        import.meta.env.PUBLIC_APP_ENV !== 'production' &&
-                        courierId !== DEV_COURIER_ID
-                    ) {
-                        startOrdersSubscription(DEV_COURIER_ID, false);
-                        return;
-                    }
-
-                    setOrders(data);
-                    setLoading(false);
-                },
-                (error) => {
-                    console.error(error);
-                    setOrders([]);
-                    setLoading(false);
-                    setMessage('No se pudieron cargar las entregas del emulador.');
-                }
-            );
-        };
-
-
-        const unsubscribeAuth = onAuthStateChanged(auth, (user) => {
-            const devCourierId =
-                import.meta.env.PUBLIC_APP_ENV !== 'production' ? DEV_COURIER_ID : null;
-            const courierId = user?.uid || devCourierId;
-            const allowDevFallback = !user;
-
-            setCurrentCourierId(courierId);
-
-            if (!courierId) {
-                unsubscribeOrders?.();
-                setOrders([]);
-                setLoading(false);
-                setMessage('Inicia sesion para ver tus entregas asignadas.');
-                return;
-            }
-
-            startOrdersSubscription(courierId, allowDevFallback);
-        });
-
-        return () => {
-            unsubscribeOrders?.();
-            unsubscribeAuth();
-        };
-    }, []);
-
-    useEffect(() => {
-        if (!currentCourierId) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setShiftReports([]);
-            return;
-        }
-
-        const unsubscribeReports = subscribeToMessengerShiftClosures(
-            currentCourierId,
-            setShiftReports,
-            (error) => {
-                console.error(error);
-                setMessage('No se pudo cargar el historial de jornadas.');
-            }
-        );
-
-        return () => {
-            unsubscribeReports();
-        };
-    }, [currentCourierId]);
-
-    const assignedOrders = useMemo(
-        () =>
-            sortAcceptedOrdersByAge(
-                orders.filter((order) => order.deliveryStatus === 'assigned'),
-                'newest-first'
-            ),
-        [orders]
-    );
-
-    // Un pedido `accepted` o `in_transit` cuenta como entrega activa y
-    // deshabilita la aceptación de otros pedidos asignados (pre-check de UX;
-    // la validación autoritativa vive en acceptMessengerOrder, en el servicio).
-    const hasActiveDelivery = useMemo(
-        () => hasActiveMessengerDelivery(orders),
-        [orders]
-    );
-
-    const assignedOrderIdsKey = useMemo(
-        () =>
-            assignedOrders
-                .map((order) => order.deliveryId || order.id)
-                .sort()
-                .join('|'),
-        [assignedOrders]
-    );
-
-    useEffect(() => {
-        if (loading || clientSection !== 'assigned') return;
-
-        const currentOrderIds = assignedOrderIdsKey
-            ? assignedOrderIdsKey.split('|')
-            : [];
-
-        // Primera carga: mostrar toast si hay pedidos, sin filtrar por sesión previa
-        if (isFirstLoadRef.current) {
-            isFirstLoadRef.current = false;
-
-            if (currentOrderIds.length === 0) return;
-
-            // Marcar todos como notificados para futuras comparaciones
-            const storageKey = 'sansistore:messenger:notified-order-ids';
-            const updatedIds = Array.from(new Set(currentOrderIds));
-            try {
-                sessionStorage.setItem(storageKey, JSON.stringify(updatedIds));
-            } catch { /* ignorar */ }
-            notifiedOrderIdsRef.current = new Set(updatedIds);
-
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setNewOrderCount(currentOrderIds.length);
-            return;
-        }
-
-        // Cargas posteriores: solo nuevos pedidos que no se habían notificado
-        if (currentOrderIds.length === 0) {
-            setNewOrderCount(0);
-            return;
-        }
-
-        const storageKey = 'sansistore:messenger:notified-order-ids';
-        let storedIds: string[] = [];
-        try {
-            storedIds = JSON.parse(sessionStorage.getItem(storageKey) || '[]') as string[];
-        } catch {
-            storedIds = [];
-        }
-
-        const alreadyNotifiedIds = new Set([
-            ...storedIds,
-            ...Array.from(notifiedOrderIdsRef.current),
-        ]);
-
-        const newIds = currentOrderIds.filter((id) => !alreadyNotifiedIds.has(id));
-        if (newIds.length === 0) return;
-
-        const updatedIds = Array.from(new Set([...storedIds, ...currentOrderIds]));
-        try {
-            sessionStorage.setItem(storageKey, JSON.stringify(updatedIds));
-        } catch { /* ignorar */ }
-        notifiedOrderIdsRef.current = new Set(updatedIds);
-        setNewOrderCount(newIds.length);
-    }, [assignedOrderIdsKey, clientSection, loading]);
-
-    const acceptedOrders = useMemo(
-        () =>
-            orders.filter(
-                (order) =>
-                    order.deliveryStatus === 'accepted' ||
-                    order.deliveryStatus === 'in_transit'
-            ),
-        [orders]
-    );
-    const sortedAcceptedOrders = useMemo(
-        () => sortAcceptedOrdersByAge(acceptedOrders, acceptedSortOrder),
-        [acceptedOrders, acceptedSortOrder]
-    );
-
-    // ✅ MODIFICADO: Se agregó ordenamiento por fecha descendente
-    const deliveredOrders = useMemo(
-        () => orders
-            .filter(isMessengerOrderCollected)
-            .sort((a, b) => {
-                const dateA = a.paymentCollectedAt;
-                const dateB = b.paymentCollectedAt;
-                if (!dateA || !dateB) return 0;
-                return dateB.getTime() - dateA.getTime();
-            }),
-        [orders]
-    );
-    const todayCollectedOrders = useMemo(
-        () => getCollectedOrdersForDay(orders),
-        [orders]
-    );
-    const todayCollectedTotal = useMemo(
-        () => getCollectedTotalForDay(orders),
-        [orders]
-    );
-    const collectedTotal = useMemo(() => getCollectedTotal(orders), [orders]);
-    const todayDateKey = useMemo(() => getLocalDateKey(new Date()), []);
-
-    const todayShiftReport = useMemo(
-        () => shiftReports.find((report) => report.dateKey === todayDateKey) ?? null,
-        [shiftReports, todayDateKey]
-    );
-
-    const currentShiftPendingOrders = useMemo(
-        () =>
-            orders.filter(
-                (order) =>
-                    order.deliveryStatus === 'assigned' ||
-                    order.deliveryStatus === 'accepted' ||
-                    order.deliveryStatus === 'in_transit'
-            ),
-        [orders]
-    );
-
-    const currentShiftNotDeliveredOrders = useMemo(
-        () => orders.filter((order) => order.deliveryStatus === 'not_delivered'),
-        [orders]
-    );
-
-    const currentShiftCancelledOrders = useMemo(
-        () => orders.filter((order) => order.deliveryStatus === 'cancelled'),
-        [orders]
-    );
-
-    const currentShiftActivityCount =
-        todayCollectedOrders.length +
-        currentShiftPendingOrders.length +
-        currentShiftNotDeliveredOrders.length +
-        currentShiftCancelledOrders.length;
-    const currentCourierActiveDeliveryCount = useMemo(() => {
-        if (!currentCourierId) return 0;
-
-        const counts = countActiveDeliveriesByCourier(
-            orders.map((order) => ({
-                courierId: currentCourierId,
-                status: order.deliveryStatus,
-            }))
-        );
-
-        return counts[currentCourierId] ?? 0;
-    }, [currentCourierId, orders]);
-    const isCurrentCourierAvailable = isCourierAvailableFromActiveCount(
-        currentCourierActiveDeliveryCount
-    );
-
-    const notDeliveredOrders = useMemo(
-        () =>
-            sortAcceptedOrdersByAge(
-                orders.filter((order) => order.deliveryStatus === 'not_delivered'),
-                'newest-first'
-            ),
-        [orders]
-    );
-
-    const reprogrammedOrders = useMemo(
-        () =>
-            orders
-                .filter((order) => order.deliveryStatus === 'reprogrammed')
-                .sort((a, b) => {
-                    const dateA =
-                        a.newDeliveryAt?.getTime() ??
-                        a.updatedAt?.getTime() ??
-                        a.createdAt?.getTime() ??
-                        0;
-
-                    const dateB =
-                        b.newDeliveryAt?.getTime() ??
-                        b.updatedAt?.getTime() ??
-                        b.createdAt?.getTime() ??
-                        0;
-
-                    return dateA - dateB;
-                }),
-        [orders]
-    );
-
-    const updateOrderStatus = async (
-        orderId: string,
-        status: MessengerOrder['deliveryStatus'],
-        options: { redirectToDetail?: boolean; reason?: string } = {}
-        ) => {
-        const targetOrder = orders.find((order) => order.id === orderId);
-        if (!targetOrder) return;
-
-        setOrders((currentOrders) =>
-            currentOrders.map((order) =>
-            order.id === orderId
-                ? {
-                    ...order,
-                    deliveryStatus: status,
-                    ...(status === 'pending_reassignment' && options.reason
-                    ? { rejectionReason: options.reason }
-                    : {}),
-                }
-                : order
-            )
-        );
-
-        try {
-            if (status === 'accepted') {
-                // Aceptar pasa por el punto único del servicio, que revalida
-                // contra Firestore que no haya otra entrega activa antes de
-                // escribir. Así la regla se cumple aunque el estado local esté
-                // desactualizado (p. ej. otra pantalla abierta en paralelo).
-                if (!currentCourierId) {
-                    throw new Error('No se pudo identificar al mensajero.');
-                }
-                await acceptMessengerOrder(targetOrder, currentCourierId);
-            } else {
-                // Pasar el motivo a Firestore si es rechazo
-                await setMessengerOrderStatus(
-                    targetOrder,
-                    status,
-                    status === 'pending_reassignment' ? options.reason : undefined
-                );
-            }
-            setMessage(getStatusUpdateMessage(status));
-            if (options.redirectToDetail) {
-                navigateToDeliveryOrderDetail(orderId);
-            }
-        } catch (error) {
-            console.error(error);
-            setMessage(
-                error instanceof Error
-                    ? error.message
-                    : 'No se pudo actualizar el estado en Firestore.'
-            );
-            setOrders((currentOrders) =>
-            currentOrders.map((order) =>
-                order.id === orderId ? targetOrder : order
-            )
-            );
-        }
-        };
-
-    const markAsDelivered = (order: MessengerOrder) => {
-        setConfirmPaymentOrder(order);
-    };
-
-    const confirmPayment = async (order: MessengerOrder, secret: string) => {
-        if (!currentCourierId) {
-            throw new Error('No se pudo identificar al mensajero.');
-        }
-
-        if (order.paymentStatusLabel === 'Cobrado') {
-            throw new Error('Este pedido ya tiene el pago registrado.');
-        }
-
-        // Validar secret contra order.secret (campo del tipo Order)
-        if (secret !== order.secret) {
-            throw new Error('Código incorrecto.');
-        }
-
-        const previousOrder = order;
-        setOrders((currentOrders) =>
-            currentOrders.map((currentOrder) =>
-                currentOrder.id === order.id
-                    ? {
-                        ...currentOrder,
-                        deliveryStatus: 'delivered',
-                        paymentStatus: 'COBRADO',
-                        paymentStatusLabel: 'Cobrado',
-                        collectedBy: currentCourierId,
-                        paymentCollectedAt: new Date(),
-                    }
-                    : currentOrder
-            )
-        );
-
-        try {
-            await registerMessengerCashPayment(order, currentCourierId);
-
-            setConfirmPaymentOrder(null);
-
-            setPaymentSuccessOrder(order);
-
-        } catch (error) {
-            console.error(error);
-            setOrders((currentOrders) =>
-                currentOrders.map((currentOrder) =>
-                    currentOrder.id === previousOrder.id ? previousOrder : currentOrder
-                )
-            );
-            throw error; // el modal captura y muestra el error
-        }
-    };
-
-
-    const openAssignedActionConfirmation = (
-        orderId: string,
-        action: AssignedOrderAction
-    ) => {
-        const order = orders.find((currentOrder) => currentOrder.id === orderId);
-        if (!order || order.deliveryStatus !== 'assigned') return;
-
-        setPendingAssignedAction({ order, action });
-    };
-
-    const acceptOrder = (orderId: string) => {
-        openAssignedActionConfirmation(orderId, 'accept');
-    };
-
-    const markAsInTransit = (orderId: string) => {
-        void updateOrderStatus(orderId, 'in_transit', { redirectToDetail: true });
-    };
-
-    const rejectOrder = (orderId: string) => {
-        openAssignedActionConfirmation(orderId, 'reject');
-    };
-
-    const confirmAssignedOrderAction = async (reason?: string) => {
-        if (!pendingAssignedAction || savingAssignedAction) return;
-
-        const { order, action } = pendingAssignedAction;
-        
-        // Si es rechazo y no hay motivo, no continuar
-        if (action === 'reject' && !reason?.trim()) {
-            setMessage('Debes seleccionar un motivo para rechazar el pedido.');
-            return;
-        }
-
-    const nextStatus =
-        action === 'accept' ? 'accepted' : 'pending_reassignment';
-
-    setSavingAssignedAction(true);
-    try {
-        // Pasar el motivo al updateOrderStatus
-        await updateOrderStatus(order.id, nextStatus, { 
-        redirectToDetail: true,
-        reason: action === 'reject' ? reason : undefined 
-        });
-        setPendingAssignedAction(null);
-    } finally {
-        setSavingAssignedAction(false);
-    }
-    };
-
-    const registerUndeliveredOrder = async (reason: string, notes: string) => {
-        if (!undeliveredOrder) return;
-        if (!currentCourierId) {
-            setMessage(
-                'No se pudo identificar al mensajero para registrar el problema.'
-            );
-            return;
-        }
-
-        const targetOrder = undeliveredOrder;
-        setSavingUndelivered(true);
-        setOrders((currentOrders) =>
-            currentOrders.map((order) =>
-                order.id === targetOrder.id
-                    ? { ...order, deliveryStatus: 'not_delivered' }
-                    : order
-            )
-        );
-
-        try {
-            await markMessengerOrderAsNotDelivered({
-                order: targetOrder,
-                reason,
-                notes,
-                courierId: currentCourierId,
-            });
-            setMessage('Problema registrado y pedido marcado como no entregado.');
-            setUndeliveredOrder(null);
-            navigateToDeliveryOrderDetail(targetOrder.id);
-        } catch (error) {
-            console.error(error);
-            setMessage('No se pudo registrar el incidente en Firestore.');
-            setOrders((currentOrders) =>
-                currentOrders.map((order) =>
-                    order.id === targetOrder.id ? targetOrder : order
-                )
-            );
-        } finally {
-            setSavingUndelivered(false);
-        }
-    };
-
-    const confirmCloseShift = async () => {
-        if (!currentCourierId) {
-            setMessage('No se pudo identificar al mensajero para cerrar la jornada.');
-            return;
-        }
-
-        if (todayShiftReport) {
-            setMessage('La jornada de hoy ya fue cerrada.');
-            setShowCloseShiftModal(false);
-            setSelectedShiftReport(todayShiftReport);
-            return;
-        }
-
-        setSavingShiftClose(true);
-
-        try {
-            const report = await closeMessengerShift({
-                courierId: currentCourierId,
-                orders,
-            });
-
-            setShowCloseShiftModal(false);
-            setSelectedShiftReport(report);
-            setMessage('Jornada cerrada correctamente. El reporte ya está disponible en el historial.');
-        } catch (error) {
-            console.error(error);
-            setMessage(
-                error instanceof Error
-                    ? error.message
-                    : 'No se pudo cerrar la jornada.'
-            );
-        } finally {
-            setSavingShiftClose(false);
-        }
-    };
-
-    const activeOrders =
-        clientSection === 'assigned'
-            ? assignedOrders
-            : clientSection === 'not_delivered'
-                ? notDeliveredOrders
-                : clientSection === 'reprogrammed'
-                    ? reprogrammedOrders
-                    : sortedAcceptedOrders;
-    const activeTitle =
-        clientSection === 'assigned'
-            ? 'Gestión Entregas'
-            : clientSection === 'accepted'
-                ? 'Pedidos aceptados'
-                : clientSection === 'reprogrammed'
-                    ? 'Pedidos reprogramados'
-                    : clientSection === 'not_delivered'
-                        ? 'No entregados'
-                        : 'Entregados';
-    const activeDescription =
-        clientSection === 'assigned'
-            ? 'Acepta o rechaza los pedidos asignados antes de iniciar la entrega.'
-            : clientSection === 'accepted'
-                ? 'Organiza tus entregas, revisa direcciones y cambia el estado de cada pedido.'
-                : clientSection === 'reprogrammed'
-                    ? 'Revisa los pedidos que tienen una nueva fecha u hora de entrega.'
-                    : clientSection === 'not_delivered'
-                        ? 'Revisa los pedidos con incidente registrado durante la jornada.'
-                        : 'Revisa las entregas completadas y el monto cobrado durante la jornada.';
-
-    return (
-        <main
-            className={`messenger-dashboard ${embedded ? 'messenger-dashboard--embedded' : 'min-h-[100dvh]'}`}
-        >
-            {newOrderCount > 0 && clientSection === 'assigned' && (
-                <NewOrderToast
-                    count={newOrderCount}
-                    onDismiss={() => setNewOrderCount(0)}
-                />
-            )}
-            {!embedded && (
-                <header className="messenger-header border-b">
-                    <div className="messenger-header-inner flex items-center justify-between">
-                        <a className="text-xl font-black tracking-normal" href="/">
-                            sansi <span className="messenger-logo-accent">store</span>
-                        </a>
-
-                        <div className="flex gap-2">
-                            <a
-                                className="messenger-buyer-link inline-flex h-10 items-center justify-center rounded-full border px-6 text-sm font-bold"
-                                href="/"
-                            >
-                                Comprador
-                            </a>
-                            <a
-                                className="messenger-courier-link inline-flex h-10 items-center justify-center rounded-full px-6 text-sm font-bold"
-                                href="/courier"
-                            >
-                                Mensajero
-                            </a>
-                        </div>
-                    </div>
-                </header>
-            )}
-
-            <div className="messenger-container">
-                <section className="mb-10">
-                    <p className="text-sm font-bold uppercase tracking-[0.28em] text-primary">
-                        Operacion de entregas
-                    </p>
-                    <h1 className="mt-4 text-4xl font-black tracking-[-0.04em] sm:text-5xl">
-                        {activeTitle}
-                    </h1>
-                    <p className="messenger-copy mt-2 max-w-2xl text-sm font-semibold">
-                        {activeDescription}
-                    </p>
-                </section>
-
-                {message && (
-                    <MessageToast message={message} onDismiss={() => setMessage('')} />
-                )}
-
-                {loading && (
-                    <div className="messenger-order-card mt-6 rounded-[26px] border p-8 text-sm font-semibold">
-                        Cargando entregas...
-                    </div>
-                )}
-
-                {!loading && clientSection !== 'delivered' ? (
-                    <>
-                        <section className="messenger-summary-grid grid gap-5">
-                            <SummaryCard
-                                icon={<Clock3 size={20} />}
-                                label={
-                                    clientSection === 'assigned' ? 'Asignados' 
-                                    : clientSection === 'reprogrammed' ? 'Reprogramados'
-                                    : clientSection === 'not_delivered' ? 'No entregados'
-                                    : 'Pendientes'
-                                }
-                                value={activeOrders.length}
-                            />
-                            <SummaryCard
-                                featured
-                                icon={<DollarSign size={20} />}
-                                label="Total a Cobrar"
-                                value={formatBolivianos(
-                                    activeOrders.reduce(
-                                        (total, order) => total + order.cashToCollect,
-                                        0
-                                    )
-                                )}
-                            />
-                            <SummaryCard
-                                icon={
-                                    isCurrentCourierAvailable ? (
-                                        <CheckCircle2 size={20} />
-                                    ) : (
-                                        <Truck size={20} />
-                                    )
-                                }
-                                label="Disponibilidad"
-                                value={
-                                    isCurrentCourierAvailable ? 'Disponible' : 'Ocupado'
-                                }
-                            />
-                        </section>
-
-                        <section className="mt-11">
-                            <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                                <h2 className="text-2xl font-black tracking-[-0.04em]">
-                                    {clientSection === 'assigned'
-                                        ? 'Pedidos asignados'
-                                        : clientSection === 'reprogrammed'
-                                            ? 'Pedidos reprogramados'
-                                            : clientSection === 'not_delivered'
-                                                ? 'Pedidos no entregados'
-                                                : 'Pedidos pendientes'}
-                                </h2>
-
-                                {clientSection === 'accepted' && activeOrders.length > 0 && (
-                                    <label className="flex w-full flex-col gap-2 text-sm font-bold text-text-light sm:w-auto sm:flex-row sm:items-center">
-                                        <span className="messenger-muted">Ordenar por</span>
-                                        <select
-                                            value={acceptedSortOrder}
-                                            onChange={(event) =>
-                                                setAcceptedSortOrder(
-                                                    event.target.value as AcceptedOrderSort
-                                                )
-                                            }
-                                            className="rounded-2xl border-2 border-border-light bg-card-bg-light px-4 py-3 text-sm font-bold text-text-light outline-none transition focus:border-primary"
-                                        >
-                                            <option value="oldest-first">
-                                                Más antiguos primero
-                                            </option>
-                                            <option value="newest-first">
-                                                Más recientes primero
-                                            </option>
-                                        </select>
-                                    </label>
-                                )}
-                            </div>
-
-                            <div className="space-y-6">
-                                {activeOrders.length > 0 ? (
-                                    activeOrders.map((order) => (
-                                        <PendingOrderCard
-                                            key={`${clientSection}-${order.deliveryId || order.id}`}
-                                            order={order}
-                                            onAccept={acceptOrder}
-                                            acceptDisabled={hasActiveDelivery}
-                                            onDelivered={markAsDelivered}
-                                            onDetail={(order) =>
-                                                navigateToDeliveryOrderDetail(order.id)
-                                            }
-                                            onInTransit={markAsInTransit}
-                                            onNotDelivered={setUndeliveredOrder}
-                                            onReject={rejectOrder}
-                                        />
-                                    ))
-                                ) : (
-                                    <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
-                                        {clientSection === 'assigned'
-                                            ? 'No hay pedidos asignados.'
-                                            : clientSection === 'reprogrammed'
-                                                ? 'No hay pedidos reprogramados.'
-                                                : clientSection === 'not_delivered'
-                                                    ? 'No hay pedidos no entregados.'
-                                                    : 'No hay pedidos pendientes.'}
-                                    </div>
-                                )}
-                            </div>
-                        </section>
-                    </>
-                ) : !loading ? (
-                    <>
-                        <section className="messenger-summary-grid grid gap-5">
-                            <SummaryCard
-                                icon={<CheckCircle2 size={20} />}
-                                label="Cobrados en la jornada"
-                                value={todayCollectedOrders.length}
-                            />
-                            <SummaryCard
-                                icon={<CheckCircle2 size={20} />}
-                                label="Cobrado en la jornada"
-                                value={formatBolivianos(todayCollectedTotal)}
-                            />
-                            <SummaryCard
-                                featured
-                                icon={<DollarSign size={20} />}
-                                label="Total cobrado"
-                                value={formatBolivianos(collectedTotal)}
-                            />
-
-                        </section>
-
-                        <section className="mt-8 rounded-[28px] border border-border-light bg-card-bg-light p-6 shadow-[0_14px_30px_rgba(38,33,22,0.08)]">
-                            <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-                                <div>
-                                    <p className="text-sm font-bold uppercase tracking-[0.22em] text-primary">
-                                        Cierre de jornada
-                                    </p>
-                                    <h2 className="mt-2 text-2xl font-black tracking-[-0.04em]">
-                                        Registrar cierre del día
-                                    </h2>
-                                    <p className="messenger-copy mt-2 max-w-2xl text-sm font-semibold">
-                                        Guarda un reporte con tus entregas completadas, pendientes, no entregadas, canceladas y el total cobrado.
-                                    </p>
-
-                                    {todayShiftReport && (
-                                        <p className="mt-4 rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-bold text-primary">
-                                            La jornada de hoy ya fue cerrada a las {formatTimeOnly(todayShiftReport.closedAt)}.
-                                        </p>
-                                    )}
-                                </div>
-
-                                <div className="flex flex-col gap-3 sm:flex-row">
-                                    {todayShiftReport && (
-                                        <button
-                                            className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                            onClick={() => setSelectedShiftReport(todayShiftReport)}
-                                            type="button"
-                                        >
-                                            <Eye size={17} />
-                                            Ver reporte de hoy
-                                        </button>
-                                    )}
-
-                                    <button
-                                        className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-60"
-                                        disabled={savingShiftClose || currentShiftActivityCount === 0 || Boolean(todayShiftReport)}
-                                        onClick={() => setShowCloseShiftModal(true)}
-                                        type="button"
-                                    >
-                                        <CheckCircle2 size={17} />
-                                        Cerrar jornada
-                                    </button>
-                                </div>
-                            </div>
-                        </section>
-
-                        <section className="mt-8">
-                            <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <div>
-                                    <h2 className="text-2xl font-black tracking-[-0.04em]">
-                                        Historial de jornadas
-                                    </h2>
-                                    <p className="messenger-copy mt-1 text-sm font-semibold">
-                                        Consulta los reportes generados al cerrar cada jornada.
-                                    </p>
-                                </div>
-                            </div>
-
-                            <div className="space-y-4">
-                                {shiftReports.length > 0 ? (
-                                    shiftReports.map((report) => (
-                                        <article
-                                            className="messenger-delivered-row flex flex-col gap-4 rounded-[26px] border p-6 shadow-[0_10px_24px_rgba(18,32,56,0.06)] lg:flex-row lg:items-center lg:justify-between"
-                                            key={report.id}
-                                        >
-                                            <div>
-                                                <p className="text-lg font-black">
-                                                    Jornada - {formatDateKey(report.dateKey)}
-                                                </p>
-                                                <p className="messenger-copy mt-1 text-sm font-semibold">
-                                                    Inicio: {formatTimeOnly(report.startedAt)} · Cierre: {formatTimeOnly(report.closedAt)}
-                                                </p>
-                                            </div>
-
-                                            <div className="grid min-w-0 gap-3 text-sm font-bold sm:grid-cols-4 lg:w-[520px] lg:max-w-full">
-                                                <p>
-                                                    <span className="messenger-muted block text-xs">Completadas</span>
-                                                    {report.summary.completedCount}
-                                                </p>
-                                                <p>
-                                                    <span className="messenger-muted block text-xs">Pendientes</span>
-                                                    {report.summary.pendingCount}
-                                                </p>
-                                                <p>
-                                                    <span className="messenger-muted block text-xs">Incidentes</span>
-                                                    {report.summary.notDeliveredCount + report.summary.cancelledCount}
-                                                </p>
-                                                <p>
-                                                    <span className="messenger-muted block text-xs">Cobrado</span>
-                                                    {formatBolivianos(report.summary.totalCollected)}
-                                                </p>
-                                            </div>
-
-                                            <button
-                                                className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
-                                                onClick={() => setSelectedShiftReport(report)}
-                                                type="button"
-                                            >
-                                                <Eye size={17} />
-                                                Ver detalle
-                                            </button>
-                                        </article>
-                                    ))
-                                ) : (
-                                    <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
-                                        Aún no hay jornadas cerradas.
-                                    </div>
-                                )}
-                            </div>
-                        </section>
-
-                        <section className="mt-11">
-                            <h2 className="mb-6 text-2xl font-black tracking-[-0.04em]">
-                                Historial
-                            </h2>
-
-                            <div className="space-y-4">
-                                {deliveredOrders.length > 0 ? (
-                                    deliveredOrders.map((order) => (
-                                        <DeliveredOrderRow key={order.id} order={order} />
-                                    ))
-                                ) : (
-                                    <div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
-                                        No hay entregas completadas.
-                                    </div>
-                                )}
-                            </div>
-                        </section>
-                    </>
-                ) : null}
-            </div>
-
-            {detailOrder && (
-                <OrderDetailModal
-                    order={detailOrder}
-                    onClose={() => setDetailOrder(null)}
-                    onDelivered={markAsDelivered}
-                    onNotDelivered={setUndeliveredOrder}
-                />
-            )}
-
-            {undeliveredOrder && (
-                <UndeliveredModal
-                    isSaving={savingUndelivered}
-                    order={undeliveredOrder}
-                    onClose={() => setUndeliveredOrder(null)}
-                    onConfirm={registerUndeliveredOrder}
-                />
-            )}
-            {pendingAssignedAction && (
-                <ConfirmAssignedOrderActionModal
-                    action={pendingAssignedAction.action}
-                    isSaving={savingAssignedAction}
-                    order={pendingAssignedAction.order}
-                    onClose={() => setPendingAssignedAction(null)}
-                    onConfirm={confirmAssignedOrderAction}
-                />
-            )}
-            {confirmPaymentOrder && (
-                <ConfirmPaymentModal
-                    order={confirmPaymentOrder}
-                    onClose={() => setConfirmPaymentOrder(null)}
-                    onConfirm={confirmPayment}
-                />
-            )}
-            {paymentSuccessOrder && (
-                <PaymentSuccessModal
-                    onClose={() => setPaymentSuccessOrder(null)}
-                />
-            )}
-            {showCloseShiftModal && (
-                <CloseShiftModal
-                    alreadyClosed={Boolean(todayShiftReport)}
-                    cancelledCount={currentShiftCancelledOrders.length}
-                    completedCount={todayCollectedOrders.length}
-                    isSaving={savingShiftClose}
-                    notDeliveredCount={currentShiftNotDeliveredOrders.length}
-                    onClose={() => setShowCloseShiftModal(false)}
-                    onConfirm={confirmCloseShift}
-                    pendingCount={currentShiftPendingOrders.length}
-                    totalCollected={todayCollectedTotal}
-                />
-            )}
-
-            {selectedShiftReport && (
-                <ShiftReportDetailModal
-                    report={selectedShiftReport}
-                    onClose={() => setSelectedShiftReport(null)}
-                />
-            )}
-        </main>
-    );
+	const [orders, setOrders] = useState<MessengerOrder[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [message, setMessage] = useState("");
+	const [detailOrder, setDetailOrder] = useState<MessengerOrder | null>(null);
+	const [undeliveredOrder, setUndeliveredOrder] =
+		useState<MessengerOrder | null>(null);
+	const [savingUndelivered, setSavingUndelivered] = useState(false);
+	const [confirmPaymentOrder, setConfirmPaymentOrder] =
+		useState<MessengerOrder | null>(null);
+	const [paymentSuccessOrder, setPaymentSuccessOrder] =
+		useState<MessengerOrder | null>(null);
+	const [pendingAssignedAction, setPendingAssignedAction] = useState<{
+		order: MessengerOrder;
+		action: AssignedOrderAction;
+	} | null>(null);
+	const [savingAssignedAction, setSavingAssignedAction] = useState(false);
+	const [currentCourierId, setCurrentCourierId] = useState<string | null>(null);
+	const [newOrderCount, setNewOrderCount] = useState(0);
+	const [acceptedSortOrder, setAcceptedSortOrder] =
+		useState<AcceptedOrderSort>("newest-first");
+	const [showCloseShiftModal, setShowCloseShiftModal] = useState(false);
+	const [savingShiftClose, setSavingShiftClose] = useState(false);
+	const [shiftReports, setShiftReports] = useState<MessengerShiftClosure[]>([]);
+	const [selectedShiftReport, setSelectedShiftReport] =
+		useState<MessengerShiftClosure | null>(null);
+	const notifiedOrderIdsRef = useRef<Set<string>>(new Set());
+	const isFirstLoadRef = useRef(true);
+
+	useEffect(() => {
+		let unsubscribeOrders: (() => void) | undefined;
+
+		const startOrdersSubscription = (
+			courierId: string,
+			allowDevFallback = false,
+		) => {
+			setLoading(true);
+			setMessage("");
+
+			unsubscribeOrders?.();
+
+			unsubscribeOrders = subscribeToMessengerOrders(
+				courierId,
+				(data) => {
+					if (
+						data.length === 0 &&
+						allowDevFallback &&
+						import.meta.env.PUBLIC_APP_ENV !== "production" &&
+						courierId !== DEV_COURIER_ID
+					) {
+						startOrdersSubscription(DEV_COURIER_ID, false);
+						return;
+					}
+
+					setOrders(data);
+					setLoading(false);
+				},
+				(error) => {
+					console.error(error);
+					setOrders([]);
+					setLoading(false);
+					setMessage("No se pudieron cargar las entregas del emulador.");
+				},
+			);
+		};
+
+		const unsubscribeAuth = onAuthStateChanged(auth, (user) => {
+			const devCourierId =
+				import.meta.env.PUBLIC_APP_ENV !== "production" ? DEV_COURIER_ID : null;
+			const courierId = user?.uid || devCourierId;
+			const allowDevFallback = !user;
+
+			setCurrentCourierId(courierId);
+
+			if (!courierId) {
+				unsubscribeOrders?.();
+				setOrders([]);
+				setLoading(false);
+				setMessage("Inicia sesion para ver tus entregas asignadas.");
+				return;
+			}
+
+			startOrdersSubscription(courierId, allowDevFallback);
+		});
+
+		return () => {
+			unsubscribeOrders?.();
+			unsubscribeAuth();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!currentCourierId) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setShiftReports([]);
+			return;
+		}
+
+		const unsubscribeReports = subscribeToMessengerShiftClosures(
+			currentCourierId,
+			setShiftReports,
+			(error) => {
+				console.error(error);
+				setMessage("No se pudo cargar el historial de jornadas.");
+			},
+		);
+
+		return () => {
+			unsubscribeReports();
+		};
+	}, [currentCourierId]);
+
+	const assignedOrders = useMemo(
+		() =>
+			sortAcceptedOrdersByAge(
+				orders.filter((order) => order.deliveryStatus === "assigned"),
+				"newest-first",
+			),
+		[orders],
+	);
+
+	// Un pedido `accepted` o `in_transit` cuenta como entrega activa y
+	// deshabilita la aceptación de otros pedidos asignados (pre-check de UX;
+	// la validación autoritativa vive en acceptMessengerOrder, en el servicio).
+	const hasActiveDelivery = useMemo(
+		() => hasActiveMessengerDelivery(orders),
+		[orders],
+	);
+
+	const assignedOrderIdsKey = useMemo(
+		() =>
+			assignedOrders
+				.map((order) => order.deliveryId || order.id)
+				.sort()
+				.join("|"),
+		[assignedOrders],
+	);
+
+	useEffect(() => {
+		if (loading || clientSection !== "assigned") return;
+
+		const currentOrderIds = assignedOrderIdsKey
+			? assignedOrderIdsKey.split("|")
+			: [];
+
+		// Primera carga: mostrar toast si hay pedidos, sin filtrar por sesión previa
+		if (isFirstLoadRef.current) {
+			isFirstLoadRef.current = false;
+
+			if (currentOrderIds.length === 0) return;
+
+			// Marcar todos como notificados para futuras comparaciones
+			const storageKey = "sansistore:messenger:notified-order-ids";
+			const updatedIds = Array.from(new Set(currentOrderIds));
+			try {
+				sessionStorage.setItem(storageKey, JSON.stringify(updatedIds));
+			} catch {
+				/* ignorar */
+			}
+			notifiedOrderIdsRef.current = new Set(updatedIds);
+
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setNewOrderCount(currentOrderIds.length);
+			return;
+		}
+
+		// Cargas posteriores: solo nuevos pedidos que no se habían notificado
+		if (currentOrderIds.length === 0) {
+			setNewOrderCount(0);
+			return;
+		}
+
+		const storageKey = "sansistore:messenger:notified-order-ids";
+		let storedIds: string[] = [];
+		try {
+			storedIds = JSON.parse(
+				sessionStorage.getItem(storageKey) || "[]",
+			) as string[];
+		} catch {
+			storedIds = [];
+		}
+
+		const alreadyNotifiedIds = new Set([
+			...storedIds,
+			...Array.from(notifiedOrderIdsRef.current),
+		]);
+
+		const newIds = currentOrderIds.filter((id) => !alreadyNotifiedIds.has(id));
+		if (newIds.length === 0) return;
+
+		const updatedIds = Array.from(new Set([...storedIds, ...currentOrderIds]));
+		try {
+			sessionStorage.setItem(storageKey, JSON.stringify(updatedIds));
+		} catch {
+			/* ignorar */
+		}
+		notifiedOrderIdsRef.current = new Set(updatedIds);
+		setNewOrderCount(newIds.length);
+	}, [assignedOrderIdsKey, clientSection, loading]);
+
+	const acceptedOrders = useMemo(
+		() =>
+			orders.filter(
+				(order) =>
+					order.deliveryStatus === "accepted" ||
+					order.deliveryStatus === "in_transit",
+			),
+		[orders],
+	);
+	const sortedAcceptedOrders = useMemo(
+		() => sortAcceptedOrdersByAge(acceptedOrders, acceptedSortOrder),
+		[acceptedOrders, acceptedSortOrder],
+	);
+
+	// ✅ MODIFICADO: Se agregó ordenamiento por fecha descendente
+	const deliveredOrders = useMemo(
+		() =>
+			orders.filter(isMessengerOrderCollected).sort((a, b) => {
+				const dateA = a.paymentCollectedAt;
+				const dateB = b.paymentCollectedAt;
+				if (!dateA || !dateB) return 0;
+				return dateB.getTime() - dateA.getTime();
+			}),
+		[orders],
+	);
+	const todayCollectedOrders = useMemo(
+		() => getCollectedOrdersForDay(orders),
+		[orders],
+	);
+	const todayCollectedTotal = useMemo(
+		() => getCollectedTotalForDay(orders),
+		[orders],
+	);
+	const collectedTotal = useMemo(() => getCollectedTotal(orders), [orders]);
+	const todayDateKey = useMemo(() => getLocalDateKey(new Date()), []);
+
+	const todayShiftReport = useMemo(
+		() =>
+			shiftReports.find((report) => report.dateKey === todayDateKey) ?? null,
+		[shiftReports, todayDateKey],
+	);
+
+	const currentShiftPendingOrders = useMemo(
+		() =>
+			orders.filter(
+				(order) =>
+					order.deliveryStatus === "assigned" ||
+					order.deliveryStatus === "accepted" ||
+					order.deliveryStatus === "in_transit",
+			),
+		[orders],
+	);
+
+	const currentShiftNotDeliveredOrders = useMemo(
+		() => orders.filter((order) => order.deliveryStatus === "not_delivered"),
+		[orders],
+	);
+
+	const currentShiftCancelledOrders = useMemo(
+		() => orders.filter((order) => order.deliveryStatus === "cancelled"),
+		[orders],
+	);
+
+	const currentShiftActivityCount =
+		todayCollectedOrders.length +
+		currentShiftPendingOrders.length +
+		currentShiftNotDeliveredOrders.length +
+		currentShiftCancelledOrders.length;
+	const currentCourierActiveDeliveryCount = useMemo(() => {
+		if (!currentCourierId) return 0;
+
+		const counts = countActiveDeliveriesByCourier(
+			orders.map((order) => ({
+				courierId: currentCourierId,
+				status: order.deliveryStatus,
+			})),
+		);
+
+		return counts[currentCourierId] ?? 0;
+	}, [currentCourierId, orders]);
+	const isCurrentCourierAvailable = isCourierAvailableFromActiveCount(
+		currentCourierActiveDeliveryCount,
+	);
+
+	const notDeliveredOrders = useMemo(
+		() =>
+			sortAcceptedOrdersByAge(
+				orders.filter((order) => order.deliveryStatus === "not_delivered"),
+				"newest-first",
+			),
+		[orders],
+	);
+
+	const reprogrammedOrders = useMemo(
+		() =>
+			orders
+				.filter((order) => order.deliveryStatus === "reprogrammed")
+				.sort((a, b) => {
+					const dateA =
+						a.newDeliveryAt?.getTime() ??
+						a.updatedAt?.getTime() ??
+						a.createdAt?.getTime() ??
+						0;
+
+					const dateB =
+						b.newDeliveryAt?.getTime() ??
+						b.updatedAt?.getTime() ??
+						b.createdAt?.getTime() ??
+						0;
+
+					return dateA - dateB;
+				}),
+		[orders],
+	);
+
+	const updateOrderStatus = async (
+		orderId: string,
+		status: MessengerOrder["deliveryStatus"],
+		options: { redirectToDetail?: boolean; reason?: string } = {},
+	) => {
+		const targetOrder = orders.find((order) => order.id === orderId);
+		if (!targetOrder) return;
+
+		setOrders((currentOrders) =>
+			currentOrders.map((order) =>
+				order.id === orderId
+					? {
+							...order,
+							deliveryStatus: status,
+							...(status === "pending_reassignment" && options.reason
+								? { rejectionReason: options.reason }
+								: {}),
+						}
+					: order,
+			),
+		);
+
+		try {
+			if (status === "accepted") {
+				// Aceptar pasa por el punto único del servicio, que revalida
+				// contra Firestore que no haya otra entrega activa antes de
+				// escribir. Así la regla se cumple aunque el estado local esté
+				// desactualizado (p. ej. otra pantalla abierta en paralelo).
+				if (!currentCourierId) {
+					throw new Error("No se pudo identificar al mensajero.");
+				}
+				await acceptMessengerOrder(targetOrder, currentCourierId);
+			} else {
+				// Pasar el motivo a Firestore si es rechazo
+				await setMessengerOrderStatus(
+					targetOrder,
+					status,
+					status === "pending_reassignment" ? options.reason : undefined,
+				);
+			}
+			setMessage(getStatusUpdateMessage(status));
+			if (options.redirectToDetail) {
+				navigateToDeliveryOrderDetail(orderId);
+			}
+		} catch (error) {
+			console.error(error);
+			setMessage(
+				error instanceof Error
+					? error.message
+					: "No se pudo actualizar el estado en Firestore.",
+			);
+			setOrders((currentOrders) =>
+				currentOrders.map((order) =>
+					order.id === orderId ? targetOrder : order,
+				),
+			);
+		}
+	};
+
+	const markAsDelivered = (order: MessengerOrder) => {
+		setConfirmPaymentOrder(order);
+	};
+
+	const confirmPayment = async (order: MessengerOrder, secret: string) => {
+		if (!currentCourierId) {
+			throw new Error("No se pudo identificar al mensajero.");
+		}
+
+		if (order.paymentStatusLabel === "Cobrado") {
+			throw new Error("Este pedido ya tiene el pago registrado.");
+		}
+
+		// Validar secret contra order.secret (campo del tipo Order)
+		if (secret !== order.secret) {
+			throw new Error("Código incorrecto.");
+		}
+
+		const previousOrder = order;
+		setOrders((currentOrders) =>
+			currentOrders.map((currentOrder) =>
+				currentOrder.id === order.id
+					? {
+							...currentOrder,
+							deliveryStatus: "delivered",
+							paymentStatus: "COBRADO",
+							paymentStatusLabel: "Cobrado",
+							collectedBy: currentCourierId,
+							paymentCollectedAt: new Date(),
+						}
+					: currentOrder,
+			),
+		);
+
+		try {
+			await registerMessengerCashPayment(order, currentCourierId);
+
+			setConfirmPaymentOrder(null);
+
+			setPaymentSuccessOrder(order);
+		} catch (error) {
+			console.error(error);
+			setOrders((currentOrders) =>
+				currentOrders.map((currentOrder) =>
+					currentOrder.id === previousOrder.id ? previousOrder : currentOrder,
+				),
+			);
+			throw error; // el modal captura y muestra el error
+		}
+	};
+
+	const openAssignedActionConfirmation = (
+		orderId: string,
+		action: AssignedOrderAction,
+	) => {
+		const order = orders.find((currentOrder) => currentOrder.id === orderId);
+		if (order?.deliveryStatus !== "assigned") return;
+
+		setPendingAssignedAction({ order, action });
+	};
+
+	const acceptOrder = (orderId: string) => {
+		openAssignedActionConfirmation(orderId, "accept");
+	};
+
+	const markAsInTransit = (orderId: string) => {
+		void updateOrderStatus(orderId, "in_transit", { redirectToDetail: true });
+	};
+
+	const rejectOrder = (orderId: string) => {
+		openAssignedActionConfirmation(orderId, "reject");
+	};
+
+	const confirmAssignedOrderAction = async (reason?: string) => {
+		if (!pendingAssignedAction || savingAssignedAction) return;
+
+		const { order, action } = pendingAssignedAction;
+
+		// Si es rechazo y no hay motivo, no continuar
+		if (action === "reject" && !reason?.trim()) {
+			setMessage("Debes seleccionar un motivo para rechazar el pedido.");
+			return;
+		}
+
+		const nextStatus =
+			action === "accept" ? "accepted" : "pending_reassignment";
+
+		setSavingAssignedAction(true);
+		try {
+			// Pasar el motivo al updateOrderStatus
+			await updateOrderStatus(order.id, nextStatus, {
+				redirectToDetail: true,
+				reason: action === "reject" ? reason : undefined,
+			});
+			setPendingAssignedAction(null);
+		} finally {
+			setSavingAssignedAction(false);
+		}
+	};
+
+	const registerUndeliveredOrder = async (reason: string, notes: string) => {
+		if (!undeliveredOrder) return;
+		if (!currentCourierId) {
+			setMessage(
+				"No se pudo identificar al mensajero para registrar el problema.",
+			);
+			return;
+		}
+
+		const targetOrder = undeliveredOrder;
+		setSavingUndelivered(true);
+		setOrders((currentOrders) =>
+			currentOrders.map((order) =>
+				order.id === targetOrder.id
+					? { ...order, deliveryStatus: "not_delivered" }
+					: order,
+			),
+		);
+
+		try {
+			await markMessengerOrderAsNotDelivered({
+				order: targetOrder,
+				reason,
+				notes,
+				courierId: currentCourierId,
+			});
+			setMessage("Problema registrado y pedido marcado como no entregado.");
+			setUndeliveredOrder(null);
+			navigateToDeliveryOrderDetail(targetOrder.id);
+		} catch (error) {
+			console.error(error);
+			setMessage("No se pudo registrar el incidente en Firestore.");
+			setOrders((currentOrders) =>
+				currentOrders.map((order) =>
+					order.id === targetOrder.id ? targetOrder : order,
+				),
+			);
+		} finally {
+			setSavingUndelivered(false);
+		}
+	};
+
+	const confirmCloseShift = async () => {
+		if (!currentCourierId) {
+			setMessage("No se pudo identificar al mensajero para cerrar la jornada.");
+			return;
+		}
+
+		if (todayShiftReport) {
+			setMessage("La jornada de hoy ya fue cerrada.");
+			setShowCloseShiftModal(false);
+			setSelectedShiftReport(todayShiftReport);
+			return;
+		}
+
+		setSavingShiftClose(true);
+
+		try {
+			const report = await closeMessengerShift({
+				courierId: currentCourierId,
+				orders,
+			});
+
+			setShowCloseShiftModal(false);
+			setSelectedShiftReport(report);
+			setMessage(
+				"Jornada cerrada correctamente. El reporte ya está disponible en el historial.",
+			);
+		} catch (error) {
+			console.error(error);
+			setMessage(
+				error instanceof Error
+					? error.message
+					: "No se pudo cerrar la jornada.",
+			);
+		} finally {
+			setSavingShiftClose(false);
+		}
+	};
+
+	const activeOrders =
+		clientSection === "assigned"
+			? assignedOrders
+			: clientSection === "not_delivered"
+				? notDeliveredOrders
+				: clientSection === "reprogrammed"
+					? reprogrammedOrders
+					: sortedAcceptedOrders;
+	const activeTitle =
+		clientSection === "assigned"
+			? "Gestión Entregas"
+			: clientSection === "accepted"
+				? "Pedidos aceptados"
+				: clientSection === "reprogrammed"
+					? "Pedidos reprogramados"
+					: clientSection === "not_delivered"
+						? "No entregados"
+						: "Entregados";
+	const activeDescription =
+		clientSection === "assigned"
+			? "Acepta o rechaza los pedidos asignados antes de iniciar la entrega."
+			: clientSection === "accepted"
+				? "Organiza tus entregas, revisa direcciones y cambia el estado de cada pedido."
+				: clientSection === "reprogrammed"
+					? "Revisa los pedidos que tienen una nueva fecha u hora de entrega."
+					: clientSection === "not_delivered"
+						? "Revisa los pedidos con incidente registrado durante la jornada."
+						: "Revisa las entregas completadas y el monto cobrado durante la jornada.";
+
+	return (
+		<main
+			className={`messenger-dashboard ${embedded ? "messenger-dashboard--embedded" : "min-h-[100dvh]"}`}
+		>
+			{newOrderCount > 0 && clientSection === "assigned" && (
+				<NewOrderToast
+					count={newOrderCount}
+					onDismiss={() => setNewOrderCount(0)}
+				/>
+			)}
+			{!embedded && (
+				<header className="messenger-header border-b">
+					<div className="messenger-header-inner flex items-center justify-between">
+						<a className="text-xl font-black tracking-normal" href="/">
+							sansi <span className="messenger-logo-accent">store</span>
+						</a>
+
+						<div className="flex gap-2">
+							<a
+								className="messenger-buyer-link inline-flex h-10 items-center justify-center rounded-full border px-6 text-sm font-bold"
+								href="/"
+							>
+								Comprador
+							</a>
+							<a
+								className="messenger-courier-link inline-flex h-10 items-center justify-center rounded-full px-6 text-sm font-bold"
+								href="/courier"
+							>
+								Mensajero
+							</a>
+						</div>
+					</div>
+				</header>
+			)}
+
+			<div className="messenger-container">
+				<section className="mb-10">
+					<p className="text-sm font-bold uppercase tracking-[0.28em] text-primary">
+						Operacion de entregas
+					</p>
+					<h1 className="mt-4 text-4xl font-black tracking-[-0.04em] sm:text-5xl">
+						{activeTitle}
+					</h1>
+					<p className="messenger-copy mt-2 max-w-2xl text-sm font-semibold">
+						{activeDescription}
+					</p>
+				</section>
+
+				{message && (
+					<MessageToast message={message} onDismiss={() => setMessage("")} />
+				)}
+
+				{loading && (
+					<div className="messenger-order-card mt-6 rounded-[26px] border p-8 text-sm font-semibold">
+						Cargando entregas...
+					</div>
+				)}
+
+				{!loading && clientSection !== "delivered" ? (
+					<>
+						<section className="messenger-summary-grid grid gap-5">
+							<SummaryCard
+								icon={<Clock3 size={20} />}
+								label={
+									clientSection === "assigned"
+										? "Asignados"
+										: clientSection === "reprogrammed"
+											? "Reprogramados"
+											: clientSection === "not_delivered"
+												? "No entregados"
+												: "Pendientes"
+								}
+								value={activeOrders.length}
+							/>
+							<SummaryCard
+								featured
+								icon={<DollarSign size={20} />}
+								label="Total a Cobrar"
+								value={formatBolivianos(
+									activeOrders.reduce(
+										(total, order) => total + order.cashToCollect,
+										0,
+									),
+								)}
+							/>
+							<SummaryCard
+								icon={
+									isCurrentCourierAvailable ? (
+										<CheckCircle2 size={20} />
+									) : (
+										<Truck size={20} />
+									)
+								}
+								label="Disponibilidad"
+								value={isCurrentCourierAvailable ? "Disponible" : "Ocupado"}
+							/>
+						</section>
+
+						<section className="mt-11">
+							<div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+								<h2 className="text-2xl font-black tracking-[-0.04em]">
+									{clientSection === "assigned"
+										? "Pedidos asignados"
+										: clientSection === "reprogrammed"
+											? "Pedidos reprogramados"
+											: clientSection === "not_delivered"
+												? "Pedidos no entregados"
+												: "Pedidos pendientes"}
+								</h2>
+
+								{clientSection === "accepted" && activeOrders.length > 0 && (
+									<label className="flex w-full flex-col gap-2 text-sm font-bold text-text-light sm:w-auto sm:flex-row sm:items-center">
+										<span className="messenger-muted">Ordenar por</span>
+										<select
+											value={acceptedSortOrder}
+											onChange={(event) =>
+												setAcceptedSortOrder(
+													event.target.value as AcceptedOrderSort,
+												)
+											}
+											className="rounded-2xl border-2 border-border-light bg-card-bg-light px-4 py-3 text-sm font-bold text-text-light outline-none transition focus:border-primary"
+										>
+											<option value="oldest-first">Más antiguos primero</option>
+											<option value="newest-first">
+												Más recientes primero
+											</option>
+										</select>
+									</label>
+								)}
+							</div>
+
+							<div className="space-y-6">
+								{activeOrders.length > 0 ? (
+									activeOrders.map((order) => (
+										<PendingOrderCard
+											key={`${clientSection}-${order.deliveryId || order.id}`}
+											order={order}
+											onAccept={acceptOrder}
+											acceptDisabled={hasActiveDelivery}
+											onDelivered={markAsDelivered}
+											onDetail={(order) =>
+												navigateToDeliveryOrderDetail(order.id)
+											}
+											onInTransit={markAsInTransit}
+											onNotDelivered={setUndeliveredOrder}
+											onReject={rejectOrder}
+										/>
+									))
+								) : (
+									<div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
+										{clientSection === "assigned"
+											? "No hay pedidos asignados."
+											: clientSection === "reprogrammed"
+												? "No hay pedidos reprogramados."
+												: clientSection === "not_delivered"
+													? "No hay pedidos no entregados."
+													: "No hay pedidos pendientes."}
+									</div>
+								)}
+							</div>
+						</section>
+					</>
+				) : !loading ? (
+					<>
+						<section className="messenger-summary-grid grid gap-5">
+							<SummaryCard
+								icon={<CheckCircle2 size={20} />}
+								label="Cobrados en la jornada"
+								value={todayCollectedOrders.length}
+							/>
+							<SummaryCard
+								icon={<CheckCircle2 size={20} />}
+								label="Cobrado en la jornada"
+								value={formatBolivianos(todayCollectedTotal)}
+							/>
+							<SummaryCard
+								featured
+								icon={<DollarSign size={20} />}
+								label="Total cobrado"
+								value={formatBolivianos(collectedTotal)}
+							/>
+						</section>
+
+						<section className="mt-8 rounded-[28px] border border-border-light bg-card-bg-light p-6 shadow-[0_14px_30px_rgba(38,33,22,0.08)]">
+							<div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+								<div>
+									<p className="text-sm font-bold uppercase tracking-[0.22em] text-primary">
+										Cierre de jornada
+									</p>
+									<h2 className="mt-2 text-2xl font-black tracking-[-0.04em]">
+										Registrar cierre del día
+									</h2>
+									<p className="messenger-copy mt-2 max-w-2xl text-sm font-semibold">
+										Guarda un reporte con tus entregas completadas, pendientes,
+										no entregadas, canceladas y el total cobrado.
+									</p>
+
+									{todayShiftReport && (
+										<p className="mt-4 rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm font-bold text-primary">
+											La jornada de hoy ya fue cerrada a las{" "}
+											{formatTimeOnly(todayShiftReport.closedAt)}.
+										</p>
+									)}
+								</div>
+
+								<div className="flex flex-col gap-3 sm:flex-row">
+									{todayShiftReport && (
+										<button
+											className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+											onClick={() => setSelectedShiftReport(todayShiftReport)}
+											type="button"
+										>
+											<Eye size={17} />
+											Ver reporte de hoy
+										</button>
+									)}
+
+									<button
+										className="messenger-deliver-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-60"
+										disabled={
+											savingShiftClose ||
+											currentShiftActivityCount === 0 ||
+											Boolean(todayShiftReport)
+										}
+										onClick={() => setShowCloseShiftModal(true)}
+										type="button"
+									>
+										<CheckCircle2 size={17} />
+										Cerrar jornada
+									</button>
+								</div>
+							</div>
+						</section>
+
+						<section className="mt-8">
+							<div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+								<div>
+									<h2 className="text-2xl font-black tracking-[-0.04em]">
+										Historial de jornadas
+									</h2>
+									<p className="messenger-copy mt-1 text-sm font-semibold">
+										Consulta los reportes generados al cerrar cada jornada.
+									</p>
+								</div>
+							</div>
+
+							<div className="space-y-4">
+								{shiftReports.length > 0 ? (
+									shiftReports.map((report) => (
+										<article
+											className="messenger-delivered-row flex flex-col gap-4 rounded-[26px] border p-6 shadow-[0_10px_24px_rgba(18,32,56,0.06)] lg:flex-row lg:items-center lg:justify-between"
+											key={report.id}
+										>
+											<div>
+												<p className="text-lg font-black">
+													Jornada - {formatDateKey(report.dateKey)}
+												</p>
+												<p className="messenger-copy mt-1 text-sm font-semibold">
+													Inicio: {formatTimeOnly(report.startedAt)} · Cierre:{" "}
+													{formatTimeOnly(report.closedAt)}
+												</p>
+											</div>
+
+											<div className="grid min-w-0 gap-3 text-sm font-bold sm:grid-cols-4 lg:w-[520px] lg:max-w-full">
+												<p>
+													<span className="messenger-muted block text-xs">
+														Completadas
+													</span>
+													{report.summary.completedCount}
+												</p>
+												<p>
+													<span className="messenger-muted block text-xs">
+														Pendientes
+													</span>
+													{report.summary.pendingCount}
+												</p>
+												<p>
+													<span className="messenger-muted block text-xs">
+														Incidentes
+													</span>
+													{report.summary.notDeliveredCount +
+														report.summary.cancelledCount}
+												</p>
+												<p>
+													<span className="messenger-muted block text-xs">
+														Cobrado
+													</span>
+													{formatBolivianos(report.summary.totalCollected)}
+												</p>
+											</div>
+
+											<button
+												className="messenger-map-button inline-flex h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 text-sm font-bold transition"
+												onClick={() => setSelectedShiftReport(report)}
+												type="button"
+											>
+												<Eye size={17} />
+												Ver detalle
+											</button>
+										</article>
+									))
+								) : (
+									<div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
+										Aún no hay jornadas cerradas.
+									</div>
+								)}
+							</div>
+						</section>
+
+						<section className="mt-11">
+							<h2 className="mb-6 text-2xl font-black tracking-[-0.04em]">
+								Historial
+							</h2>
+
+							<div className="space-y-4">
+								{deliveredOrders.length > 0 ? (
+									deliveredOrders.map((order) => (
+										<DeliveredOrderRow key={order.id} order={order} />
+									))
+								) : (
+									<div className="messenger-order-card rounded-[28px] border p-8 text-sm font-semibold">
+										No hay entregas completadas.
+									</div>
+								)}
+							</div>
+						</section>
+					</>
+				) : null}
+			</div>
+
+			{detailOrder && (
+				<OrderDetailModal
+					order={detailOrder}
+					onClose={() => setDetailOrder(null)}
+					onDelivered={markAsDelivered}
+					onNotDelivered={setUndeliveredOrder}
+				/>
+			)}
+
+			{undeliveredOrder && (
+				<UndeliveredModal
+					isSaving={savingUndelivered}
+					order={undeliveredOrder}
+					onClose={() => setUndeliveredOrder(null)}
+					onConfirm={registerUndeliveredOrder}
+				/>
+			)}
+			{pendingAssignedAction && (
+				<ConfirmAssignedOrderActionModal
+					action={pendingAssignedAction.action}
+					isSaving={savingAssignedAction}
+					order={pendingAssignedAction.order}
+					onClose={() => setPendingAssignedAction(null)}
+					onConfirm={confirmAssignedOrderAction}
+				/>
+			)}
+			{confirmPaymentOrder && (
+				<ConfirmPaymentModal
+					order={confirmPaymentOrder}
+					onClose={() => setConfirmPaymentOrder(null)}
+					onConfirm={confirmPayment}
+				/>
+			)}
+			{paymentSuccessOrder && (
+				<PaymentSuccessModal onClose={() => setPaymentSuccessOrder(null)} />
+			)}
+			{showCloseShiftModal && (
+				<CloseShiftModal
+					alreadyClosed={Boolean(todayShiftReport)}
+					cancelledCount={currentShiftCancelledOrders.length}
+					completedCount={todayCollectedOrders.length}
+					isSaving={savingShiftClose}
+					notDeliveredCount={currentShiftNotDeliveredOrders.length}
+					onClose={() => setShowCloseShiftModal(false)}
+					onConfirm={confirmCloseShift}
+					pendingCount={currentShiftPendingOrders.length}
+					totalCollected={todayCollectedTotal}
+				/>
+			)}
+
+			{selectedShiftReport && (
+				<ShiftReportDetailModal
+					report={selectedShiftReport}
+					onClose={() => setSelectedShiftReport(null)}
+				/>
+			)}
+		</main>
+	);
 }

--- a/src/features/mensajero/modals/AcceptBlockedModal.tsx
+++ b/src/features/mensajero/modals/AcceptBlockedModal.tsx
@@ -8,7 +8,7 @@ interface AcceptBlockedModalProps {
 export default function AcceptBlockedModal({ onClose }: AcceptBlockedModalProps) {
   return (
     <div
-      className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -16,14 +16,14 @@ export default function AcceptBlockedModal({ onClose }: AcceptBlockedModalProps)
       aria-modal="true"
       aria-labelledby="accept-blocked-title"
     >
-      <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-        <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
-          <div className="flex items-center gap-4">
-            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-red-500/10 text-red-600">
+      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-500/10 text-red-600 sm:h-12 sm:w-12">
               <AlertTriangle size={24} />
             </span>
-            <div>
-              <h2 className="text-xl font-black tracking-normal" id="accept-blocked-title">
+            <div className="min-w-0">
+              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl" id="accept-blocked-title">
                 No puedes aceptar este pedido
               </h2>
               <p className="text-sm font-medium opacity-70">
@@ -42,14 +42,14 @@ export default function AcceptBlockedModal({ onClose }: AcceptBlockedModalProps)
           </button>
         </header>
 
-        <div className="px-6 py-6">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6">
           <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
             <AlertTriangle className="mt-0.5 shrink-0 text-red-500" size={18} />
             <p>{ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE}</p>
           </div>
         </div>
 
-        <footer className="border-t border-border-light bg-secondary-bg-light/50 px-6 py-5">
+        <footer className="shrink-0 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:px-6 sm:py-4">
           <button
             className="inline-flex h-12 w-full items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
             onClick={onClose}

--- a/src/features/mensajero/modals/AcceptBlockedModal.tsx
+++ b/src/features/mensajero/modals/AcceptBlockedModal.tsx
@@ -1,64 +1,73 @@
-import { AlertTriangle, X } from 'lucide-react';
-import { ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE } from '../utils/acceptEligibility';
+import { AlertTriangle, X } from "lucide-react";
+import { ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE } from "../utils/acceptEligibility";
 
 interface AcceptBlockedModalProps {
-  onClose: () => void;
+	onClose: () => void;
 }
 
-export default function AcceptBlockedModal({ onClose }: AcceptBlockedModalProps) {
-  return (
-    <div
-      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="accept-blocked-title"
-    >
-      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-500/10 text-red-600 sm:h-12 sm:w-12">
-              <AlertTriangle size={24} />
-            </span>
-            <div className="min-w-0">
-              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl" id="accept-blocked-title">
-                No puedes aceptar este pedido
-              </h2>
-              <p className="text-sm font-medium opacity-70">
-                Tienes una entrega activa en curso.
-              </p>
-            </div>
-          </div>
+export default function AcceptBlockedModal({
+	onClose,
+}: AcceptBlockedModalProps) {
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="accept-blocked-title"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div className="flex min-w-0 items-center gap-3 sm:gap-4">
+						<span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-500/10 text-red-600 sm:h-12 sm:w-12">
+							<AlertTriangle size={24} />
+						</span>
+						<div className="min-w-0">
+							<h2
+								className="text-lg font-black leading-tight tracking-normal sm:text-xl"
+								id="accept-blocked-title"
+							>
+								No puedes aceptar este pedido
+							</h2>
+							<p className="text-sm font-medium opacity-70">
+								Tienes una entrega activa en curso.
+							</p>
+						</div>
+					</div>
 
-          <button
-            aria-label="Cerrar"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-            onClick={onClose}
-            type="button"
-          >
-            <X size={16} />
-          </button>
-        </header>
+					<button
+						aria-label="Cerrar"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6">
-          <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
-            <AlertTriangle className="mt-0.5 shrink-0 text-red-500" size={18} />
-            <p>{ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE}</p>
-          </div>
-        </div>
+				<div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6">
+					<div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
+						<AlertTriangle className="mt-0.5 shrink-0 text-red-500" size={18} />
+						<p>{ACCEPT_BLOCKED_BY_ACTIVE_DELIVERY_MESSAGE}</p>
+					</div>
+				</div>
 
-        <footer className="shrink-0 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:px-6 sm:py-4">
-          <button
-            className="inline-flex h-12 w-full items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
-            onClick={onClose}
-            type="button"
-          >
-            Entendido
-          </button>
-        </footer>
-      </section>
-    </div>
-  );
+				<footer className="shrink-0 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:px-6 sm:py-4">
+					<button
+						className="inline-flex h-12 w-full items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
+						onClick={onClose}
+						type="button"
+					>
+						Entendido
+					</button>
+				</footer>
+			</section>
+		</div>
+	);
 }

--- a/src/features/mensajero/modals/CancelNoPaymentModal.tsx
+++ b/src/features/mensajero/modals/CancelNoPaymentModal.tsx
@@ -34,20 +34,20 @@ export default function CancelNoPaymentModal({
 
   return (
     <div
-      className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-        <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
           <div className="flex items-center gap-4">
-            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-(--theme-error-bg) text-(--theme-error)">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-(--theme-error-bg) text-(--theme-error) sm:h-12 sm:w-12">
               <DollarSign size={24} />
             </span>
 
             <div>
-              <h2 className="text-xl font-black tracking-normal">
+              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
                 Cancelar pedido
               </h2>
               <p className="text-sm font-medium opacity-70">
@@ -66,7 +66,7 @@ export default function CancelNoPaymentModal({
           </button>
         </header>
 
-        <div className="space-y-6 px-6 py-6">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6">
           <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
             <div>
               <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
@@ -100,7 +100,7 @@ export default function CancelNoPaymentModal({
           </label>
         </div>
 
-        <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
+        <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
           <button
             className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
             onClick={onClose}

--- a/src/features/mensajero/modals/CancelNoPaymentModal.tsx
+++ b/src/features/mensajero/modals/CancelNoPaymentModal.tsx
@@ -1,129 +1,137 @@
-import { useMemo, useState } from 'react';
-import { DollarSign, LoaderCircle, X, XCircle } from 'lucide-react';
-import type { MessengerOrder } from '../types';
-import { formatBolivianos } from '../utils/money';
+import { DollarSign, LoaderCircle, X, XCircle } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { MessengerOrder } from "../types";
+import { formatBolivianos } from "../utils/money";
 
 interface CancelNoPaymentModalProps {
-  order: MessengerOrder;
-  isSaving: boolean;
-  onClose: () => void;
-  onConfirm: (notes: string) => Promise<void>;
+	order: MessengerOrder;
+	isSaving: boolean;
+	onClose: () => void;
+	onConfirm: (notes: string) => Promise<void>;
 }
 
 export default function CancelNoPaymentModal({
-  order,
-  isSaving,
-  onClose,
-  onConfirm,
+	order,
+	isSaving,
+	onClose,
+	onConfirm,
 }: CancelNoPaymentModalProps) {
-  const [notes, setNotes] = useState('');
+	const [notes, setNotes] = useState("");
 
-  const currentDate = useMemo(
-    () =>
-      new Intl.DateTimeFormat('es-BO', {
-        dateStyle: 'short',
-        timeStyle: 'short',
-      }).format(new Date()),
-    []
-  );
+	const currentDate = useMemo(
+		() =>
+			new Intl.DateTimeFormat("es-BO", {
+				dateStyle: "short",
+				timeStyle: "short",
+			}).format(new Date()),
+		[],
+	);
 
-  const confirmCancellation = async () => {
-    if (isSaving) return;
-    await onConfirm(notes.trim());
-  };
+	const confirmCancellation = async () => {
+		if (isSaving) return;
+		await onConfirm(notes.trim());
+	};
 
-  return (
-    <div
-      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-          <div className="flex items-center gap-4">
-            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-(--theme-error-bg) text-(--theme-error) sm:h-12 sm:w-12">
-              <DollarSign size={24} />
-            </span>
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div className="flex items-center gap-4">
+						<span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-(--theme-error-bg) text-(--theme-error) sm:h-12 sm:w-12">
+							<DollarSign size={24} />
+						</span>
 
-            <div>
-              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
-                Cancelar pedido
-              </h2>
-              <p className="text-sm font-medium opacity-70">
-                Registra la cancelación por falta de pago.
-              </p>
-            </div>
-          </div>
+						<div>
+							<h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
+								Cancelar pedido
+							</h2>
+							<p className="text-sm font-medium opacity-70">
+								Registra la cancelación por falta de pago.
+							</p>
+						</div>
+					</div>
 
-          <button
-            aria-label="Cerrar"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-            onClick={onClose}
-            type="button"
-          >
-            <X size={16} />
-          </button>
-        </header>
+					<button
+						aria-label="Cerrar"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6">
-          <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
-              <p className="mt-1 text-sm font-bold">{order.customerName}</p>
-            </div>
+				<div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6">
+					<div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Cliente</p>
+							<p className="mt-1 text-sm font-bold">{order.customerName}</p>
+						</div>
 
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Monto</p>
-              <p className="mt-1 text-sm font-bold">{formatBolivianos(order.cashToCollect)}</p>
-            </div>
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Monto</p>
+							<p className="mt-1 text-sm font-bold">
+								{formatBolivianos(order.cashToCollect)}
+							</p>
+						</div>
 
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Fecha</p>
-              <p className="mt-1 text-sm font-bold">{currentDate}</p>
-            </div>
-          </div>
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Fecha</p>
+							<p className="mt-1 text-sm font-bold">{currentDate}</p>
+						</div>
+					</div>
 
-          <div className="rounded-2xl border border-(--theme-error-border) bg-(--theme-error-bg) p-4 text-sm font-semibold text-(--theme-error)">
-            El pedido será marcado como CANCELADO porque el cliente no realizó
-            el pago contra entrega.
-          </div>
+					<div className="rounded-2xl border border-(--theme-error-border) bg-(--theme-error-bg) p-4 text-sm font-semibold text-(--theme-error)">
+						El pedido será marcado como CANCELADO porque el cliente no realizó
+						el pago contra entrega.
+					</div>
 
-          <label className="block text-sm font-bold">
-            Observaciones adicionales
-            <textarea
-              className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-(--theme-error-border)"
-              onChange={(event) => setNotes(event.target.value)}
-              placeholder="Ej: El cliente indicó que no realizará el pago..."
-              value={notes}
-            />
-          </label>
-        </div>
+					<label className="block text-sm font-bold">
+						Observaciones adicionales
+						<textarea
+							className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-(--theme-error-border)"
+							onChange={(event) => setNotes(event.target.value)}
+							placeholder="Ej: El cliente indicó que no realizará el pago..."
+							value={notes}
+						/>
+					</label>
+				</div>
 
-        <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
-          <button
-            className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
-            onClick={onClose}
-            type="button"
-          >
-            Volver
-          </button>
+				<footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
+					<button
+						className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
+						onClick={onClose}
+						type="button"
+					>
+						Volver
+					</button>
 
-          <button
-            className="inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full bg-(--theme-error) px-5 text-sm font-black uppercase text-(--theme-bg) transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={isSaving}
-            onClick={confirmCancellation}
-            type="button"
-          >
-            {isSaving ? (
-              <LoaderCircle className="animate-spin" size={16} />
-            ) : (
-              <XCircle size={16} />
-            )}
-            Confirmar cancelación
-          </button>
-        </footer>
-      </section>
-    </div>
-  );
+					<button
+						className="inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full bg-(--theme-error) px-5 text-sm font-black uppercase text-(--theme-bg) transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+						disabled={isSaving}
+						onClick={confirmCancellation}
+						type="button"
+					>
+						{isSaving ? (
+							<LoaderCircle className="animate-spin" size={16} />
+						) : (
+							<XCircle size={16} />
+						)}
+						Confirmar cancelación
+					</button>
+				</footer>
+			</section>
+		</div>
+	);
 }

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -1,269 +1,294 @@
-import { AlertTriangle, CheckCircle2, LoaderCircle, PackageCheck, X, XCircle } from 'lucide-react';
-import { useState } from 'react';
-import { parseOrderId } from '../../cart/services/orderService';
-import type { MessengerOrder } from '../types';
-import { formatBolivianos } from '../utils/money';
+import {
+	AlertTriangle,
+	CheckCircle2,
+	LoaderCircle,
+	PackageCheck,
+	X,
+	XCircle,
+} from "lucide-react";
+import { useState } from "react";
+import { parseOrderId } from "../../cart/services/orderService";
+import type { MessengerOrder } from "../types";
+import { formatBolivianos } from "../utils/money";
 
-type AssignedOrderAction = 'accept' | 'reject';
+type AssignedOrderAction = "accept" | "reject";
 
 interface ConfirmAssignedOrderActionModalProps {
-  order: MessengerOrder;
-  action: AssignedOrderAction;
-  isSaving: boolean;
-  onClose: () => void;
-  onConfirm: (reason?: string) => Promise<void>;
+	order: MessengerOrder;
+	action: AssignedOrderAction;
+	isSaving: boolean;
+	onClose: () => void;
+	onConfirm: (reason?: string) => Promise<void>;
 }
 
 const actionConfig = {
-  accept: {
-    title: 'Aceptar pedido asignado',
-    description: 'Confirma que tomarás este pedido para continuar con la entrega.',
-    buttonLabel: 'Confirmar',
-    Icon: CheckCircle2,
-    iconClassName: 'bg-primary/15 text-primary',
-    buttonClassName: 'bg-primary text-primary-action hover:opacity-90',
-    warning:
-      'El pedido pasará a Pedidos aceptados y quedará bajo tu responsabilidad.',
-  },
-  reject: {
-    title: 'Rechazar pedido asignado',
-    description: 'Confirma que no podrás atender este pedido asignado.',
-    buttonLabel: 'Confirmar',
-    Icon: XCircle,
-    iconClassName: 'bg-(--theme-error-bg) text-(--theme-error)',
-    buttonClassName: 'bg-(--theme-error) text-(--theme-bg) hover:opacity-90',
-    warning:
-      'El pedido quedará pendiente de reasignación para que el vendedor seleccione otro mensajero.',
-  },
+	accept: {
+		title: "Aceptar pedido asignado",
+		description:
+			"Confirma que tomarás este pedido para continuar con la entrega.",
+		buttonLabel: "Confirmar",
+		Icon: CheckCircle2,
+		iconClassName: "bg-primary/15 text-primary",
+		buttonClassName: "bg-primary text-primary-action hover:opacity-90",
+		warning:
+			"El pedido pasará a Pedidos aceptados y quedará bajo tu responsabilidad.",
+	},
+	reject: {
+		title: "Rechazar pedido asignado",
+		description: "Confirma que no podrás atender este pedido asignado.",
+		buttonLabel: "Confirmar",
+		Icon: XCircle,
+		iconClassName: "bg-(--theme-error-bg) text-(--theme-error)",
+		buttonClassName: "bg-(--theme-error) text-(--theme-bg) hover:opacity-90",
+		warning:
+			"El pedido quedará pendiente de reasignación para que el vendedor seleccione otro mensajero.",
+	},
 } satisfies Record<
-  AssignedOrderAction,
-  {
-    title: string;
-    description: string;
-    buttonLabel: string;
-    Icon: typeof CheckCircle2;
-    iconClassName: string;
-    buttonClassName: string;
-    warning: string;
-  }
+	AssignedOrderAction,
+	{
+		title: string;
+		description: string;
+		buttonLabel: string;
+		Icon: typeof CheckCircle2;
+		iconClassName: string;
+		buttonClassName: string;
+		warning: string;
+	}
 >;
 
 const rejectionReasons = [
-  'No estoy en el campus indicado',
-  'No puedo atender en este horario',
-  'No tengo acceso al edificio o area',
-  'Ubicacion del pedido incompleta',
-  'Entrega fuera de mi recorrido actual',
-  'Otro motivo',
+	"No estoy en el campus indicado",
+	"No puedo atender en este horario",
+	"No tengo acceso al edificio o area",
+	"Ubicacion del pedido incompleta",
+	"Entrega fuera de mi recorrido actual",
+	"Otro motivo",
 ];
 
 export type { AssignedOrderAction };
 
 export default function ConfirmAssignedOrderActionModal({
-  order,
-  action,
-  isSaving,
-  onClose,
-  onConfirm,
+	order,
+	action,
+	isSaving,
+	onClose,
+	onConfirm,
 }: ConfirmAssignedOrderActionModalProps) {
-  const config = actionConfig[action];
-  const { friendlyName } = parseOrderId(order.id);
-  const displayId = order.displayId ?? friendlyName;
-  const Icon = config.Icon;
+	const config = actionConfig[action];
+	const { friendlyName } = parseOrderId(order.id);
+	const displayId = order.displayId ?? friendlyName;
+	const Icon = config.Icon;
 
-  const [reason, setReason] = useState('');
-  const [customReason, setCustomReason] = useState('');
-  const [showCustomInput, setShowCustomInput] = useState(false);
-  const [errorModal, setErrorModal] = useState<string | null>(null);
+	const [reason, setReason] = useState("");
+	const [customReason, setCustomReason] = useState("");
+	const [showCustomInput, setShowCustomInput] = useState(false);
+	const [errorModal, setErrorModal] = useState<string | null>(null);
 
-  const confirmAction = async () => {
-    if (isSaving) return;
+	const confirmAction = async () => {
+		if (isSaving) return;
 
-    // Validar motivo solo para rechazo
-    if (action === 'reject') {
-      const finalReason = reason === 'Otro motivo' ? customReason : reason;
-      if (!finalReason.trim()) {
-        setErrorModal('Debes seleccionar o escribir un motivo para rechazar el pedido.');
-        return;
-      }
-      await onConfirm(finalReason);
-    } else {
-      await onConfirm();
-    }
-  };
+		// Validar motivo solo para rechazo
+		if (action === "reject") {
+			const finalReason = reason === "Otro motivo" ? customReason : reason;
+			if (!finalReason.trim()) {
+				setErrorModal(
+					"Debes seleccionar o escribir un motivo para rechazar el pedido.",
+				);
+				return;
+			}
+			await onConfirm(finalReason);
+		} else {
+			await onConfirm();
+		}
+	};
 
-  const handleReasonSelect = (selectedReason: string) => {
-    setReason(selectedReason);
-    setShowCustomInput(selectedReason === 'Otro motivo');
-    if (selectedReason !== 'Otro motivo') {
-      setCustomReason('');
-    }
-  };
+	const handleReasonSelect = (selectedReason: string) => {
+		setReason(selectedReason);
+		setShowCustomInput(selectedReason === "Otro motivo");
+		if (selectedReason !== "Otro motivo") {
+			setCustomReason("");
+		}
+	};
 
-  const isRejectAction = action === 'reject';
+	const isRejectAction = action === "reject";
 
-  return (
-    <>
-      <div
-        className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) onClose();
-        }}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="assigned-order-action-title"
-      >
-        <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-            <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-              <span
-                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl sm:h-12 sm:w-12 ${config.iconClassName}`}
-              >
-                <Icon size={24} />
-              </span>
+	return (
+		<>
+			<div
+				className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+				onClick={(event) => {
+					if (event.target === event.currentTarget) onClose();
+				}}
+				onKeyDown={(event) => {
+					if (event.key === "Escape") onClose();
+				}}
+				tabIndex={-1}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="assigned-order-action-title"
+			>
+				<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+					<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+						<div className="flex min-w-0 items-center gap-3 sm:gap-4">
+							<span
+								className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl sm:h-12 sm:w-12 ${config.iconClassName}`}
+							>
+								<Icon size={24} />
+							</span>
 
-              <div className="min-w-0">
-                <h2
-                  className="text-lg font-black leading-tight tracking-normal sm:text-xl"
-                  id="assigned-order-action-title"
-                >
-                  {config.title}
-                </h2>
-                <p className="text-sm font-medium leading-snug opacity-70">
-                  {config.description}
-                </p>
-              </div>
-            </div>
+							<div className="min-w-0">
+								<h2
+									className="text-lg font-black leading-tight tracking-normal sm:text-xl"
+									id="assigned-order-action-title"
+								>
+									{config.title}
+								</h2>
+								<p className="text-sm font-medium leading-snug opacity-70">
+									{config.description}
+								</p>
+							</div>
+						</div>
 
-            <button
-              aria-label="Cerrar"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-              disabled={isSaving}
-              onClick={onClose}
-              type="button"
-            >
-              <X size={16} />
-            </button>
-          </header>
+						<button
+							aria-label="Cerrar"
+							className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+							disabled={isSaving}
+							onClick={onClose}
+							type="button"
+						>
+							<X size={16} />
+						</button>
+					</header>
 
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
-            <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
-              <div>
-                <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
-                <p className="mt-1 text-sm font-bold">{displayId}</p>
-              </div>
+					<div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
+						<div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
+							<div>
+								<p className="text-xs font-bold uppercase opacity-50">Pedido</p>
+								<p className="mt-1 text-sm font-bold">{displayId}</p>
+							</div>
 
-              <div>
-                <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
-                <p className="mt-1 text-sm font-bold">{order.customerName}</p>
-              </div>
+							<div>
+								<p className="text-xs font-bold uppercase opacity-50">
+									Cliente
+								</p>
+								<p className="mt-1 text-sm font-bold">{order.customerName}</p>
+							</div>
 
-              <div>
-                <p className="text-xs font-bold uppercase opacity-50">Zona</p>
-                <p className="mt-1 text-sm font-bold">{order.city}</p>
-              </div>
+							<div>
+								<p className="text-xs font-bold uppercase opacity-50">Zona</p>
+								<p className="mt-1 text-sm font-bold">{order.city}</p>
+							</div>
 
-              <div>
-                <p className="text-xs font-bold uppercase opacity-50">
-                  Monto a cobrar
-                </p>
-                <p className="mt-1 text-sm font-bold">
-                  {formatBolivianos(order.cashToCollect)}
-                </p>
-              </div>
-            </div>
+							<div>
+								<p className="text-xs font-bold uppercase opacity-50">
+									Monto a cobrar
+								</p>
+								<p className="mt-1 text-sm font-bold">
+									{formatBolivianos(order.cashToCollect)}
+								</p>
+							</div>
+						</div>
 
-            <div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
-              <PackageCheck className="mt-0.5 shrink-0 text-primary" size={18} />
-              <p>{config.warning}</p>
-            </div>
+						<div className="flex gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 text-sm font-semibold">
+							<PackageCheck
+								className="mt-0.5 shrink-0 text-primary"
+								size={18}
+							/>
+							<p>{config.warning}</p>
+						</div>
 
-            {/* Campo de motivo - solo para rechazo */}
-            {isRejectAction && (
-              <div className="space-y-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4">
-                <p className="text-sm font-bold">Motivo del rechazo:</p>
-                <div className="flex flex-wrap gap-2">
-                  {rejectionReasons.map((reasonOption) => (
-                    <button
-                      key={reasonOption}
-                      className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
-                        reason === reasonOption
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border-light hover:border-primary/50'
-                      }`}
-                      onClick={() => handleReasonSelect(reasonOption)}
-                      type="button"
-                    >
-                      {reasonOption}
-                    </button>
-                  ))}
-                </div>
-                {showCustomInput && (
-                  <textarea
-                    placeholder="Escribe tu motivo..."
-                    className="w-full rounded-xl border border-border-light p-3 text-sm"
-                    value={customReason}
-                    onChange={(e) => setCustomReason(e.target.value)}
-                    rows={2}
-                  />
-                )}
-              </div>
-            )}
-          </div>
+						{/* Campo de motivo - solo para rechazo */}
+						{isRejectAction && (
+							<div className="space-y-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4">
+								<p className="text-sm font-bold">Motivo del rechazo:</p>
+								<div className="flex flex-wrap gap-2">
+									{rejectionReasons.map((reasonOption) => (
+										<button
+											key={reasonOption}
+											className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+												reason === reasonOption
+													? "border-primary bg-primary/10 text-primary"
+													: "border-border-light hover:border-primary/50"
+											}`}
+											onClick={() => handleReasonSelect(reasonOption)}
+											type="button"
+										>
+											{reasonOption}
+										</button>
+									))}
+								</div>
+								{showCustomInput && (
+									<textarea
+										placeholder="Escribe tu motivo..."
+										className="w-full rounded-xl border border-border-light p-3 text-sm"
+										value={customReason}
+										onChange={(e) => setCustomReason(e.target.value)}
+										rows={2}
+									/>
+								)}
+							</div>
+						)}
+					</div>
 
-          <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
-            <button
-              className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={isSaving}
-              onClick={onClose}
-              type="button"
-            >
-              Cancelar
-            </button>
+					<footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
+						<button
+							className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
+							disabled={isSaving}
+							onClick={onClose}
+							type="button"
+						>
+							Cancelar
+						</button>
 
-            <button
-              className={`inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full px-5 text-sm font-black uppercase transition disabled:cursor-not-allowed disabled:opacity-50 ${config.buttonClassName}`}
-              disabled={isSaving}
-              onClick={confirmAction}
-              type="button"
-            >
-              {isSaving ? (
-                <LoaderCircle className="animate-spin" size={16} />
-              ) : (
-                <Icon size={16} />
-              )}
-              {config.buttonLabel}
-            </button>
-          </footer>
-        </section>
-      </div>
+						<button
+							className={`inline-flex h-12 flex-[1.4] items-center justify-center gap-2 rounded-full px-5 text-sm font-black uppercase transition disabled:cursor-not-allowed disabled:opacity-50 ${config.buttonClassName}`}
+							disabled={isSaving}
+							onClick={confirmAction}
+							type="button"
+						>
+							{isSaving ? (
+								<LoaderCircle className="animate-spin" size={16} />
+							) : (
+								<Icon size={16} />
+							)}
+							{config.buttonLabel}
+						</button>
+					</footer>
+				</section>
+			</div>
 
-      {/* Modal de error */}
-      {errorModal && (
-        <div
-          className="fixed inset-0 z-[9999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-          onClick={() => setErrorModal(null)}
-        >
-          <div className="my-2 w-full max-w-md rounded-[24px] border border-(--theme-error-border) bg-card-bg-light p-4 shadow-2xl sm:my-auto sm:rounded-[28px] sm:p-6">
-            <div className="flex items-center gap-4">
-              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-(--theme-error-bg) text-(--theme-error)">
-                <AlertTriangle size={24} />
-              </span>
-              <div>
-                <h3 className="text-lg font-black">Error</h3>
-                <p className="text-sm font-semibold opacity-80">{errorModal}</p>
-              </div>
-            </div>
-            <button
-              className="mt-6 w-full rounded-full border border-border-light bg-card-bg-light py-3 text-sm font-black uppercase transition hover:bg-secondary-bg-light"
-              onClick={() => setErrorModal(null)}
-              type="button"
-            >
-              Entendido
-            </button>
-          </div>
-        </div>
-      )}
-    </>
-  );
+			{/* Modal de error */}
+			{errorModal && (
+				<div
+					className="fixed inset-0 z-[9999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+					onClick={() => setErrorModal(null)}
+					onKeyDown={(event) => {
+						if (event.key === "Escape") setErrorModal(null);
+					}}
+					tabIndex={-1}
+					role="dialog"
+					aria-modal="true"
+				>
+					<div className="my-2 w-full max-w-md rounded-[24px] border border-(--theme-error-border) bg-card-bg-light p-4 shadow-2xl sm:my-auto sm:rounded-[28px] sm:p-6">
+						<div className="flex items-center gap-4">
+							<span className="flex h-12 w-12 items-center justify-center rounded-full bg-(--theme-error-bg) text-(--theme-error)">
+								<AlertTriangle size={24} />
+							</span>
+							<div>
+								<h3 className="text-lg font-black">Error</h3>
+								<p className="text-sm font-semibold opacity-80">{errorModal}</p>
+							</div>
+						</div>
+						<button
+							className="mt-6 w-full rounded-full border border-border-light bg-card-bg-light py-3 text-sm font-black uppercase transition hover:bg-secondary-bg-light"
+							onClick={() => setErrorModal(null)}
+							type="button"
+						>
+							Entendido
+						</button>
+					</div>
+				</div>
+			)}
+		</>
+	);
 }

--- a/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
+++ b/src/features/mensajero/modals/ConfirmAssignedOrderActionModal.tsx
@@ -49,11 +49,11 @@ const actionConfig = {
 >;
 
 const rejectionReasons = [
-  'Pedido muy lejos de mi zona',
-  'No tengo disponibilidad horaria',
-  'El pedido es demasiado grande para mi vehículo',
-  'Problemas con mi vehículo',
-  'No conozco la zona de entrega',
+  'No estoy en el campus indicado',
+  'No puedo atender en este horario',
+  'No tengo acceso al edificio o area',
+  'Ubicacion del pedido incompleta',
+  'Entrega fuera de mi recorrido actual',
   'Otro motivo',
 ];
 
@@ -105,7 +105,7 @@ export default function ConfirmAssignedOrderActionModal({
   return (
     <>
       <div
-        className="fixed inset-0 z-[999] flex items-center justify-center overflow-y-auto bg-black/65 p-4 backdrop-blur-sm"
+        className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
         onClick={(event) => {
           if (event.target === event.currentTarget) onClose();
         }}
@@ -113,23 +113,23 @@ export default function ConfirmAssignedOrderActionModal({
         aria-modal="true"
         aria-labelledby="assigned-order-action-title"
       >
-        <section className="flex max-h-[calc(100vh-2rem)] w-full max-w-lg flex-col overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-          <header className="shrink-0 flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
-            <div className="flex items-center gap-4">
+        <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+            <div className="flex min-w-0 items-center gap-3 sm:gap-4">
               <span
-                className={`flex h-12 w-12 items-center justify-center rounded-2xl ${config.iconClassName}`}
+                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl sm:h-12 sm:w-12 ${config.iconClassName}`}
               >
                 <Icon size={24} />
               </span>
 
-              <div>
+              <div className="min-w-0">
                 <h2
-                  className="text-xl font-black tracking-normal"
+                  className="text-lg font-black leading-tight tracking-normal sm:text-xl"
                   id="assigned-order-action-title"
                 >
                   {config.title}
                 </h2>
-                <p className="text-sm font-medium opacity-70">
+                <p className="text-sm font-medium leading-snug opacity-70">
                   {config.description}
                 </p>
               </div>
@@ -146,7 +146,7 @@ export default function ConfirmAssignedOrderActionModal({
             </button>
           </header>
 
-          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-6">
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
             <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-2">
               <div>
                 <p className="text-xs font-bold uppercase opacity-50">Pedido</p>
@@ -211,7 +211,7 @@ export default function ConfirmAssignedOrderActionModal({
             )}
           </div>
 
-          <footer className="shrink-0 flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
+          <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
             <button
               className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase disabled:cursor-not-allowed disabled:opacity-50"
               disabled={isSaving}
@@ -241,10 +241,10 @@ export default function ConfirmAssignedOrderActionModal({
       {/* Modal de error */}
       {errorModal && (
         <div
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+          className="fixed inset-0 z-[9999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
           onClick={() => setErrorModal(null)}
         >
-          <div className="w-full max-w-md rounded-[28px] border border-(--theme-error-border) bg-card-bg-light p-6 shadow-2xl">
+          <div className="my-2 w-full max-w-md rounded-[24px] border border-(--theme-error-border) bg-card-bg-light p-4 shadow-2xl sm:my-auto sm:rounded-[28px] sm:p-6">
             <div className="flex items-center gap-4">
               <span className="flex h-12 w-12 items-center justify-center rounded-full bg-(--theme-error-bg) text-(--theme-error)">
                 <AlertTriangle size={24} />

--- a/src/features/mensajero/modals/Confirmpaymentmodal.tsx
+++ b/src/features/mensajero/modals/Confirmpaymentmodal.tsx
@@ -39,15 +39,15 @@ const canSubmit = secret.trim().length > 0 && !saving;
 
     return (
         <div
-            className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
             onClick={(e) => {
                 if (e.target === e.currentTarget && !saving) onClose();
             }}
         >
-            <section className="w-full max-w-md rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
+            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
 
                 {/* Header */}
-                <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
+                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
                     <div>
                         <h2 className="text-xl font-black tracking-tight">
                             Registrar pago
@@ -67,7 +67,7 @@ const canSubmit = secret.trim().length > 0 && !saving;
                     </button>
                 </header>
 
-                <div className="space-y-5 p-6">
+                <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4 sm:p-6">
 
                     {/* Resumen del pedido */}
                     <article className="messenger-cash-box rounded-[20px] border-2 p-5 space-y-3">

--- a/src/features/mensajero/modals/Confirmpaymentmodal.tsx
+++ b/src/features/mensajero/modals/Confirmpaymentmodal.tsx
@@ -1,145 +1,144 @@
-import { useState } from 'react';
-import { CheckCircle2, KeyRound, X } from 'lucide-react';
-import type { MessengerOrder } from '../types';
-import { parseOrderId } from '../../cart/services/orderService';
-import { formatBolivianos } from '../utils/money';
+import { CheckCircle2, KeyRound, X } from "lucide-react";
+import { useState } from "react";
+import { parseOrderId } from "../../cart/services/orderService";
+import type { MessengerOrder } from "../types";
+import { formatBolivianos } from "../utils/money";
 
 interface ConfirmPaymentModalProps {
-    order: MessengerOrder;
-    onClose: () => void;
-    onConfirm: (order: MessengerOrder, secret: string) => Promise<void>;
+	order: MessengerOrder;
+	onClose: () => void;
+	onConfirm: (order: MessengerOrder, secret: string) => Promise<void>;
 }
 
 export default function ConfirmPaymentModal({
-    order,
-    onClose,
-    onConfirm,
+	order,
+	onClose,
+	onConfirm,
 }: ConfirmPaymentModalProps) {
-    const [secret, setSecret] = useState('');
-    const [saving, setSaving] = useState(false);
+	const [secret, setSecret] = useState("");
+	const [saving, setSaving] = useState(false);
 
-    const [error, setError] = useState('');
-    const orderDisplayId = order.displayId ?? parseOrderId(order.id).friendlyName;
+	const [error, setError] = useState("");
+	const orderDisplayId = order.displayId ?? parseOrderId(order.id).friendlyName;
 
-const canSubmit = secret.trim().length > 0 && !saving;
+	const canSubmit = secret.trim().length > 0 && !saving;
 
-    const handleConfirm = async () => {
-        if (!canSubmit) return;
-        setError('');
-        setSaving(true);
-        try {
-                await onConfirm(order, secret.trim());
-        } catch (err) {
-            console.error(err);
-            setError('Código incorrecto o no se pudo registrar el pago.');
-        } finally {
-            setSaving(false);
-        }
-    };
+	const handleConfirm = async () => {
+		if (!canSubmit) return;
+		setError("");
+		setSaving(true);
+		try {
+			await onConfirm(order, secret.trim());
+		} catch (err) {
+			console.error(err);
+			setError("Código incorrecto o no se pudo registrar el pago.");
+		} finally {
+			setSaving(false);
+		}
+	};
 
-    return (
-        <div
-            className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-            onClick={(e) => {
-                if (e.target === e.currentTarget && !saving) onClose();
-            }}
-        >
-            <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(e) => {
+				if (e.target === e.currentTarget && !saving) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape" && !saving) onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				{/* Header */}
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div>
+						<h2 className="text-xl font-black tracking-tight">
+							Registrar pago
+						</h2>
+						<p className="mt-0.5 text-sm font-semibold opacity-60">
+							Ingresa el código del comprador para confirmar.
+						</p>
+					</div>
+					<button
+						aria-label="Cerrar"
+						className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+						disabled={saving}
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-                {/* Header */}
-                <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-                    <div>
-                        <h2 className="text-xl font-black tracking-tight">
-                            Registrar pago
-                        </h2>
-                        <p className="mt-0.5 text-sm font-semibold opacity-60">
-                            Ingresa el código del comprador para confirmar.
-                        </p>
-                    </div>
-                    <button
-                        aria-label="Cerrar"
-                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-                        onClick={onClose}
-                        type="button"
-                        disabled={saving}
-                    >
-                        <X size={16} />
-                    </button>
-                </header>
+				<div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4 sm:p-6">
+					{/* Resumen del pedido */}
+					<article className="messenger-cash-box rounded-[20px] border-2 p-5 space-y-3">
+						<div className="flex justify-between items-center">
+							<span className="messenger-muted text-xs font-bold uppercase">
+								Orden
+							</span>
+							<span className="text-sm font-black">{orderDisplayId}</span>
+						</div>
+						<div className="flex justify-between items-center">
+							<span className="messenger-muted text-xs font-bold uppercase">
+								Cliente
+							</span>
+							<span className="text-sm font-black">{order.customerName}</span>
+						</div>
+						<div className="border-t border-border-light pt-3 flex justify-between items-center">
+							<span className="text-xs font-bold uppercase">
+								Total a cobrar
+							</span>
+							<span className="text-2xl font-black text-primary">
+								{formatBolivianos(order.cashToCollect)}
+							</span>
+						</div>
+					</article>
 
-                <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4 sm:p-6">
+					{/* Input de código secret */}
+					<div className="space-y-2">
+						<label
+							htmlFor="secret-input"
+							className="flex items-center gap-2 text-xs font-bold uppercase messenger-muted"
+						>
+							<KeyRound size={13} />
+							Código de confirmación del comprador
+						</label>
+						<input
+							id="secret-input"
+							type="text"
+							value={secret}
+							onChange={(e) => {
+								setSecret(e.target.value);
+								setError("");
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") void handleConfirm();
+							}}
+							placeholder="Ingresa el código secret"
+							className="w-full rounded-2xl border-2 border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-bold text-text-light outline-none transition placeholder:font-normal placeholder:opacity-50 focus:border-primary"
+							autoComplete="off"
+							disabled={saving}
+						/>
+						{error && (
+							<p className="text-xs font-bold text-(--theme-error)">{error}</p>
+						)}
+					</div>
 
-                    {/* Resumen del pedido */}
-                    <article className="messenger-cash-box rounded-[20px] border-2 p-5 space-y-3">
-                        <div className="flex justify-between items-center">
-                            <span className="messenger-muted text-xs font-bold uppercase">
-                                Orden
-                                </span>
-                                <span className="text-sm font-black">
-                                    {orderDisplayId}
-                                </span>
-                        </div>
-                        <div className="flex justify-between items-center">
-                            <span className="messenger-muted text-xs font-bold uppercase">
-                                Cliente
-                            </span>
-                            <span className="text-sm font-black">{order.customerName}</span>
-                        </div>
-                        <div className="border-t border-border-light pt-3 flex justify-between items-center">
-                            <span className="text-xs font-bold uppercase">Total a cobrar</span>
-                            <span className="text-2xl font-black text-primary">
-                                {formatBolivianos(order.cashToCollect)}
-                            </span>
-                        </div>
-                    </article>
-
-
-                    
-                        <>
-                            {/* Input de código secret */}
-                            <div className="space-y-2">
-                                <label
-                                    htmlFor="secret-input"
-                                    className="flex items-center gap-2 text-xs font-bold uppercase messenger-muted"
-                                >
-                                    <KeyRound size={13} />
-                                    Código de confirmación del comprador
-                                </label>
-                                <input
-                                    id="secret-input"
-                                    type="text"
-                                    value={secret}
-                                    onChange={(e) => {
-                                        setSecret(e.target.value);
-                                        setError('');
-                                    }}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter') void handleConfirm();
-                                    }}
-                                    placeholder="Ingresa el código secret"
-                                    className="w-full rounded-2xl border-2 border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-bold text-text-light outline-none transition placeholder:font-normal placeholder:opacity-50 focus:border-primary"
-                                    autoComplete="off"
-                                    disabled={saving}
-                                />
-                                {error && (
-                                    <p className="text-xs font-bold text-(--theme-error)">{error}</p>
-                                )}
-                            </div>
-
-                            {/* Botón de confirmar */}
-                            <button
-                                className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
-                                onClick={() => void handleConfirm()}
-                                type="button"
-                                disabled={!canSubmit}
-                            >
-                                <CheckCircle2 size={17} />
-                                {saving ? 'Registrando...' : 'Registrar pago'}
-                            </button>
-                        </>
-                    
-                </div>
-            </section>
-        </div>
-    );
+					{/* Botón de confirmar */}
+					<button
+						className="messenger-deliver-button inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-6 text-sm font-bold transition active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
+						onClick={() => void handleConfirm()}
+						type="button"
+						disabled={!canSubmit}
+					>
+						<CheckCircle2 size={17} />
+						{saving ? "Registrando..." : "Registrar pago"}
+					</button>
+				</div>
+			</section>
+		</div>
+	);
 }

--- a/src/features/mensajero/modals/PaymentSuccessModal.tsx
+++ b/src/features/mensajero/modals/PaymentSuccessModal.tsx
@@ -1,57 +1,58 @@
-import { X } from 'lucide-react';
-
 interface Props {
-  onClose: () => void;
+	onClose: () => void;
 }
 
 export default function PaymentSuccessModal({ onClose }: Props) {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-2 sm:p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="success-title"
-    >
-      <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-      />
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-2 sm:p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="success-title"
+		>
+			<button
+				type="button"
+				aria-label="Cerrar confirmación"
+				className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+				onClick={onClose}
+			/>
 
-      <div className="relative z-10 my-2 w-full max-w-sm rounded-2xl border border-border-light bg-card-bg-light p-5 shadow-2xl sm:my-auto sm:p-6">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          </div>
-          <h2 id="success-title" className="text-lg font-bold text-text-light">
-            ¡Pago registrado!
-          </h2>
-          <p className="text-sm text-text-light opacity-70">
-            El pago ha sido registrado exitosamente.
-          </p>
-        </div>
+			<div className="relative z-10 my-2 w-full max-w-sm rounded-2xl border border-border-light bg-card-bg-light p-5 shadow-2xl sm:my-auto sm:p-6">
+				<div className="flex flex-col items-center gap-3 text-center">
+					<div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="28"
+							height="28"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true"
+						>
+							<polyline points="20 6 9 17 4 12" />
+						</svg>
+					</div>
+					<h2 id="success-title" className="text-lg font-bold text-text-light">
+						¡Pago registrado!
+					</h2>
+					<p className="text-sm text-text-light opacity-70">
+						El pago ha sido registrado exitosamente.
+					</p>
+				</div>
 
-        <div className="mt-6">
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex w-full items-center justify-center rounded-full bg-primary px-4 py-3 text-sm font-semibold text-primary-action transition hover:opacity-90 active:scale-95"
-          >
-            Aceptar
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="mt-6">
+					<button
+						type="button"
+						onClick={onClose}
+						className="flex w-full items-center justify-center rounded-full bg-primary px-4 py-3 text-sm font-semibold text-primary-action transition hover:opacity-90 active:scale-95"
+					>
+						Aceptar
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/features/mensajero/modals/PaymentSuccessModal.tsx
+++ b/src/features/mensajero/modals/PaymentSuccessModal.tsx
@@ -7,7 +7,7 @@ interface Props {
 export default function PaymentSuccessModal({ onClose }: Props) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-2 sm:p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="success-title"
@@ -17,7 +17,7 @@ export default function PaymentSuccessModal({ onClose }: Props) {
         onClick={onClose}
       />
 
-      <div className="relative z-10 w-full max-w-sm rounded-2xl border border-border-light bg-card-bg-light p-6 shadow-2xl">
+      <div className="relative z-10 my-2 w-full max-w-sm rounded-2xl border border-border-light bg-card-bg-light p-5 shadow-2xl sm:my-auto sm:p-6">
         <div className="flex flex-col items-center gap-3 text-center">
           <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
             <svg

--- a/src/features/mensajero/modals/UndeliveredModal.tsx
+++ b/src/features/mensajero/modals/UndeliveredModal.tsx
@@ -74,22 +74,22 @@ export default function UndeliveredModal({
 
   return (
     <div
-      className="fixed inset-0 z-[999] flex items-center justify-center bg-black/65 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <section className="w-full max-w-lg overflow-hidden rounded-[28px] border border-border-light bg-card-bg-light text-text-light shadow-2xl">
-        <header className="flex items-start justify-between gap-4 border-b border-border-light px-6 py-5">
-          <div className="flex items-center gap-4">
-            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary sm:h-12 sm:w-12">
               <PackageX size={24} />
             </span>
-            <div>
-              <h2 className="text-xl font-black tracking-normal">
+            <div className="min-w-0">
+              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
                 Problema de entrega
               </h2>
-              <p className="text-sm font-medium opacity-70">
+              <p className="text-sm font-medium leading-snug opacity-70">
                 Registra el motivo por el que no se pudo entregar el pedido
               </p>
             </div>
@@ -105,7 +105,7 @@ export default function UndeliveredModal({
           </button>
         </header>
 
-        <div className="space-y-6 px-6 py-6">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
           <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
             <div>
               <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
@@ -172,7 +172,7 @@ export default function UndeliveredModal({
           </label>
         </div>
 
-        <footer className="flex flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-6 py-5 sm:flex-row">
+        <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
           <button
             className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
             onClick={onClose}
@@ -181,7 +181,7 @@ export default function UndeliveredModal({
             Cancelar
           </button>
           <button
-            className="inline-flex h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-black uppercase text-primary-action transition disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex min-h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-center text-sm font-black uppercase leading-tight text-primary-action transition disabled:cursor-not-allowed disabled:opacity-50"
             disabled={!canSubmit || isSaving}
             onClick={confirmIncident}
             type="button"

--- a/src/features/mensajero/modals/UndeliveredModal.tsx
+++ b/src/features/mensajero/modals/UndeliveredModal.tsx
@@ -1,200 +1,206 @@
-import { useMemo, useState } from 'react';
 import {
-  DollarSign,
-  HandMetal,
-  LoaderCircle,
-  MapPinOff,
-  MoreHorizontal,
-  PackageX,
-  ShieldAlert,
-  UserX,
-  X,
-} from 'lucide-react';
-import type { MessengerOrder } from '../types';
+	DollarSign,
+	HandMetal,
+	LoaderCircle,
+	MapPinOff,
+	MoreHorizontal,
+	PackageX,
+	ShieldAlert,
+	UserX,
+	X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import type { MessengerOrder } from "../types";
 
 interface UndeliveredModalProps {
-  order: MessengerOrder;
-  isSaving: boolean;
-  onClose: () => void;
-  onConfirm: (reason: string, notes: string) => Promise<void>;
+	order: MessengerOrder;
+	isSaving: boolean;
+	onClose: () => void;
+	onConfirm: (reason: string, notes: string) => Promise<void>;
 }
 
 const reasons = [
-  { id: 'cliente_ausente', label: 'Cliente ausente', icon: UserX },
-  {
-    id: 'direccion_incorrecta',
-    label: 'Direccion incorrecta',
-    icon: MapPinOff,
-  },
-  {
-    id: 'acceso_restringido',
-    label: 'Acceso restringido',
-    icon: ShieldAlert,
-  },
-  {
-    id: 'falta_pago_cliente',
-    label: 'Falta de pago del cliente',
-    icon: DollarSign,
-  },
-  { id: 'cliente_rechazo', label: 'Cliente rechazo pedido', icon: HandMetal },
-  { id: 'otro', label: 'Otro motivo', icon: MoreHorizontal },
+	{ id: "cliente_ausente", label: "Cliente ausente", icon: UserX },
+	{
+		id: "direccion_incorrecta",
+		label: "Direccion incorrecta",
+		icon: MapPinOff,
+	},
+	{
+		id: "acceso_restringido",
+		label: "Acceso restringido",
+		icon: ShieldAlert,
+	},
+	{
+		id: "falta_pago_cliente",
+		label: "Falta de pago del cliente",
+		icon: DollarSign,
+	},
+	{ id: "cliente_rechazo", label: "Cliente rechazo pedido", icon: HandMetal },
+	{ id: "otro", label: "Otro motivo", icon: MoreHorizontal },
 ];
 
 export default function UndeliveredModal({
-  order,
-  isSaving,
-  onClose,
-  onConfirm,
+	order,
+	isSaving,
+	onClose,
+	onConfirm,
 }: UndeliveredModalProps) {
-  const [selectedReason, setSelectedReason] = useState('');
-  const [otherReason, setOtherReason] = useState('');
-  const [notes, setNotes] = useState('');
+	const [selectedReason, setSelectedReason] = useState("");
+	const [otherReason, setOtherReason] = useState("");
+	const [notes, setNotes] = useState("");
 
-  const currentDate = useMemo(
-    () =>
-      new Intl.DateTimeFormat('es-BO', {
-        dateStyle: 'short',
-        timeStyle: 'short',
-      }).format(new Date()),
-    []
-  );
+	const currentDate = useMemo(
+		() =>
+			new Intl.DateTimeFormat("es-BO", {
+				dateStyle: "short",
+				timeStyle: "short",
+			}).format(new Date()),
+		[],
+	);
 
-  const reasonText =
-    selectedReason === 'otro'
-      ? otherReason.trim()
-      : reasons.find((reason) => reason.id === selectedReason)?.label || '';
-  const canSubmit =
-    reasonText.length > 0 &&
-    (selectedReason !== 'otro' || otherReason.trim().length > 3);
+	const reasonText =
+		selectedReason === "otro"
+			? otherReason.trim()
+			: reasons.find((reason) => reason.id === selectedReason)?.label || "";
+	const canSubmit =
+		reasonText.length > 0 &&
+		(selectedReason !== "otro" || otherReason.trim().length > 3);
 
-  const confirmIncident = async () => {
-    if (!canSubmit || isSaving) return;
-    await onConfirm(reasonText, notes.trim());
-  };
+	const confirmIncident = async () => {
+		if (!canSubmit || isSaving) return;
+		await onConfirm(reasonText, notes.trim());
+	};
 
-  return (
-    <div
-      className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary sm:h-12 sm:w-12">
-              <PackageX size={24} />
-            </span>
-            <div className="min-w-0">
-              <h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
-                Problema de entrega
-              </h2>
-              <p className="text-sm font-medium leading-snug opacity-70">
-                Registra el motivo por el que no se pudo entregar el pedido
-              </p>
-            </div>
-          </div>
+	return (
+		<div
+			className="fixed inset-0 z-[999] flex items-start justify-center overflow-y-auto bg-black/65 p-2 backdrop-blur-sm sm:p-4"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+			role="dialog"
+			aria-modal="true"
+		>
+			<section className="my-2 flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-[24px] border border-border-light bg-card-bg-light text-text-light shadow-2xl sm:my-0 sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-border-light px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div className="flex min-w-0 items-center gap-3 sm:gap-4">
+						<span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary sm:h-12 sm:w-12">
+							<PackageX size={24} />
+						</span>
+						<div className="min-w-0">
+							<h2 className="text-lg font-black leading-tight tracking-normal sm:text-xl">
+								Problema de entrega
+							</h2>
+							<p className="text-sm font-medium leading-snug opacity-70">
+								Registra el motivo por el que no se pudo entregar el pedido
+							</p>
+						</div>
+					</div>
 
-          <button
-            aria-label="Cerrar"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
-            onClick={onClose}
-            type="button"
-          >
-            <X size={16} />
-          </button>
-        </header>
+					<button
+						aria-label="Cerrar"
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-secondary-bg-light transition hover:text-primary"
+						onClick={onClose}
+						type="button"
+					>
+						<X size={16} />
+					</button>
+				</header>
 
-        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
-          <div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Cliente</p>
-              <p className="mt-1 text-sm font-bold">{order.customerName}</p>
-            </div>
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Zona</p>
-              <p className="mt-1 text-sm font-bold">{order.city}</p>
-            </div>
-            <div>
-              <p className="text-xs font-bold uppercase opacity-50">Fecha</p>
-              <p className="mt-1 text-sm font-bold">{currentDate}</p>
-            </div>
-          </div>
+				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
+					<div className="grid gap-3 rounded-2xl border border-border-light bg-secondary-bg-light/60 p-4 sm:grid-cols-3">
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Cliente</p>
+							<p className="mt-1 text-sm font-bold">{order.customerName}</p>
+						</div>
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Zona</p>
+							<p className="mt-1 text-sm font-bold">{order.city}</p>
+						</div>
+						<div>
+							<p className="text-xs font-bold uppercase opacity-50">Fecha</p>
+							<p className="mt-1 text-sm font-bold">{currentDate}</p>
+						</div>
+					</div>
 
-          <div>
-            <p className="mb-3 text-xs font-bold uppercase tracking-[0.12em] opacity-60">
-              Selecciona el problema
-            </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {reasons.map((reason) => {
-                const Icon = reason.icon;
-                const active = selectedReason === reason.id;
+					<div>
+						<p className="mb-3 text-xs font-bold uppercase tracking-[0.12em] opacity-60">
+							Selecciona el problema
+						</p>
+						<div className="grid gap-3 sm:grid-cols-2">
+							{reasons.map((reason) => {
+								const Icon = reason.icon;
+								const active = selectedReason === reason.id;
 
-                return (
-                  <button
-                    className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left text-sm font-bold transition ${
-                      active
-                        ? 'border-primary bg-primary/15 text-primary'
-                        : 'border-border-light bg-card-bg-light hover:border-primary/50'
-                    }`}
-                    key={reason.id}
-                    onClick={() => setSelectedReason(reason.id)}
-                    type="button"
-                  >
-                    <Icon size={18} />
-                    {reason.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+								return (
+									<button
+										className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left text-sm font-bold transition ${
+											active
+												? "border-primary bg-primary/15 text-primary"
+												: "border-border-light bg-card-bg-light hover:border-primary/50"
+										}`}
+										key={reason.id}
+										onClick={() => setSelectedReason(reason.id)}
+										type="button"
+									>
+										<Icon size={18} />
+										{reason.label}
+									</button>
+								);
+							})}
+						</div>
+					</div>
 
-          {selectedReason === 'otro' && (
-            <label className="block text-sm font-bold">
-              Describe el motivo
-              <textarea
-                className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-primary"
-                onChange={(event) => setOtherReason(event.target.value)}
-                placeholder="Ej: El edificio estaba cerrado..."
-                value={otherReason}
-              />
-            </label>
-          )}
+					{selectedReason === "otro" && (
+						<label className="block text-sm font-bold">
+							Describe el motivo
+							<textarea
+								className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-primary"
+								onChange={(event) => setOtherReason(event.target.value)}
+								placeholder="Ej: El edificio estaba cerrado..."
+								value={otherReason}
+							/>
+						</label>
+					)}
 
-          <label className="block text-sm font-bold">
-            Observaciones adicionales
-            <textarea
-              className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-primary"
-              onChange={(event) => setNotes(event.target.value)}
-              placeholder="Ej: Se intento llamar 2 veces..."
-              value={notes}
-            />
-          </label>
-        </div>
+					<label className="block text-sm font-bold">
+						Observaciones adicionales
+						<textarea
+							className="mt-2 min-h-24 w-full resize-none rounded-2xl border border-border-light bg-secondary-bg-light px-4 py-3 text-sm font-medium outline-none focus:border-primary"
+							onChange={(event) => setNotes(event.target.value)}
+							placeholder="Ej: Se intento llamar 2 veces..."
+							value={notes}
+						/>
+					</label>
+				</div>
 
-        <footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
-          <button
-            className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
-            onClick={onClose}
-            type="button"
-          >
-            Cancelar
-          </button>
-          <button
-            className="inline-flex min-h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-center text-sm font-black uppercase leading-tight text-primary-action transition disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!canSubmit || isSaving}
-            onClick={confirmIncident}
-            type="button"
-          >
-            {isSaving ? (
-              <LoaderCircle className="animate-spin" size={16} />
-            ) : (
-              <PackageX size={16} />
-            )}
-            Registrar como no entregado
-          </button>
-        </footer>
-      </section>
-    </div>
-  );
+				<footer className="flex shrink-0 flex-col gap-3 border-t border-border-light bg-secondary-bg-light/50 px-4 py-3 sm:flex-row sm:px-6 sm:py-4">
+					<button
+						className="inline-flex h-12 flex-1 items-center justify-center rounded-full border border-border-light bg-card-bg-light text-sm font-black uppercase"
+						onClick={onClose}
+						type="button"
+					>
+						Cancelar
+					</button>
+					<button
+						className="inline-flex min-h-12 flex-[1.2] items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-center text-sm font-black uppercase leading-tight text-primary-action transition disabled:cursor-not-allowed disabled:opacity-50"
+						disabled={!canSubmit || isSaving}
+						onClick={confirmIncident}
+						type="button"
+					>
+						{isSaving ? (
+							<LoaderCircle className="animate-spin" size={16} />
+						) : (
+							<PackageX size={16} />
+						)}
+						Registrar como no entregado
+					</button>
+				</footer>
+			</section>
+		</div>
+	);
 }

--- a/src/features/profile/ProfileView.tsx
+++ b/src/features/profile/ProfileView.tsx
@@ -1,536 +1,672 @@
-import { useEffect, useState } from 'react';
-import { onAuthStateChanged } from 'firebase/auth';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
-import { auth, db } from '../../lib/firebase';
-import { getDeliveryStatsByCourier } from './courierServices.ts';
-import { Pencil, Check, X, AlertCircle, CheckCircle, MapPin, Package, Star } from 'lucide-react';
+import { onAuthStateChanged } from "firebase/auth";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import {
+	AlertCircle,
+	Check,
+	CheckCircle,
+	MapPin,
+	Package,
+	Pencil,
+	Star,
+	X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { auth, db } from "../../lib/firebase";
+import { getDeliveryStatsByCourier } from "./courierServices.ts";
 
 interface ProfileData {
-    displayName: string;
-    ci: string;
-    email: string;
-    phone: string;
-    secondaryMail: string;
-    photoURL: string;
-    roles: string[];
-    deliveryRating?: number;
+	displayName: string;
+	ci: string;
+	email: string;
+	phone: string;
+	secondaryMail: string;
+	photoURL: string;
+	roles: string[];
+	deliveryRating?: number;
 }
 
 interface DeliveryStatsData {
-    totalDelivered: number;
-    totalNotDelivered: number;
-    total: number;
-    deliveryRate: number;
-    isLoading: boolean;
+	totalDelivered: number;
+	totalNotDelivered: number;
+	total: number;
+	deliveryRate: number;
+	isLoading: boolean;
 }
 
 export default function ProfileView() {
-    const [loading, setLoading] = useState(true);
-    const [authenticated, setAuthenticated] = useState(false);
-    const [uid, setUid] = useState<string | null>(null);
-    const [profile, setProfile] = useState<ProfileData>({
-        displayName: '',
-        ci: 'No registrado',
-        email: '',
-        phone: 'No registrado',
-        secondaryMail: 'No registrado',
-        photoURL: '',
-        roles: [],
-    });
-    const [roles, setRoles] = useState<string[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [authenticated, setAuthenticated] = useState(false);
+	const [uid, setUid] = useState<string | null>(null);
+	const [profile, setProfile] = useState<ProfileData>({
+		displayName: "",
+		ci: "No registrado",
+		email: "",
+		phone: "No registrado",
+		secondaryMail: "No registrado",
+		photoURL: "",
+		roles: [],
+	});
+	const [deliveryStats, setDeliveryStats] = useState<DeliveryStatsData>({
+		totalDelivered: 0,
+		totalNotDelivered: 0,
+		total: 0,
+		deliveryRate: 0,
+		isLoading: true,
+	});
 
-    const [deliveryStats, setDeliveryStats] = useState<DeliveryStatsData>({
-        totalDelivered: 0,
-        totalNotDelivered: 0,
-        total: 0,
-        deliveryRate: 0,
-        isLoading: true,
-    });
+	const [toast, setToast] = useState<{
+		type: "success" | "error";
+		message: string;
+	} | null>(null);
 
-    const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+	const [isEditingPhone, setIsEditingPhone] = useState(false);
+	const [isEditingMail, setIsEditingMail] = useState(false);
+	const [isEditingCi, setIsEditingCi] = useState(false);
 
-    const [isEditingPhone, setIsEditingPhone] = useState(false);
-    const [isEditingMail, setIsEditingMail] = useState(false);
-    const [isEditingCi, setIsEditingCi] = useState(false);
+	const [tempPhone, setTempPhone] = useState("");
+	const [tempMail, setTempMail] = useState("");
+	const [tempCi, setTempCi] = useState("");
 
-    const [tempPhone, setTempPhone] = useState('');
-    const [tempMail, setTempMail] = useState('');
-    const [tempCi, setTempCi] = useState('');
+	const [errors, setErrors] = useState<{
+		phone?: string;
+		secondaryMail?: string;
+		ci?: string;
+	}>({});
 
-    const [errors, setErrors] = useState<{ phone?: string; secondaryMail?: string; ci?: string }>({});
+	useEffect(() => {
+		const unsubscribe = onAuthStateChanged(auth, async (user) => {
+			if (!user) {
+				setAuthenticated(false);
+				setLoading(false);
+				return;
+			}
 
-    useEffect(() => {
-        const unsubscribe = onAuthStateChanged(auth, async (user) => {
-            if (!user) {
-                setAuthenticated(false);
-                setLoading(false);
-                return;
-            }
+			setUid(user.uid);
 
-            setUid(user.uid);
+			try {
+				const userDoc = await getDoc(doc(db, "users", user.uid));
+				let phone = "No registrado";
+				let secondaryMail = "No registrado";
+				let ci = "No registrado";
+				let userRoles: string[] = [];
+				let deliveryRating: number | undefined;
 
-            try {
-                const userDoc = await getDoc(doc(db, 'users', user.uid));
-                let phone = 'No registrado';
-                let secondaryMail = 'No registrado';
-                let ci = 'No registrado';
-                let userRoles: string[] = [];
-                let deliveryRating = undefined;
+				if (userDoc.exists()) {
+					const data = userDoc.data();
+					phone = data.phone || "No registrado";
+					secondaryMail = data.secondaryMail || "No registrado";
+					ci = data.ci ? String(data.ci) : "No registrado";
+					userRoles = Array.isArray(data.roles) ? data.roles : [];
+					deliveryRating = data.deliveryRating ?? undefined;
+				}
 
-                if (userDoc.exists()) {
-                    const data = userDoc.data();
-                    phone = data.phone || 'No registrado';
-                    secondaryMail = data.secondaryMail || 'No registrado';
-                    ci = data.ci ? String(data.ci) : 'No registrado';
-                    setRoles(data.roles || []);
-                    userRoles = Array.isArray(data.roles) ? data.roles : [];
-                    deliveryRating = data.deliveryRating ?? undefined;
-                }
+				setProfile({
+					displayName: user.displayName || "Sin nombre",
+					ci,
+					email: user.email || "No disponible",
+					phone,
+					secondaryMail,
+					photoURL: user.photoURL || "",
+					roles: userRoles,
+					deliveryRating,
+				});
 
-                setProfile({
-                    displayName: user.displayName || 'Sin nombre',
-                    ci,
-                    email: user.email || 'No disponible',
-                    phone,
-                    secondaryMail,
-                    photoURL: user.photoURL || '',
-                    roles: userRoles,
-                    deliveryRating,
-                });
+				setAuthenticated(true);
 
-                setAuthenticated(true);
+				const isMensajero =
+					userRoles.includes("mensajero") || userRoles.includes("admin");
 
-                const isMensajero = userRoles.includes('mensajero') || userRoles.includes('admin');
+				if (isMensajero) {
+					try {
+						const stats = await getDeliveryStatsByCourier(user.uid);
+						setDeliveryStats({
+							totalDelivered: stats.totalDelivered,
+							totalNotDelivered: stats.totalNotDelivered,
+							total: stats.total,
+							deliveryRate: stats.deliveryRate,
+							isLoading: false,
+						});
+					} catch (error) {
+						console.error("Error cargando estadísticas de delivery:", error);
+						setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
+					}
+				} else {
+					setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
+				}
+			} catch (error) {
+				console.error("Error cargando perfil:", error);
+				setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
+			} finally {
+				setLoading(false);
+			}
+		});
 
-                if (isMensajero) {
-                    try {
-                        const stats = await getDeliveryStatsByCourier(user.uid);
-                        setDeliveryStats({
-                            totalDelivered: stats.totalDelivered,
-                            totalNotDelivered: stats.totalNotDelivered,
-                            total: stats.total,
-                            deliveryRate: stats.deliveryRate,
-                            isLoading: false,
-                        });
-                    } catch (error) {
-                        console.error('Error cargando estadísticas de delivery:', error);
-                        setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
-                    }
-                } else {
-                    setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
-                }
+		return unsubscribe;
+	}, []);
 
-            } catch (error) {
-                console.error('Error cargando perfil:', error);
-                setDeliveryStats((prev) => ({ ...prev, isLoading: false }));
-            } finally {
-                setLoading(false);
-            }
-        });
+	const showToast = (type: "success" | "error", message: string) => {
+		setToast({ type, message });
+		setTimeout(() => setToast(null), 4000);
+	};
 
-        return unsubscribe;
-    }, []);
+	const validatePhone = (value: string): boolean => {
+		setErrors((prev) => ({ ...prev, phone: undefined }));
+		const phoneRegex = /^[67]\d{7}$/;
+		if (!value || value.trim() === "" || value === "No registrado") {
+			setErrors((prev) => ({
+				...prev,
+				phone: "El teléfono celular es obligatorio.",
+			}));
+			return false;
+		}
+		if (!phoneRegex.test(value)) {
+			setErrors((prev) => ({
+				...prev,
+				phone: "Debe tener 8 dígitos e iniciar con 6 o 7.",
+			}));
+			return false;
+		}
+		return true;
+	};
 
-    const showToast = (type: 'success' | 'error', message: string) => {
-        setToast({ type, message });
-        setTimeout(() => setToast(null), 4000);
-    };
+	const validateMail = (value: string): boolean => {
+		setErrors((prev) => ({ ...prev, secondaryMail: undefined }));
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		if (!value || value.trim() === "" || value === "No registrado") return true;
+		if (value.length > 100) {
+			setErrors((prev) => ({
+				...prev,
+				secondaryMail: "El correo no puede exceder los 100 caracteres.",
+			}));
+			return false;
+		}
+		if (!emailRegex.test(value)) {
+			setErrors((prev) => ({
+				...prev,
+				secondaryMail: "Formato de correo electrónico inválido.",
+			}));
+			return false;
+		}
+		return true;
+	};
 
-    const validatePhone = (value: string): boolean => {
-        setErrors((prev) => ({ ...prev, phone: undefined }));
-        const phoneRegex = /^[67]\d{7}$/;
-        if (!value || value.trim() === '' || value === 'No registrado') {
-            setErrors((prev) => ({ ...prev, phone: 'El teléfono celular es obligatorio.' }));
-            return false;
-        }
-        if (!phoneRegex.test(value)) {
-            setErrors((prev) => ({ ...prev, phone: 'Debe tener 8 dígitos e iniciar con 6 o 7.' }));
-            return false;
-        }
-        return true;
-    };
+	const validateCi = (value: string): boolean => {
+		setErrors((prev) => ({ ...prev, ci: undefined }));
+		if (!value || value.trim() === "" || value === "No registrado") {
+			setErrors((prev) => ({
+				...prev,
+				ci: "El carnet de identidad es obligatorio.",
+			}));
+			return false;
+		}
+		if (!/^\d+$/.test(value)) {
+			setErrors((prev) => ({
+				...prev,
+				ci: "El CI solo debe contener números.",
+			}));
+			return false;
+		}
+		if (value.length < 5 || value.length > 10) {
+			setErrors((prev) => ({
+				...prev,
+				ci: "El CI debe tener entre 5 y 10 dígitos.",
+			}));
+			return false;
+		}
+		return true;
+	};
 
-    const validateMail = (value: string): boolean => {
-        setErrors((prev) => ({ ...prev, secondaryMail: undefined }));
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!value || value.trim() === '' || value === 'No registrado') return true;
-        if (value.length > 100) {
-            setErrors((prev) => ({ ...prev, secondaryMail: 'El correo no puede exceder los 100 caracteres.' }));
-            return false;
-        }
-        if (!emailRegex.test(value)) {
-            setErrors((prev) => ({ ...prev, secondaryMail: 'Formato de correo electrónico inválido.' }));
-            return false;
-        }
-        return true;
-    };
+	const handleStartEditPhone = () => {
+		setTempPhone(profile.phone === "No registrado" ? "" : profile.phone);
+		setErrors((prev) => ({ ...prev, phone: undefined }));
+		setIsEditingPhone(true);
+	};
 
-    const validateCi = (value: string): boolean => {
-        setErrors((prev) => ({ ...prev, ci: undefined }));
-        if (!value || value.trim() === '' || value === 'No registrado') {
-            setErrors((prev) => ({ ...prev, ci: 'El carnet de identidad es obligatorio.' }));
-            return false;
-        }
-        if (!/^\d+$/.test(value)) {
-            setErrors((prev) => ({ ...prev, ci: 'El CI solo debe contener números.' }));
-            return false;
-        }
-        if (value.length < 5 || value.length > 10) {
-            setErrors((prev) => ({ ...prev, ci: 'El CI debe tener entre 5 y 10 dígitos.' }));
-            return false;
-        }
-        return true;
-    };
+	const handleStartEditMail = () => {
+		setTempMail(
+			profile.secondaryMail === "No registrado" ? "" : profile.secondaryMail,
+		);
+		setErrors((prev) => ({ ...prev, secondaryMail: undefined }));
+		setIsEditingMail(true);
+	};
 
-    const handleStartEditPhone = () => {
-        setTempPhone(profile.phone === 'No registrado' ? '' : profile.phone);
-        setErrors((prev) => ({ ...prev, phone: undefined }));
-        setIsEditingPhone(true);
-    };
+	const handleStartEditCi = () => {
+		setTempCi(profile.ci === "No registrado" ? "" : profile.ci);
+		setErrors((prev) => ({ ...prev, ci: undefined }));
+		setIsEditingCi(true);
+	};
 
-    const handleStartEditMail = () => {
-        setTempMail(profile.secondaryMail === 'No registrado' ? '' : profile.secondaryMail);
-        setErrors((prev) => ({ ...prev, secondaryMail: undefined }));
-        setIsEditingMail(true);
-    };
+	const handleSavePhone = async () => {
+		if (!validatePhone(tempPhone) || !uid) return;
+		try {
+			await setDoc(
+				doc(db, "users", uid),
+				{ phone: tempPhone },
+				{ merge: true },
+			);
+			setProfile((prev) => ({ ...prev, phone: tempPhone }));
+			setIsEditingPhone(false);
+			showToast("success", "Teléfono celular actualizado correctamente");
+		} catch (error) {
+			console.error(error);
+			showToast("error", "Ocurrió un error al guardar el teléfono");
+		}
+	};
 
-    const handleStartEditCi = () => {
-        setTempCi(profile.ci === 'No registrado' ? '' : profile.ci);
-        setErrors((prev) => ({ ...prev, ci: undefined }));
-        setIsEditingCi(true);
-    };
+	const handleSaveMail = async () => {
+		if (!validateMail(tempMail) || !uid) return;
+		const finalMail = tempMail.trim() === "" ? "No registrado" : tempMail;
+		try {
+			await setDoc(
+				doc(db, "users", uid),
+				{ secondaryMail: finalMail },
+				{ merge: true },
+			);
+			setProfile((prev) => ({ ...prev, secondaryMail: finalMail }));
+			setIsEditingMail(false);
+			showToast("success", "Correo de respaldo actualizado correctamente");
+		} catch (error) {
+			console.error(error);
+			showToast("error", "Ocurrió un error al guardar el correo");
+		}
+	};
 
-    const handleSavePhone = async () => {
-        if (!validatePhone(tempPhone) || !uid) return;
-        try {
-            await setDoc(doc(db, 'users', uid), { phone: tempPhone }, { merge: true });
-            setProfile((prev) => ({ ...prev, phone: tempPhone }));
-            setIsEditingPhone(false);
-            showToast('success', 'Teléfono celular actualizado correctamente');
-        } catch (error) {
-            console.error(error);
-            showToast('error', 'Ocurrió un error al guardar el teléfono');
-        }
-    };
+	const handleSaveCi = async () => {
+		if (!validateCi(tempCi) || !uid) return;
+		try {
+			await setDoc(doc(db, "users", uid), { ci: tempCi }, { merge: true });
+			setProfile((prev) => ({ ...prev, ci: tempCi }));
+			setIsEditingCi(false);
+			showToast("success", "Carnet de identidad actualizado correctamente");
+		} catch (error) {
+			console.error(error);
+			showToast("error", "Ocurrió un error al guardar el CI");
+		}
+	};
 
-    const handleSaveMail = async () => {
-        if (!validateMail(tempMail) || !uid) return;
-        const finalMail = tempMail.trim() === '' ? 'No registrado' : tempMail;
-        try {
-            await setDoc(doc(db, 'users', uid), { secondaryMail: finalMail }, { merge: true });
-            setProfile((prev) => ({ ...prev, secondaryMail: finalMail }));
-            setIsEditingMail(false);
-            showToast('success', 'Correo de respaldo actualizado correctamente');
-        } catch (error) {
-            console.error(error);
-            showToast('error', 'Ocurrió un error al guardar el correo');
-        }
-    };
+	if (loading) {
+		return (
+			<div className="text-center py-8 text-text-light/60 font-medium">
+				Cargando perfil...
+			</div>
+		);
+	}
 
-    const handleSaveCi = async () => {
-        if (!validateCi(tempCi) || !uid) return;
-        try {
-            await setDoc(doc(db, 'users', uid), { ci: tempCi }, { merge: true });
-            setProfile((prev) => ({ ...prev, ci: tempCi }));
-            setIsEditingCi(false);
-            showToast('success', 'Carnet de identidad actualizado correctamente');
-        } catch (error) {
-            console.error(error);
-            showToast('error', 'Ocurrió un error al guardar el CI');
-        }
-    };
+	if (!authenticated) {
+		return (
+			<div className="text-center flex flex-col items-center gap-6 py-6">
+				<p className="text-error font-semibold">No autenticado</p>
+				<a
+					href="/login"
+					className="rounded-full bg-primary text-white px-6 py-3 text-xs uppercase font-bold tracking-wider hover:opacity-90 transition-all"
+				>
+					Iniciar sesión
+				</a>
+			</div>
+		);
+	}
 
-    if (loading) {
-        return (
-            <div className="text-center py-8 text-text-light/60 font-medium">
-                Cargando perfil...
-            </div>
-        );
-    }
+	// --- LÓGICA CORREGIDA DE ROLES ---
+	const showMisDirecciones = true; // Todo usuario autenticado puede tener direcciones
+	const showMisPedidos =
+		profile.roles.length === 0 ||
+		profile.roles.some((r) => ["comprador", "admin"].includes(r));
+	const showCalificacionMensajero =
+		profile.roles.includes("mensajero") || profile.roles.includes("admin");
+	const isMensajero =
+		profile.roles.includes("mensajero") || profile.roles.includes("admin");
 
-    if (!authenticated) {
-        return (
-            <div className="text-center flex flex-col items-center gap-6 py-6">
-                <p className="text-error font-semibold">No autenticado</p>
-                <a
-                    href="/login"
-                    className="rounded-full bg-primary text-white px-6 py-3 text-xs uppercase font-bold tracking-wider hover:opacity-90 transition-all"
-                >
-                    Iniciar sesión
-                </a>
-            </div>
-        );
-    }
+	return (
+		<>
+			{toast && (
+				<div
+					className={`fixed bottom-6 left-1/2 z-[200] flex -translate-x-1/2 items-center gap-2 rounded-full px-5 py-2.5 shadow-lg transition-all animate-fade-in ${
+						toast.type === "success" ? "bg-[#88B04B]" : "bg-red-500"
+					}`}
+				>
+					{toast.type === "success" ? (
+						<CheckCircle size={15} className="text-white" />
+					) : (
+						<AlertCircle size={15} className="text-white" />
+					)}
+					<span className="font-outfit text-sm font-bold text-white">
+						{toast.message}
+					</span>
+				</div>
+			)}
 
-    // --- LÓGICA CORREGIDA DE ROLES ---
-    const showMisDirecciones = true; // Todo usuario autenticado puede tener direcciones
-    const showMisPedidos = profile.roles.length === 0 || profile.roles.some(r => ['comprador', 'admin'].includes(r));
-    const showCalificacionMensajero = profile.roles.includes('mensajero') || profile.roles.includes('admin');
-    const isMensajero = profile.roles.includes('mensajero') || profile.roles.includes('admin');
+			<section className="bg-card-bg-light border border-border-light rounded-[1.25rem] p-6 shadow-sm max-w-xl mx-auto flex flex-col gap-6">
+				<header className="flex flex-col items-center text-center pb-6 border-b border-border-light pt-4 relative">
+					{profile.photoURL ? (
+						<img
+							src={profile.photoURL}
+							alt={profile.displayName}
+							className="size-24 rounded-full object-cover shadow-sm ring-4 ring-primary/10 border border-border-light mb-4"
+						/>
+					) : (
+						<div className="size-24 rounded-full bg-border-light/40 flex items-center justify-center text-text-light/40 font-bold text-2xl shadow-sm mb-4">
+							{profile.displayName.charAt(0).toUpperCase()}
+						</div>
+					)}
 
-    return (
-        <>
-            {toast && (
-                <div
-                    className={`fixed bottom-6 left-1/2 z-[200] flex -translate-x-1/2 items-center gap-2 rounded-full px-5 py-2.5 shadow-lg transition-all animate-fade-in ${toast.type === 'success' ? 'bg-[#88B04B]' : 'bg-red-500'
-                        }`}
-                >
-                    {toast.type === 'success' ? (
-                        <CheckCircle size={15} className="text-white" />
-                    ) : (
-                        <AlertCircle size={15} className="text-white" />
-                    )}
-                    <span className="font-outfit text-sm font-bold text-white">
-                        {toast.message}
-                    </span>
-                </div>
-            )}
+					<h1 className="text-xl font-black tracking-tight text-text-light mb-1">
+						{profile.displayName}
+					</h1>
 
-            <section className="bg-card-bg-light border border-border-light rounded-[1.25rem] p-6 shadow-sm max-w-xl mx-auto flex flex-col gap-6">
+					<dd className="text-[13px] font-medium text-text-light opacity-60 mb-2">
+						{profile.email}
+					</dd>
 
-                <header className="flex flex-col items-center text-center pb-6 border-b border-border-light pt-4 relative">
-                    {profile.photoURL ? (
-                        <img
-                            src={profile.photoURL}
-                            alt={profile.displayName}
-                            className="size-24 rounded-full object-cover shadow-sm ring-4 ring-primary/10 border border-border-light mb-4"
-                        />
-                    ) : (
-                        <div className="size-24 rounded-full bg-border-light/40 flex items-center justify-center text-text-light/40 font-bold text-2xl shadow-sm mb-4">
-                            {profile.displayName.charAt(0).toUpperCase()}
-                        </div>
-                    )}
+					{showCalificacionMensajero &&
+						profile.deliveryRating !== undefined && (
+							<div className="flex items-center gap-1 bg-primary/10 text-primary border border-primary/20 px-3 py-1 rounded-full text-xs font-bold mt-1">
+								<Star size={13} fill="currentColor" />
+								<span>
+									Calificación: {profile.deliveryRating.toFixed(1)} / 5.0
+								</span>
+							</div>
+						)}
+				</header>
 
-                    <h1 className="text-xl font-black tracking-tight text-text-light mb-1">
-                        {profile.displayName}
-                    </h1>
+				<div className="flex flex-col gap-5 pb-2">
+					{/* Campo: CI */}
+					<div className="flex flex-col">
+						<label
+							htmlFor="profile-ci-input"
+							className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5"
+						>
+							Carnet de identidad
+						</label>
+						{isEditingCi ? (
+							<div className="flex flex-col gap-1">
+								<div className="flex items-center gap-2">
+									<input
+										id="profile-ci-input"
+										type="text"
+										value={tempCi}
+										onChange={(e) => setTempCi(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") handleSaveCi();
+											if (e.key === "Escape") setIsEditingCi(false);
+										}}
+										className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.ci ? "border-error focus:border-error" : "border-border-light focus:border-primary"}`}
+										placeholder="Ej. 12345678"
+									/>
+									<button
+										type="button"
+										onClick={handleSaveCi}
+										aria-label="Confirmar CI"
+										className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all"
+									>
+										<Check size={16} />
+									</button>
+									<button
+										type="button"
+										onClick={() => setIsEditingCi(false)}
+										aria-label="Cancelar edición de CI"
+										className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all"
+									>
+										<X size={16} />
+									</button>
+								</div>
+								{errors.ci && (
+									<span className="text-[11px] font-medium text-error mt-0.5">
+										{errors.ci}
+									</span>
+								)}
+							</div>
+						) : (
+							<div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
+								<span className="text-sm font-bold text-text-light">
+									{profile.ci}
+								</span>
+								<button
+									type="button"
+									onClick={handleStartEditCi}
+									aria-label="Editar CI"
+									className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all"
+								>
+									<Pencil size={13} />
+								</button>
+							</div>
+						)}
+					</div>
 
-                    <dd className="text-[13px] font-medium text-text-light opacity-60 mb-2">
-                        {profile.email}
-                    </dd>
+					{/* Campo: Teléfono Celular */}
+					<div className="flex flex-col">
+						<label
+							htmlFor="profile-phone-input"
+							className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5"
+						>
+							Teléfono celular
+						</label>
+						{isEditingPhone ? (
+							<div className="flex flex-col gap-1">
+								<div className="flex items-center gap-2">
+									<input
+										id="profile-phone-input"
+										type="text"
+										value={tempPhone}
+										onChange={(e) => setTempPhone(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") handleSavePhone();
+											if (e.key === "Escape") setIsEditingPhone(false);
+										}}
+										className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.phone ? "border-error focus:border-error" : "border-border-light focus:border-primary"}`}
+										placeholder="Ej. 71234567"
+									/>
+									<button
+										type="button"
+										onClick={handleSavePhone}
+										aria-label="Confirmar teléfono"
+										className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all"
+									>
+										<Check size={16} />
+									</button>
+									<button
+										type="button"
+										onClick={() => setIsEditingPhone(false)}
+										aria-label="Cancelar edición de teléfono"
+										className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all"
+									>
+										<X size={16} />
+									</button>
+								</div>
+								{errors.phone && (
+									<span className="text-[11px] font-medium text-error mt-0.5">
+										{errors.phone}
+									</span>
+								)}
+							</div>
+						) : (
+							<div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
+								<span className="text-sm font-bold text-text-light">
+									{profile.phone}
+								</span>
+								<button
+									type="button"
+									onClick={handleStartEditPhone}
+									aria-label="Editar teléfono"
+									className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all"
+								>
+									<Pencil size={13} />
+								</button>
+							</div>
+						)}
+					</div>
 
-                    {showCalificacionMensajero && profile.deliveryRating !== undefined && (
-                        <div className="flex items-center gap-1 bg-primary/10 text-primary border border-primary/20 px-3 py-1 rounded-full text-xs font-bold mt-1">
-                            <Star size={13} fill="currentColor" />
-                            <span>Calificación: {profile.deliveryRating.toFixed(1)} / 5.0</span>
-                        </div>
-                    )}
-                </header>
+					{/* Campo: Correo Electrónico de Respaldo */}
+					<div className="flex flex-col">
+						<label
+							htmlFor="profile-secondary-mail-input"
+							className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5"
+						>
+							Correo de respaldo
+						</label>
+						{isEditingMail ? (
+							<div className="flex flex-col gap-1">
+								<div className="flex items-center gap-2">
+									<input
+										id="profile-secondary-mail-input"
+										type="email"
+										value={tempMail}
+										onChange={(e) => setTempMail(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") handleSaveMail();
+											if (e.key === "Escape") setIsEditingMail(false);
+										}}
+										className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.secondaryMail ? "border-error focus:border-error" : "border-border-light focus:border-primary"}`}
+										placeholder="ejemplo@correo.com"
+									/>
+									<button
+										type="button"
+										onClick={handleSaveMail}
+										aria-label="Confirmar correo"
+										className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all"
+									>
+										<Check size={16} />
+									</button>
+									<button
+										type="button"
+										onClick={() => setIsEditingMail(false)}
+										aria-label="Cancelar edición de correo"
+										className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all"
+									>
+										<X size={16} />
+									</button>
+								</div>
+								{errors.secondaryMail && (
+									<span className="text-[11px] font-medium text-error mt-0.5">
+										{errors.secondaryMail}
+									</span>
+								)}
+							</div>
+						) : (
+							<div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
+								<span className="text-sm font-bold text-text-light">
+									{profile.secondaryMail}
+								</span>
+								<button
+									type="button"
+									onClick={handleStartEditMail}
+									aria-label="Editar correo de respaldo"
+									className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all"
+								>
+									<Pencil size={13} />
+								</button>
+							</div>
+						)}
+					</div>
+				</div>
 
-                <div className="flex flex-col gap-5 pb-2">
-                    {/* Campo: CI */}
-                    <div className="flex flex-col">
-                        <label className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5">
-                            Carnet de identidad
-                        </label>
-                        {isEditingCi ? (
-                            <div className="flex flex-col gap-1">
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="text"
-                                        value={tempCi}
-                                        onChange={(e) => setTempCi(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') handleSaveCi();
-                                            if (e.key === 'Escape') setIsEditingCi(false);
-                                        }}
-                                        autoFocus
-                                        className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.ci ? 'border-error focus:border-error' : 'border-border-light focus:border-primary'}`}
-                                        placeholder="Ej. 12345678"
-                                    />
-                                    <button type="button" onClick={handleSaveCi} aria-label="Confirmar CI"
-                                        className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all">
-                                        <Check size={16} />
-                                    </button>
-                                    <button type="button" onClick={() => setIsEditingCi(false)} aria-label="Cancelar edición de CI"
-                                        className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all">
-                                        <X size={16} />
-                                    </button>
-                                </div>
-                                {errors.ci && <span className="text-[11px] font-medium text-error mt-0.5">{errors.ci}</span>}
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
-                                <span className="text-sm font-bold text-text-light">{profile.ci}</span>
-                                <button type="button" onClick={handleStartEditCi} aria-label="Editar CI"
-                                    className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all">
-                                    <Pencil size={13} />
-                                </button>
-                            </div>
-                        )}
-                    </div>
+				{/* Estadísticas de Delivery */}
+				{isMensajero && (
+					<div className="rounded-2xl border border-border-light bg-bg-light p-4">
+						<h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-text-light opacity-50">
+							Estadísticas de delivery
+						</h3>
+						<div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+							{deliveryStats.isLoading ? (
+								<div className="col-span-4 text-center text-text-light/60 text-sm py-2">
+									Cargando estadísticas...
+								</div>
+							) : (
+								<>
+									<div className="bg-white/50 rounded-xl p-3 text-center border border-border-light/50">
+										<p className="text-xs text-text-light/60 font-medium uppercase tracking-wider">
+											Total
+										</p>
+										<p className="text-xl font-bold text-text-light mt-1">
+											{deliveryStats.total}
+										</p>
+									</div>
+									<div className="bg-green-50 rounded-xl p-3 text-center border border-green-200/50">
+										<p className="text-xs text-green-700/60 font-medium uppercase tracking-wider">
+											Entregados
+										</p>
+										<p className="text-xl font-bold text-green-700 mt-1">
+											{deliveryStats.totalDelivered}
+										</p>
+									</div>
+									<div className="bg-red-50 rounded-xl p-3 text-center border border-red-200/50">
+										<p className="text-xs text-red-700/60 font-medium uppercase tracking-wider">
+											No entregados
+										</p>
+										<p className="text-xl font-bold text-red-700 mt-1">
+											{deliveryStats.totalNotDelivered}
+										</p>
+									</div>
+									<div className="bg-blue-50 rounded-xl p-3 text-center border border-blue-200/50">
+										<p className="text-xs text-blue-700/60 font-medium uppercase tracking-wider">
+											Tasa de éxito
+										</p>
+										<p className="text-xl font-bold text-blue-700 mt-1">
+											{deliveryStats.deliveryRate}%
+										</p>
+									</div>
+								</>
+							)}
+						</div>
+					</div>
+				)}
 
-                    {/* Campo: Teléfono Celular */}
-                    <div className="flex flex-col">
-                        <label className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5">
-                            Teléfono celular
-                        </label>
-                        {isEditingPhone ? (
-                            <div className="flex flex-col gap-1">
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="text"
-                                        value={tempPhone}
-                                        onChange={(e) => setTempPhone(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') handleSavePhone();
-                                            if (e.key === 'Escape') setIsEditingPhone(false);
-                                        }}
-                                        autoFocus
-                                        className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.phone ? 'border-error focus:border-error' : 'border-border-light focus:border-primary'}`}
-                                        placeholder="Ej. 71234567"
-                                    />
-                                    <button type="button" onClick={handleSavePhone} aria-label="Confirmar teléfono"
-                                        className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all">
-                                        <Check size={16} />
-                                    </button>
-                                    <button type="button" onClick={() => setIsEditingPhone(false)} aria-label="Cancelar edición de teléfono"
-                                        className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all">
-                                        <X size={16} />
-                                    </button>
-                                </div>
-                                {errors.phone && <span className="text-[11px] font-medium text-error mt-0.5">{errors.phone}</span>}
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
-                                <span className="text-sm font-bold text-text-light">{profile.phone}</span>
-                                <button type="button" onClick={handleStartEditPhone} aria-label="Editar teléfono"
-                                    className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all">
-                                    <Pencil size={13} />
-                                </button>
-                            </div>
-                        )}
-                    </div>
+				{/* CONSOLIDADO: Gestión de Cuenta */}
+				{(showMisPedidos || showMisDirecciones) && (
+					<footer className="mb-2 rounded-2xl border border-border-light bg-bg-light p-4 flex flex-col gap-3">
+						<h3 className="text-xs font-bold uppercase tracking-widest text-text-light opacity-50 mb-1">
+							Gestión de Cuenta
+						</h3>
 
-                    {/* Campo: Correo Electrónico de Respaldo */}
-                    <div className="flex flex-col">
-                        <label className="text-[11px] font-bold uppercase tracking-wider text-text-light/50 mb-1.5">
-                            Correo de respaldo
-                        </label>
-                        {isEditingMail ? (
-                            <div className="flex flex-col gap-1">
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="email"
-                                        value={tempMail}
-                                        onChange={(e) => setTempMail(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') handleSaveMail();
-                                            if (e.key === 'Escape') setIsEditingMail(false);
-                                        }}
-                                        autoFocus
-                                        className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md border bg-transparent text-text-light focus:outline-none focus:ring-2 focus:ring-primary/20 ${errors.secondaryMail ? 'border-error focus:border-error' : 'border-border-light focus:border-primary'}`}
-                                        placeholder="ejemplo@correo.com"
-                                    />
-                                    <button type="button" onClick={handleSaveMail} aria-label="Confirmar correo"
-                                        className="p-1.5 rounded-md text-text-light/60 hover:text-primary hover:bg-border-light/40 transition-all">
-                                        <Check size={16} />
-                                    </button>
-                                    <button type="button" onClick={() => setIsEditingMail(false)} aria-label="Cancelar edición de correo"
-                                        className="p-1.5 rounded-md text-text-light/40 hover:text-error hover:bg-border-light/40 transition-all">
-                                        <X size={16} />
-                                    </button>
-                                </div>
-                                {errors.secondaryMail && (
-                                    <span className="text-[11px] font-medium text-error mt-0.5">{errors.secondaryMail}</span>
-                                )}
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-between group pb-3 border-b border-dotted border-border-light">
-                                <span className="text-sm font-bold text-text-light">{profile.secondaryMail}</span>
-                                <button type="button" onClick={handleStartEditMail} aria-label="Editar correo de respaldo"
-                                    className="p-1.5 text-text-light/40 hover:text-primary rounded-md hover:bg-border-light/20 transition-all">
-                                    <Pencil size={13} />
-                                </button>
-                            </div>
-                        )}
-                    </div>
-                </div>
+						{showMisDirecciones && (
+							<a
+								href="/location"
+								className="group flex items-center justify-between rounded-xl border border-border-light bg-card-bg-light p-3 transition-all hover:border-primary hover:shadow-sm"
+							>
+								<div className="flex items-center gap-3">
+									<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
+										<MapPin size={18} />
+									</div>
+									<div className="flex flex-col">
+										<h4 className="font-bold text-text-light text-sm">
+											Mis direcciones
+										</h4>
+										<span className="text-[11px] text-text-light/50 font-medium">
+											Gestionar mis lugares de entrega
+										</span>
+									</div>
+								</div>
+								<span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
+									→
+								</span>
+							</a>
+						)}
 
-                {/* Estadísticas de Delivery */}
-                {isMensajero && (
-                    <div className="rounded-2xl border border-border-light bg-bg-light p-4">
-                        <h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-text-light opacity-50">
-                            Estadísticas de delivery
-                        </h3>
-                        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                            {deliveryStats.isLoading ? (
-                                <div className="col-span-4 text-center text-text-light/60 text-sm py-2">
-                                    Cargando estadísticas...
-                                </div>
-                            ) : (
-                                <>
-                                    <div className="bg-white/50 rounded-xl p-3 text-center border border-border-light/50">
-                                        <p className="text-xs text-text-light/60 font-medium uppercase tracking-wider">Total</p>
-                                        <p className="text-xl font-bold text-text-light mt-1">{deliveryStats.total}</p>
-                                    </div>
-                                    <div className="bg-green-50 rounded-xl p-3 text-center border border-green-200/50">
-                                        <p className="text-xs text-green-700/60 font-medium uppercase tracking-wider">Entregados</p>
-                                        <p className="text-xl font-bold text-green-700 mt-1">{deliveryStats.totalDelivered}</p>
-                                    </div>
-                                    <div className="bg-red-50 rounded-xl p-3 text-center border border-red-200/50">
-                                        <p className="text-xs text-red-700/60 font-medium uppercase tracking-wider">No entregados</p>
-                                        <p className="text-xl font-bold text-red-700 mt-1">{deliveryStats.totalNotDelivered}</p>
-                                    </div>
-                                    <div className="bg-blue-50 rounded-xl p-3 text-center border border-blue-200/50">
-                                        <p className="text-xs text-blue-700/60 font-medium uppercase tracking-wider">Tasa de éxito</p>
-                                        <p className="text-xl font-bold text-blue-700 mt-1">{deliveryStats.deliveryRate}%</p>
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                    </div>
-                )}
-
-                {/* CONSOLIDADO: Gestión de Cuenta */}
-                {(showMisPedidos || showMisDirecciones) && (
-                    <footer className="mb-2 rounded-2xl border border-border-light bg-bg-light p-4 flex flex-col gap-3">
-                        <h3 className="text-xs font-bold uppercase tracking-widest text-text-light opacity-50 mb-1">
-                            Gestión de Cuenta
-                        </h3>
-                        
-                        {showMisDirecciones && (
-                            <a
-                                href="/location"
-                                className="group flex items-center justify-between rounded-xl border border-border-light bg-card-bg-light p-3 transition-all hover:border-primary hover:shadow-sm"
-                            >
-                                <div className="flex items-center gap-3">
-                                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
-                                        <MapPin size={18} />
-                                    </div>
-                                    <div className="flex flex-col">
-                                        <h4 className="font-bold text-text-light text-sm">Mis direcciones</h4>
-                                        <span className="text-[11px] text-text-light/50 font-medium">Gestionar mis lugares de entrega</span>
-                                    </div>
-                                </div>
-                                <span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
-                                    →
-                                </span>
-                            </a>
-                        )}
-
-                        {showMisPedidos && (
-                            <a
-                                href="/mis-pedidos"
-                                className="group flex items-center justify-between rounded-xl border border-border-light bg-card-bg-light p-3 transition-all hover:border-primary hover:shadow-sm"
-                            >
-                                <div className="flex items-center gap-3">
-                                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
-                                        <Package size={18} />
-                                    </div>
-                                    <div className="flex flex-col">
-                                        <h4 className="font-bold text-text-light text-sm">Mis pedidos y devoluciones</h4>
-                                        <span className="text-[11px] text-text-light/50 font-medium">Ver mis compras</span>
-                                    </div>
-                                </div>
-                                <span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
-                                    →
-                                </span>
-                            </a>
-                        )}
-                    </footer>
-                )}
-            </section>
-        </>
-    );
+						{showMisPedidos && (
+							<a
+								href="/mis-pedidos"
+								className="group flex items-center justify-between rounded-xl border border-border-light bg-card-bg-light p-3 transition-all hover:border-primary hover:shadow-sm"
+							>
+								<div className="flex items-center gap-3">
+									<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
+										<Package size={18} />
+									</div>
+									<div className="flex flex-col">
+										<h4 className="font-bold text-text-light text-sm">
+											Mis pedidos y devoluciones
+										</h4>
+										<span className="text-[11px] text-text-light/50 font-medium">
+											Ver mis compras
+										</span>
+									</div>
+								</div>
+								<span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
+									→
+								</span>
+							</a>
+						)}
+					</footer>
+				)}
+			</section>
+		</>
+	);
 }

--- a/src/features/profile/ProfileView.tsx
+++ b/src/features/profile/ProfileView.tsx
@@ -484,7 +484,7 @@ export default function ProfileView() {
 
                 {/* CONSOLIDADO: Gestión de Cuenta */}
                 {(showMisPedidos || showMisDirecciones) && (
-                    <div className="mb-2 rounded-2xl border border-border-light bg-bg-light p-4 flex flex-col gap-3">
+                    <footer className="mb-2 rounded-2xl border border-border-light bg-bg-light p-4 flex flex-col gap-3">
                         <h3 className="text-xs font-bold uppercase tracking-widest text-text-light opacity-50 mb-1">
                             Gestión de Cuenta
                         </h3>
@@ -520,7 +520,7 @@ export default function ProfileView() {
                                     </div>
                                     <div className="flex flex-col">
                                         <h4 className="font-bold text-text-light text-sm">Mis pedidos y devoluciones</h4>
-                                        <span className="text-[11px] text-text-light/50 font-medium">Ver el historial de mis compras</span>
+                                        <span className="text-[11px] text-text-light/50 font-medium">Ver mis compras</span>
                                     </div>
                                 </div>
                                 <span className="text-primary font-bold opacity-50 transition-transform group-hover:translate-x-1 group-hover:opacity-100 pr-2">
@@ -528,7 +528,7 @@ export default function ProfileView() {
                                 </span>
                             </a>
                         )}
-                    </div>
+                    </footer>
                 )}
             </section>
         </>

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -29,7 +29,7 @@ export function AssignMessengerModal({
   return createPortal(
     (
       <div
-        className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
+        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
         role="dialog"
         aria-modal="true"
         aria-labelledby="assign-messenger-title"
@@ -37,17 +37,17 @@ export function AssignMessengerModal({
           if (event.target === event.currentTarget) onClose();
         }}
       >
-        <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
-          <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
-            <div>
+        <section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+            <div className="min-w-0">
               <h2
                 id="order-details-title"
-                className="mt-2 text-2xl font-bold tracking-tight text-(--theme-text)"
+                className="text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl"
                 style={{ fontFamily: "Outfit, sans-serif" }}
               >
                 {parseOrderId(order.orderId).friendlyName}
               </h2>
-              <p className="mt-1 text-sm text-(--theme-text) opacity-70">
+              <p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
                 Selecciona un mensajero disponible y confirma la asignación.
               </p>
             </div>
@@ -62,7 +62,7 @@ export function AssignMessengerModal({
             </button>
           </header>
 
-          <div className="p-6">
+          <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
             <div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
               <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
                 Pedido listo
@@ -143,7 +143,7 @@ export function AssignMessengerModal({
               )}
             </div>
 
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
               <button
                 type="button"
                 onClick={onClose}

--- a/src/features/seller/components/AssignMessengerModal.tsx
+++ b/src/features/seller/components/AssignMessengerModal.tsx
@@ -4,76 +4,79 @@ import { parseOrderId } from "@/features/cart/services/orderService";
 import type { Messenger, Order } from "../types";
 
 interface Props {
-  order: Order;
-  messengers: Messenger[];
-  selectedCourierId?: string;
-  messengersLoading: boolean;
-  isLoading: boolean;
-  onSelectCourier: (orderId: string, courierId: string) => void;
-  onConfirm: () => void;
-  onClose: () => void;
+	order: Order;
+	messengers: Messenger[];
+	selectedCourierId?: string;
+	messengersLoading: boolean;
+	isLoading: boolean;
+	onSelectCourier: (orderId: string, courierId: string) => void;
+	onConfirm: () => void;
+	onClose: () => void;
 }
 
 export function AssignMessengerModal({
-  order,
-  messengers,
-  selectedCourierId,
-  messengersLoading,
-  isLoading,
-  onSelectCourier,
-  onConfirm,
-  onClose,
+	order,
+	messengers,
+	selectedCourierId,
+	messengersLoading,
+	isLoading,
+	onSelectCourier,
+	onConfirm,
+	onClose,
 }: Props) {
 	const availableCount = messengers.filter((m) => m.isAvailable).length;
 
-  return createPortal(
-    (
-      <div
-        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="assign-messenger-title"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) onClose();
-        }}
-      >
-        <section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-            <div className="min-w-0">
-              <h2
-                id="order-details-title"
-                className="text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl"
-                style={{ fontFamily: "Outfit, sans-serif" }}
-              >
-                {parseOrderId(order.orderId).friendlyName}
-              </h2>
-              <p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
-                Selecciona un mensajero disponible y confirma la asignación.
-              </p>
-            </div>
+	return createPortal(
+		<div
+			className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="assign-messenger-title"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+		>
+			<section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div className="min-w-0">
+						<h2
+							id="order-details-title"
+							className="text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl"
+							style={{ fontFamily: "Outfit, sans-serif" }}
+						>
+							{parseOrderId(order.orderId).friendlyName}
+						</h2>
+						<p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
+							Selecciona un mensajero disponible y confirma la asignación.
+						</p>
+					</div>
 
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary"
-              aria-label="Cerrar modal"
-            >
-              <X size={18} />
-            </button>
-          </header>
+					<button
+						type="button"
+						onClick={onClose}
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary"
+						aria-label="Cerrar modal"
+					>
+						<X size={18} />
+					</button>
+				</header>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
-            <div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
-              <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
-                Pedido listo
-              </p>
-              <p className="mt-1 text-lg font-900 text-(--theme-text)">
-                {order.buyerName ?? 'Comprador desconocido'}
-              </p>
-              <p className="mt-1 text-sm text-(--theme-text) opacity-70">
-                {order.locationLabel ?? 'Ubicación no registrada'}
-              </p>
-            </div>
+				<div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+					<div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
+						<p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
+							Pedido listo
+						</p>
+						<p className="mt-1 text-lg font-900 text-(--theme-text)">
+							{order.buyerName ?? "Comprador desconocido"}
+						</p>
+						<p className="mt-1 text-sm text-(--theme-text) opacity-70">
+							{order.locationLabel ?? "Ubicación no registrada"}
+						</p>
+					</div>
 
 					{!messengersLoading && messengers.length > 0 && (
 						<p className="mt-4 text-xs text-(--theme-text) opacity-50">
@@ -81,90 +84,97 @@ export function AssignMessengerModal({
 						</p>
 					)}
 
-            <div className="mt-3 grid gap-3">
-              {messengersLoading ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
-                  Cargando mensajeros…
-                </div>
-              ) : messengers.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
-                  No hay mensajeros registrados.
-                </div>
-              ) : availableCount === 0 ? (
-                <div className="rounded-2xl border border-dashed border-amber-300 bg-amber-50 px-4 py-6 text-sm text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-300">
-                  Todos los mensajeros están ocupados en este momento. Intenta nuevamente en unos minutos.
-                </div>
-              ) : (
-                messengers.map((messenger) => {
-                  const isSelected = selectedCourierId === messenger.uid;
-                  const isDisabled = !messenger.isAvailable;
+					<div className="mt-3 grid gap-3">
+						{messengersLoading ? (
+							<div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+								Cargando mensajeros…
+							</div>
+						) : messengers.length === 0 ? (
+							<div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+								No hay mensajeros registrados.
+							</div>
+						) : availableCount === 0 ? (
+							<div className="rounded-2xl border border-dashed border-amber-300 bg-amber-50 px-4 py-6 text-sm text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-300">
+								Todos los mensajeros están ocupados en este momento. Intenta
+								nuevamente en unos minutos.
+							</div>
+						) : (
+							messengers.map((messenger) => {
+								const isSelected = selectedCourierId === messenger.uid;
+								const isDisabled = !messenger.isAvailable;
 
-                  return (
-                    <button
-                      key={messenger.uid}
-                      type="button"
-                      disabled={isDisabled}
-                      onClick={() => onSelectCourier(order.orderId, messenger.uid)}
-                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${isDisabled
-                        ? 'cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50'
-                        : isSelected
-                          ? 'border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)'
-                          : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)'
-                        }`}
-                    >
-                      <div className="flex items-center gap-3">
-                        <span
-                          className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected && !isDisabled ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'
-                            }`}
-                        >
-                          <UserRound size={16} />
-                        </span>
-                        <div>
-                          <p className="font-800 flex items-center gap-2">
-                            {messenger.displayName}
-                            <span
-                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide ${messenger.isAvailable
-                                ? 'bg-success-bg text-success border border-success-border'
-                                : 'bg-danger-bg text-danger border border-danger-border'
-                                }`}
-                            >
-                              {messenger.isAvailable ? 'Disponible' : 'Ocupado'}
-                            </span>
-                          </p>
-                        </div>
-                      </div>
+								return (
+									<button
+										key={messenger.uid}
+										type="button"
+										disabled={isDisabled}
+										onClick={() =>
+											onSelectCourier(order.orderId, messenger.uid)
+										}
+										className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${
+											isDisabled
+												? "cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50"
+												: isSelected
+													? "border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)"
+													: "border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)"
+										}`}
+									>
+										<div className="flex items-center gap-3">
+											<span
+												className={`flex h-10 w-10 items-center justify-center rounded-full ${
+													isSelected && !isDisabled
+														? "bg-primary text-primary-action"
+														: "bg-(--theme-secondary-bg)"
+												}`}
+											>
+												<UserRound size={16} />
+											</span>
+											<div>
+												<p className="font-800 flex items-center gap-2">
+													{messenger.displayName}
+													<span
+														className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide ${
+															messenger.isAvailable
+																? "bg-success-bg text-success border border-success-border"
+																: "bg-danger-bg text-danger border border-danger-border"
+														}`}
+													>
+														{messenger.isAvailable ? "Disponible" : "Ocupado"}
+													</span>
+												</p>
+											</div>
+										</div>
 
-                      <span className="text-sm font-semibold opacity-70">
-                        {isDisabled ? '' : isSelected ? 'Seleccionado' : 'Elegir'}
-                      </span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
+										<span className="text-sm font-semibold opacity-70">
+											{isDisabled ? "" : isSelected ? "Seleccionado" : "Elegir"}
+										</span>
+									</button>
+								);
+							})
+						)}
+					</div>
 
-            <div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={isLoading}
-                className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
-              >
-                Cancelar
-              </button>
-              <button
-                type="button"
-                onClick={onConfirm}
-                disabled={!selectedCourierId || isLoading || messengersLoading}
-                className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
-              >
-                {isLoading ? 'Asignando…' : 'Confirmar asignación'}
-              </button>
-            </div>
-          </div>
-        </section>
-      </div>
-    ),
-    document.body,
-  );
+					<div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
+						<button
+							type="button"
+							onClick={onClose}
+							disabled={isLoading}
+							className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
+						>
+							Cancelar
+						</button>
+						<button
+							type="button"
+							onClick={onConfirm}
+							disabled={!selectedCourierId || isLoading || messengersLoading}
+							className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
+						>
+							{isLoading ? "Asignando…" : "Confirmar asignación"}
+						</button>
+					</div>
+				</div>
+			</section>
+		</div>,
+		document.body,
+	);
 }

--- a/src/features/seller/components/BusyMessengerWarinigModal.tsx
+++ b/src/features/seller/components/BusyMessengerWarinigModal.tsx
@@ -13,7 +13,7 @@ export const BusyMessengerWarinigModal = ({ messenger, isLoading, onConfirm, onC
   return createPortal(
     (
       <div
-        className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
+        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
         role="dialog"
         aria-modal="true"
         aria-labelledby="busy-warning-title"
@@ -21,7 +21,7 @@ export const BusyMessengerWarinigModal = ({ messenger, isLoading, onConfirm, onC
           if (event.target === event.currentTarget) onCancel();
         }}
       >
-        <section className="w-full max-w-sm rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) p-6 shadow-2xl">
+        <section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-sm overflow-y-auto rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) p-4 shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
           <div className="flex items-start justify-between gap-3">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
               <AlertTriangle className="text-amber-600 dark:text-amber-400" size={22} />

--- a/src/features/seller/components/BusyMessengerWarinigModal.tsx
+++ b/src/features/seller/components/BusyMessengerWarinigModal.tsx
@@ -3,69 +3,78 @@ import { createPortal } from "react-dom";
 import type { Messenger } from "../types";
 
 interface Props {
-  messenger: Messenger;
-  isLoading: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
+	messenger: Messenger;
+	isLoading: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
 }
 
-export const BusyMessengerWarinigModal = ({ messenger, isLoading, onConfirm, onCancel }: Props) => {
-  return createPortal(
-    (
-      <div
-        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="busy-warning-title"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) onCancel();
-        }}
-      >
-        <section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-sm overflow-y-auto rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) p-4 shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
-              <AlertTriangle className="text-amber-600 dark:text-amber-400" size={22} />
-            </div>
-            <button
-              type="button"
-              onClick={onCancel}
-              className="flex h-8 w-8 items-center justify-center rounded-full text-(--theme-text) opacity-50 transition hover:opacity-100"
-              aria-label="Cerrar"
-            >
-              <X size={16} />
-            </button>
-          </div>
+export const BusyMessengerWarinigModal = ({
+	messenger,
+	isLoading,
+	onConfirm,
+	onCancel,
+}: Props) => {
+	return createPortal(
+		<div
+			className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="busy-warning-title"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onCancel();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onCancel();
+			}}
+			tabIndex={-1}
+		>
+			<section className="my-2 max-h-[calc(100dvh-1rem)] w-full max-w-sm overflow-y-auto rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) p-4 shadow-2xl sm:my-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px] sm:p-6">
+				<div className="flex items-start justify-between gap-3">
+					<div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+						<AlertTriangle
+							className="text-amber-600 dark:text-amber-400"
+							size={22}
+						/>
+					</div>
+					<button
+						type="button"
+						onClick={onCancel}
+						className="flex h-8 w-8 items-center justify-center rounded-full text-(--theme-text) opacity-50 transition hover:opacity-100"
+						aria-label="Cerrar"
+					>
+						<X size={16} />
+					</button>
+				</div>
 
-          <h2
-            id="busy-warning-title"
-            className="mt-4 text-lg font-800 text-(--theme-text)"
-            style={{ fontFamily: 'Outfit, sans-serif' }}
-          >
-            {messenger.displayName} está ocupado
-          </h2>
+				<h2
+					id="busy-warning-title"
+					className="mt-4 text-lg font-800 text-(--theme-text)"
+					style={{ fontFamily: "Outfit, sans-serif" }}
+				>
+					{messenger.displayName} está ocupado
+				</h2>
 
-
-          <div className="mt-6 flex gap-3">
-            <button
-              type="button"
-              onClick={onCancel}
-              disabled={isLoading}
-              className="flex-1 rounded-full border border-(--theme-border) px-4 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
-            >
-              Cancelar
-            </button>
-            <button
-              type="button"
-              onClick={onConfirm}
-              disabled={isLoading}
-              className="flex-1 rounded-full bg-amber-500 px-4 py-2.5 text-sm font-700 text-white transition hover:bg-amber-600 disabled:opacity-60"
-            >
-              {isLoading ? 'Asignando…' : 'Asignar de todas formas'}
-            </button>
-          </div>
-        </section>
-      </div>
-    ),
-    document.body,
-  );
-}
+				<div className="mt-6 flex gap-3">
+					<button
+						type="button"
+						onClick={onCancel}
+						disabled={isLoading}
+						className="flex-1 rounded-full border border-(--theme-border) px-4 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
+					>
+						Cancelar
+					</button>
+					<button
+						type="button"
+						onClick={onConfirm}
+						disabled={isLoading}
+						className="flex-1 rounded-full bg-amber-500 px-4 py-2.5 text-sm font-700 text-white transition hover:bg-amber-600 disabled:opacity-60"
+					>
+						{isLoading ? "Asignando…" : "Asignar de todas formas"}
+					</button>
+				</div>
+			</section>
+		</div>,
+		document.body,
+	);
+};

--- a/src/features/seller/components/ReassignModal.tsx
+++ b/src/features/seller/components/ReassignModal.tsx
@@ -1,209 +1,246 @@
-import { createPortal } from 'react-dom';
-import { X, UserRound } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { db } from '../../../lib/firebase';
-import { fetchDeliveryData } from '../services/sellerServices';
-import type { Messenger, Order } from '../types';
-import { ErrorMessage } from './ErrorMessage';
-import { parseOrderId } from '@/features/cart/services/orderService';
+import { UserRound, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { parseOrderId } from "@/features/cart/services/orderService";
+import { db } from "../../../lib/firebase";
+import { fetchDeliveryData } from "../services/sellerServices";
+import type { Messenger, Order } from "../types";
+import { ErrorMessage } from "./ErrorMessage";
 
 interface Props {
-  order: Order;
-  messengers: Messenger[];
-  selectedCourierId?: string;
-  messengersLoading: boolean;
-  isLoading: boolean;
-  onSelectCourier: (orderId: string, courierId: string) => void;
-  onConfirm: () => void;
-  onClose: () => void;
+	order: Order;
+	messengers: Messenger[];
+	selectedCourierId?: string;
+	messengersLoading: boolean;
+	isLoading: boolean;
+	onSelectCourier: (orderId: string, courierId: string) => void;
+	onConfirm: () => void;
+	onClose: () => void;
 }
 
 export function ReassignModal({
-  order,
-  messengers,
-  selectedCourierId,
-  messengersLoading,
-  isLoading,
-  onSelectCourier,
-  onConfirm,
-  onClose,
+	order,
+	messengers,
+	selectedCourierId,
+	messengersLoading,
+	isLoading,
+	onSelectCourier,
+	onConfirm,
+	onClose,
 }: Props) {
-  const [rejectingCourierId, setRejectingCourierId] = useState<string | null>(null);
-  const [rejectingCourierName, setRejectingCourierName] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+	const [rejectingCourierId, setRejectingCourierId] = useState<string | null>(
+		null,
+	);
+	const [rejectingCourierName, setRejectingCourierName] = useState<
+		string | null
+	>(null);
+	const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let mounted = true;
+	useEffect(() => {
+		let mounted = true;
 
-    (async () => {
-      if (!order.deliveryId) {
-        setError('El pedido no tiene un ID de entrega asociado.');
-        return;
-      }
-      try {
-        const d = await fetchDeliveryData(db, order.deliveryId);
-        if (!mounted) return;
-        setRejectingCourierId(d?.courierId ?? null);
-        setRejectingCourierName(d?.deliveryCourierName ?? null);
-      } catch {
-        setError('No se pudo obtener la información de la entrega');
-      }
-    })();
+		(async () => {
+			if (!order.deliveryId) {
+				setError("El pedido no tiene un ID de entrega asociado.");
+				return;
+			}
+			try {
+				const d = await fetchDeliveryData(db, order.deliveryId);
+				if (!mounted) return;
+				setRejectingCourierId(d?.courierId ?? null);
+				setRejectingCourierName(d?.deliveryCourierName ?? null);
+			} catch {
+				setError("No se pudo obtener la información de la entrega");
+			}
+		})();
 
-    return () => { mounted = false; };
-  }, [order.deliveryId, order.orderId]);
+		return () => {
+			mounted = false;
+		};
+	}, [order.deliveryId]);
 
-  const availableCount = messengers.filter(
-    (m) => m.isAvailable && m.uid !== rejectingCourierId,
-  ).length;
+	const availableCount = messengers.filter(
+		(m) => m.isAvailable && m.uid !== rejectingCourierId,
+	).length;
 
-  return createPortal(
-    (
-      <div
-        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="reassign-messenger-title"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) onClose();
-        }}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') onClose();
-        }}
-      >
-        <section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
-          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
-            <div className="min-w-0">
-              <h2 id="reassign-messenger-title" className="font-display text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl">
-                {parseOrderId(order.orderId).friendlyName}
-              </h2>
-              <p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
-                Selecciona un mensajero disponible. El que rechazó no puede ser seleccionado.
-              </p>
-            </div>
+	return createPortal(
+		<div
+			className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="reassign-messenger-title"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") onClose();
+			}}
+			tabIndex={-1}
+		>
+			<section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+				<header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+					<div className="min-w-0">
+						<h2
+							id="reassign-messenger-title"
+							className="font-display text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl"
+						>
+							{parseOrderId(order.orderId).friendlyName}
+						</h2>
+						<p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
+							Selecciona un mensajero disponible. El que rechazó no puede ser
+							seleccionado.
+						</p>
+					</div>
 
-            <button type="button" onClick={onClose} className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary" aria-label="Cerrar modal">
-              <X size={18} />
-            </button>
-          </header>
+					<button
+						type="button"
+						onClick={onClose}
+						className="flex h-10 w-10 items-center justify-center rounded-full border border-(--theme-border) bg-(--theme-secondary-bg) text-(--theme-text) transition hover:border-primary hover:text-primary"
+						aria-label="Cerrar modal"
+					>
+						<X size={18} />
+					</button>
+				</header>
 
-          {error && <ErrorMessage message={error} />}
+				{error && <ErrorMessage message={error} />}
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
-            <div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
-              <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">Pedido pendiente</p>
-              <p className="mt-1 text-lg font-900 text-(--theme-text)">{order.buyerName ?? 'Comprador desconocido'}</p>
-              <p className="mt-1 text-sm text-(--theme-text) opacity-70">{order.locationLabel ?? 'Ubicación no registrada'}</p>
-            </div>
+				<div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+					<div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
+						<p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">
+							Pedido pendiente
+						</p>
+						<p className="mt-1 text-lg font-900 text-(--theme-text)">
+							{order.buyerName ?? "Comprador desconocido"}
+						</p>
+						<p className="mt-1 text-sm text-(--theme-text) opacity-70">
+							{order.locationLabel ?? "Ubicación no registrada"}
+						</p>
+					</div>
 
-            {rejectingCourierName && (
-              <div className="mt-4 rounded-2xl border border-dashed border-(--theme-border) px-4 py-4 text-sm text-(--theme-text) opacity-80">
-                <p className="text-xs font-800 opacity-60">Mensajero que rechazó</p>
-                <p className="mt-1 font-700">{rejectingCourierName}</p>
-              </div>
-            )}
+					{rejectingCourierName && (
+						<div className="mt-4 rounded-2xl border border-dashed border-(--theme-border) px-4 py-4 text-sm text-(--theme-text) opacity-80">
+							<p className="text-xs font-800 opacity-60">
+								Mensajero que rechazó
+							</p>
+							<p className="mt-1 font-700">{rejectingCourierName}</p>
+						</div>
+					)}
 
-            {!messengersLoading && messengers.length > 0 && (
-              <p className="mt-4 text-xs text-(--theme-text) opacity-50">
-                {availableCount} de {messengers.length} mensajeros disponibles para reasignar
-              </p>
-            )}
+					{!messengersLoading && messengers.length > 0 && (
+						<p className="mt-4 text-xs text-(--theme-text) opacity-50">
+							{availableCount} de {messengers.length} mensajeros disponibles
+							para reasignar
+						</p>
+					)}
 
-            <div className="mt-3 grid gap-3">
-              {messengersLoading ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
-                  Cargando mensajeros…
-                </div>
-              ) : messengers.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
-                  No hay mensajeros registrados.
-                </div>
-              ) : availableCount === 0 ? (
-                <div className="rounded-2xl border border-dashed border-warning-border bg-warning-bg px-4 py-6 text-sm text-warning">
-                  No hay mensajeros disponibles para reasignar en este momento.
-                </div>
-              ) : (
-                messengers.map((messenger) => {
-                  const isRejecting = messenger.uid === rejectingCourierId;
-                  const isBusy = !messenger.isAvailable;
-                  const isDisabled = isRejecting || isBusy || !!error;
-                  const isSelected = selectedCourierId === messenger.uid;
+					<div className="mt-3 grid gap-3">
+						{messengersLoading ? (
+							<div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+								Cargando mensajeros…
+							</div>
+						) : messengers.length === 0 ? (
+							<div className="rounded-2xl border border-dashed border-(--theme-border) px-4 py-6 text-sm text-(--theme-text) opacity-50">
+								No hay mensajeros registrados.
+							</div>
+						) : availableCount === 0 ? (
+							<div className="rounded-2xl border border-dashed border-warning-border bg-warning-bg px-4 py-6 text-sm text-warning">
+								No hay mensajeros disponibles para reasignar en este momento.
+							</div>
+						) : (
+							messengers.map((messenger) => {
+								const isRejecting = messenger.uid === rejectingCourierId;
+								const isBusy = !messenger.isAvailable;
+								const isDisabled = isRejecting || isBusy || !!error;
+								const isSelected = selectedCourierId === messenger.uid;
 
-                  return (
-                    <button
-                      key={messenger.uid}
-                      type="button"
-                      onClick={() => !isDisabled && onSelectCourier(order.orderId, messenger.uid)}
-                      disabled={isDisabled}
-                      className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${isDisabled
-                        ? 'cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50'
-                        : isSelected
-                          ? 'border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)'
-                          : 'border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)'
-                        }`}
-                    >
-                      <div className="flex items-center gap-3">
-                        <span
-                          className={`flex h-10 w-10 items-center justify-center rounded-full ${isSelected && !isDisabled ? 'bg-primary text-primary-action' : 'bg-(--theme-secondary-bg)'
-                            }`}
-                        >
-                          <UserRound aria-hidden="true" size={16} />
-                        </span>
-                        <div>
-                          <p className="font-800 flex items-center gap-2">
-                            {messenger.displayName}
-                            {!isRejecting && (
-                              <span
-                                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide border ${messenger.isAvailable
-                                  ? 'bg-success-bg text-success border-success-border'
-                                  : 'bg-danger-bg text-danger border-danger-border'
-                                  }`}
-                              >
-                                {messenger.isAvailable
-                                  ? 'Disponible'
-                                  : 'Ocupado'}
-                              </span>
-                            )}
-                          </p>
-                          <p className="text-xs opacity-55">
-                            {messenger.institutionalId || 'Sin CI institucional'}
-                          </p>
-                        </div>
-                      </div>
+								return (
+									<button
+										key={messenger.uid}
+										type="button"
+										onClick={() =>
+											!isDisabled &&
+											onSelectCourier(order.orderId, messenger.uid)
+										}
+										disabled={isDisabled}
+										className={`flex items-center justify-between rounded-2xl border px-4 py-4 text-left transition ${
+											isDisabled
+												? "cursor-not-allowed border-(--theme-border) bg-(--theme-secondary-bg)/40 opacity-50"
+												: isSelected
+													? "border-primary bg-primary/10 text-primary hover:border-primary hover:bg-(--theme-secondary-bg)"
+													: "border-(--theme-border) bg-(--theme-card-bg) text-(--theme-text) hover:border-primary hover:bg-(--theme-secondary-bg)"
+										}`}
+									>
+										<div className="flex items-center gap-3">
+											<span
+												className={`flex h-10 w-10 items-center justify-center rounded-full ${
+													isSelected && !isDisabled
+														? "bg-primary text-primary-action"
+														: "bg-(--theme-secondary-bg)"
+												}`}
+											>
+												<UserRound aria-hidden="true" size={16} />
+											</span>
+											<div>
+												<p className="font-800 flex items-center gap-2">
+													{messenger.displayName}
+													{!isRejecting && (
+														<span
+															className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-700 uppercase tracking-wide border ${
+																messenger.isAvailable
+																	? "bg-success-bg text-success border-success-border"
+																	: "bg-danger-bg text-danger border-danger-border"
+															}`}
+														>
+															{messenger.isAvailable ? "Disponible" : "Ocupado"}
+														</span>
+													)}
+												</p>
+												<p className="text-xs opacity-55">
+													{messenger.institutionalId || "Sin CI institucional"}
+												</p>
+											</div>
+										</div>
 
-                      <span className="text-sm font-semibold opacity-70">
-                        {isRejecting ? 'Rechazó' : isBusy ? '' : isSelected ? 'Seleccionado' : 'Elegir'}
-                      </span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
+										<span className="text-sm font-semibold opacity-70">
+											{isRejecting
+												? "Rechazó"
+												: isBusy
+													? ""
+													: isSelected
+														? "Seleccionado"
+														: "Elegir"}
+										</span>
+									</button>
+								);
+							})
+						)}
+					</div>
 
-            <div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={isLoading}
-                className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
-              >
-                Cancelar
-              </button>
-              <button
-                type="button"
-                onClick={onConfirm}
-                disabled={!selectedCourierId || isLoading || messengersLoading || !!error}
-                className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
-              >
-                {isLoading ? 'Reasignando…' : 'Confirmar reasignación'}
-              </button>
-            </div>
-          </div>
-        </section>
-      </div>
-    ),
-    document.body,
-  );
+					<div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
+						<button
+							type="button"
+							onClick={onClose}
+							disabled={isLoading}
+							className="rounded-full border border-(--theme-border) px-5 py-2.5 text-sm font-700 text-(--theme-text) transition hover:bg-(--theme-secondary-bg) disabled:opacity-50"
+						>
+							Cancelar
+						</button>
+						<button
+							type="button"
+							onClick={onConfirm}
+							disabled={
+								!selectedCourierId || isLoading || messengersLoading || !!error
+							}
+							className="rounded-full bg-primary px-5 py-2.5 text-sm font-800 text-primary-action transition hover:opacity-90 disabled:opacity-50"
+						>
+							{isLoading ? "Reasignando…" : "Confirmar reasignación"}
+						</button>
+					</div>
+				</div>
+			</section>
+		</div>,
+		document.body,
+	);
 }
 
 export default ReassignModal;

--- a/src/features/seller/components/ReassignModal.tsx
+++ b/src/features/seller/components/ReassignModal.tsx
@@ -60,7 +60,7 @@ export function ReassignModal({
   return createPortal(
     (
       <div
-        className="fixed inset-0 z-999 flex items-center justify-center bg-black/75 p-4 backdrop-blur-md"
+        className="fixed inset-0 z-999 flex items-start justify-center overflow-y-auto bg-black/75 p-2 backdrop-blur-md sm:p-4"
         role="dialog"
         aria-modal="true"
         aria-labelledby="reassign-messenger-title"
@@ -71,13 +71,13 @@ export function ReassignModal({
           if (event.key === 'Escape') onClose();
         }}
       >
-        <section className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[28px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl">
-          <header className="flex items-start justify-between gap-4 border-b border-(--theme-border) px-6 py-5">
-            <div>
-              <h2 id="reassign-messenger-title" className="mt-2 font-display text-2xl font-bold tracking-tight text-(--theme-text)">
+        <section className="my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[24px] border border-(--theme-border) bg-(--theme-card-bg) shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-[28px]">
+          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--theme-border) px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+            <div className="min-w-0">
+              <h2 id="reassign-messenger-title" className="font-display text-xl font-bold leading-tight tracking-tight text-(--theme-text) sm:mt-2 sm:text-2xl">
                 {parseOrderId(order.orderId).friendlyName}
               </h2>
-              <p className="mt-1 text-sm text-(--theme-text) opacity-70">
+              <p className="mt-1 text-sm leading-snug text-(--theme-text) opacity-70">
                 Selecciona un mensajero disponible. El que rechazó no puede ser seleccionado.
               </p>
             </div>
@@ -89,7 +89,7 @@ export function ReassignModal({
 
           {error && <ErrorMessage message={error} />}
 
-          <div className="p-6">
+          <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
             <div className="rounded-3xl border border-(--theme-border) bg-(--theme-secondary-bg)/50 p-4">
               <p className="text-[11px] font-800 uppercase tracking-[0.24em] text-(--theme-text) opacity-45">Pedido pendiente</p>
               <p className="mt-1 text-lg font-900 text-(--theme-text)">{order.buyerName ?? 'Comprador desconocido'}</p>
@@ -180,7 +180,7 @@ export function ReassignModal({
               )}
             </div>
 
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <div className="sticky bottom-0 -mx-4 mt-6 flex flex-col gap-3 border-t border-(--theme-border) bg-(--theme-card-bg) px-4 py-4 sm:-mx-6 sm:flex-row sm:justify-end sm:px-6">
               <button
                 type="button"
                 onClick={onClose}


### PR DESCRIPTION
## Resumen

Se corrigen problemas responsive en pantallas de mensajero/courier y modales relacionados con asignación de mensajeros. También se mejora el mapa en móvil para ver detalles bajo demanda y mantener disponible el cambio de tema claro/oscuro.

## URL de los cambios

- URL: http://localhost:4321/courier
- Ruta o pantalla afectada: `/courier`, `/mapa`, `/delivery/order/[id]`, `/seller/ready-orders`, `/seller/rejected-orders`

## Cómo probar

1. Entrar como mensajero y revisar `/courier` con zoom alto o vista móvil.
2. Abrir los modales de rechazar, no entregado, registrar pago, detalle y mapa.
3. Entrar como vendedor a asignar/reasignar mensajero y abrir los modales relacionados.

## Resultado esperado

Las pantallas y modales deben adaptarse correctamente en móvil, desktop y con zoom alto. En el mapa móvil, los detalles se abren con botón y no tapan el mapa por defecto; el cambio claro/oscuro sigue disponible.

## Evidencia visual

No aplica.

## Tipo de cambio

- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor
- [ ] Documentación
- [ ] Configuración o mantenimiento

## Issues relacionados

No aplica.

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

El cambio es principalmente visual/responsive. No modifica reglas de negocio ni estados de pedidos; solo ajusta layout, modales y controles del mapa para que funcionen mejor en móvil, desktop y zoom alto.