### PR TITLE
Fix/701 fix order modal ci field

### DIFF
--- a/src/features/orders/components/OrderModal.tsx
+++ b/src/features/orders/components/OrderModal.tsx
@@ -67,10 +67,20 @@ export default function OrderModal({
 					{order.buyerInstitutionalId && (
 						<>
 							<div className="leading-[140%] col-start-1 col-end-4 text-(--theme-text) opacity-60">
-								Carnet:
+								Código SIS:
 							</div>
 							<div className="leading-[140%] col-start-7  min-[765px]:col-start-5 col-end-21">
 								{order.buyerInstitutionalId}
+							</div>
+						</>
+					)}
+					{order.buyerCi && (
+						<>
+							<div className="leading-[140%] col-start-1 col-end-4 text-(--theme-text) opacity-60">
+								Carnet:
+							</div>
+							<div className="leading-[140%] col-start-7  min-[765px]:col-start-5 col-end-21">
+								{order.buyerCi}
 							</div>
 						</>
 					)}

--- a/src/features/orders/services/ordersService.ts
+++ b/src/features/orders/services/ordersService.ts
@@ -508,6 +508,7 @@ async function processQuerySnapshot(
 				buyerName: buyer?.displayName || "Usuario desconocido",
 				buyerPhoneNumber: buyer?.phoneNumber,
 				buyerInstitutionalId: buyer?.institutionalId,
+				buyerCi: buyer?.ci,
 				delivery,
 				items,
 				incidentReason: data.incidentReason,

--- a/src/features/orders/types.ts
+++ b/src/features/orders/types.ts
@@ -81,6 +81,7 @@ export interface Order {
 	buyerName?: string;
 	buyerPhoneNumber?: string;
 	buyerInstitutionalId?: string;
+	buyerCi?: string;
 	sellerId?: string;
 	status: OrderStatus;
 	buyerReceptionConfirmed?: boolean;

--- a/src/features/seller/services/getOrders.ts
+++ b/src/features/seller/services/getOrders.ts
@@ -47,11 +47,11 @@ async function fetchLocationsData(
 async function fetchBuyersData(
   db: Firestore,
   buyerIds: string[],
-): Promise<Record<string, { displayName: string; email: string; institutionalId: string }>> {
+): Promise<Record<string, { displayName: string; email: string; institutionalId: string; ci: string }>> {
   if (buyerIds.length === 0) return {};
 
   try {
-    const map: Record<string, { displayName: string; email: string; institutionalId: string }> = {};
+    const map: Record<string, { displayName: string; email: string; institutionalId: string; ci: string }> = {};
 
     const userSnapshots = await Promise.all(
       buyerIds.map((uid) => getDoc(doc(db, 'users', uid)))
@@ -64,6 +64,7 @@ async function fetchBuyersData(
           displayName: data.displayName ?? data.email ?? 'Comprador desconocido',
           email: data.email ?? '',
           institutionalId: data.institutionalId ?? '',
+          ci: data.ci ?? '',
         };
       }
     });
@@ -135,6 +136,7 @@ async function enrichOrdersWithData(
     buyerName: buyerMap[order.buyerId]?.displayName,
     buyerEmail: buyerMap[order.buyerId]?.email,
     buyerInstitutionalId: buyerMap[order.buyerId]?.institutionalId,
+    buyerCi: buyerMap[order.buyerId]?.ci,
     locationLabel: locationMap[order.locationId]?.label,
     locationType: locationMap[order.locationId]?.type,
     items: itemsMap[order.orderId] ?? [],


### PR DESCRIPTION
## Resumen

Se corrige un bug en el modal de detalles de la orden donde el campo etiquetado como "Carnet" mostraba por error el `institutionalId` (Código SIS) del comprador en lugar de su Carnet de Identidad (`ci`). Se actualizó el esquema de datos, los servicios de obtención de órdenes y el frontend para mostrar ambos valores ("Código SIS" y "Carnet") con sus etiquetas correctas.

## URL de los cambios

- URL: https://sansistore-do3yocr78-jhons-projects-644475cf.vercel.app/seller/created-orders
- Ruta o pantalla afectada: `/seller/orders` y `/seller/created-orders` (Al abrir el modal de una orden).

## Cómo probar

1. Iniciar sesión con un usuario que tenga el rol de `vendedor`.
2. Dirigirse a la vista de pedidos (`/seller/orders` o `/seller/created-orders`).
3. Hacer clic sobre cualquier orden para abrir el **Modal de Detalles de la Orden**.
4. En la sección de información del cliente, verificar los campos mostrados bajo su nombre.

## Resultado esperado

El modal debe mostrar ahora las siguientes etiquetas correctamente (si el cliente tiene registrados ambos datos en su perfil):
- **Código SIS:** `EST-202X-XXX` (Valor de `institutionalId`)
- **Carnet:** `12345678` (Valor de `ci`)

Ya no debe mostrar el valor `EST-...` bajo la etiqueta de "Carnet".

## Evidencia visual

| Antes | Después |
| --- | --- |
#### Antes
<img width="696" height="502" alt="image" src="https://github.com/user-attachments/assets/6f51ffc7-b61c-49b6-858d-d49dda9f1208" />

#### Despues
<img width="575" height="412" alt="image" src="https://github.com/user-attachments/assets/c0a383bf-e1c1-4805-8a49-a89a52a4462b" />

## Tipo de cambio


- [x] Corrección de bug


## Issues relacionados

Closes #701

## Checklist del autor

- [x] Probé el cambio localmente
- [x] Agregué la URL o ruta donde se revisa el cambio
- [x] Agregué evidencia visual o indiqué que no aplica
- [x] No hay errores ni warnings nuevos conocidos
- [x] Revisé mi propio código antes de pedir review

## Notas para quien revisa

Se modificó la interfaz `Order` en `types.ts` para incluir la propiedad opcional `buyerCi`. Además, se actualizaron los servicios `getOrders.ts` y `ordersService.ts` para extraer este dato específico desde el documento del usuario en Firebase y embeberlo en el objeto de la orden que se consume en el frontend.
