### PR TITLE
Eliminación funcionalidad Asignar mensagero por duplicado o…

### DIFF
--- a/src/features/orders/components/OrderActions.tsx
+++ b/src/features/orders/components/OrderActions.tsx
@@ -1,6 +1,6 @@
-import { useAssignOrdersToDelivery } from "@features/seller/hooks/useAssignOrdersToDelivery";
-import { useGetMessengers } from "@features/seller/hooks/useGetMessengers";
-import { UserRound } from "lucide-react";
+/*import { useAssignOrdersToDelivery } from "@features/seller/hooks/useAssignOrdersToDelivery";*/
+/*import { useGetMessengers } from "@features/seller/hooks/useGetMessengers";*/
+/*import { UserRound } from "lucide-react";*/
 import { useState } from "react";
 import {
 	cancelOrder,
@@ -110,7 +110,7 @@ export default function OrderActions({
 			/>
 		);
 	}
-
+/*
 	if (order.status === "LISTO") {
 		return (
 			<ReadyOrderSection
@@ -120,7 +120,11 @@ export default function OrderActions({
 			/>
 		);
 	}
+*/
 
+if (order.status === "LISTO") {
+	return null;
+}
 	if (order.status === "RECHAZADO") {
 		return (
 			<RejectedOrderSection
@@ -344,6 +348,8 @@ function RejectedOrderSection({
 	);
 }
 
+/*desde aqui*/
+/*
 function ReadyOrderSection({
 	order,
 	onSuccess,
@@ -463,3 +469,4 @@ function ReadyOrderSection({
 		</div>
 	);
 }
+*/


### PR DESCRIPTION

Resumen

Se corrige el bug #702.
El modal de una orden con estado LISTO ya no permite asignar mensajero, porque esa funcionalidad estaba duplicada u obsoleta.

URL de los cambios
URL: http://localhost:4321/seller/orders
Ruta o pantalla afectada: Mis pedidos → modal de detalle de orden con estado LISTO
Cómo probar
Iniciar sesión con un usuario vendedor.
Entrar a /seller/orders.
Filtrar las órdenes por estado LISTO.
Abrir el modal de detalle de una orden lista.
Verificar que ya no aparece la opción para asignar mensajero desde ese modal.
Resultado esperado

El modal de una orden con estado LISTO no debe mostrar la funcionalidad de asignar mensajero.
La asignación debe realizarse desde la sección correspondiente de pedidos listos, evitando duplicidad de acciones.